### PR TITLE
Wiki data qvalue as literal

### DIFF
--- a/aeon.ttl
+++ b/aeon.ttl
@@ -187,7 +187,7 @@ aeon:has_WDQID rdf:type owl:ObjectProperty ;
 [[partOfSubobject::Template:Subobject Organization_ID]]
 
 [[Category:AEON]] [[Category:Imported vocabulary]]""" ;
-               aeon:WikidataLabel "item" .
+               aeon:WikidataLabel "itemID" .
 
 
 ###  https://github.com/tibonto/aeon#has_attendee


### PR DESCRIPTION
@StroemPhi can you remove this small change. It is meant to help with getting the WikidataID from an `?item` URI , within the SPARQL queries.
It relates to https://github.com/TIBHannover/confiDent-SPARQL-wikidata/commit/0ee10b988171bf5696c7a9ad79d07bc77bb0c200