### PR TITLE
Draft: removed aeon:SMW_datatype

### DIFF
--- a/aeon.ttl
+++ b/aeon.ttl
@@ -1,15 +1,9 @@
 @prefix : <https://github.com/tibonto/aeon#> .
-@prefix dc: <http://dublincore.org/specifications/dublin-core/dcmi-terms/2012-06-14/> .
-@prefix ns: <http://www.w3.org/2003/06/sw-vocab-status/ns#> .
-@prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix aeon: <https://github.com/tibonto/aeon#> .
-@prefix obda: <https://w3id.org/obda/vocabulary#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @base <https://github.com/tibonto/aeon> .
 
 <https://github.com/tibonto/aeon> rdf:type owl:Ontology ;
@@ -29,46 +23,46 @@
 #################################################################
 
 ###  http://dublincore.org/specifications/dublin-core/dcmi-terms/2012-06-14/creator
-dc:creator rdf:type owl:AnnotationProperty .
+<http://dublincore.org/specifications/dublin-core/dcmi-terms/2012-06-14/creator> rdf:type owl:AnnotationProperty .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000111
-obo:IAO_0000111 rdf:type owl:AnnotationProperty ;
-                obo:IAO_0000111 "editor preferred term"@en ;
-                obo:IAO_0000114 obo:IAO_0000122 ;
-                obo:IAO_0000115 "The concise, meaningful, and human-friendly name for a class or property preferred by the ontology developers. (US-English)"@en ;
-                obo:IAO_0000117 "PERSON:Daniel Schober"@en ;
-                obo:IAO_0000119 "GROUP:OBI:<http://purl.obolibrary.org/obo/obi>"@en ;
-                rdfs:isDefinedBy obo:iao.owl ;
-                rdfs:label "editor preferred term"@en .
+<http://purl.obolibrary.org/obo/IAO_0000111> rdf:type owl:AnnotationProperty ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000111> "editor preferred term"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000122> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000115> "The concise, meaningful, and human-friendly name for a class or property preferred by the ontology developers. (US-English)"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON:Daniel Schober"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000119> "GROUP:OBI:<http://purl.obolibrary.org/obo/obi>"@en ;
+                                             rdfs:isDefinedBy <http://purl.obolibrary.org/obo/iao.owl> ;
+                                             rdfs:label "editor preferred term"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000112
-obo:IAO_0000112 rdf:type owl:AnnotationProperty ;
-                obo:IAO_0000111 "example of usage"@en ;
-                obo:IAO_0000114 obo:IAO_0000122 ;
-                obo:IAO_0000115 "A phrase describing how a term should be used and/or a citation to a work which uses it. May also include other kinds of examples that facilitate immediate understanding, such as widely know prototypes or instances of a class, or cases where a relation is said to hold."@en ;
-                obo:IAO_0000117 "PERSON:Daniel Schober"@en ;
-                obo:IAO_0000119 "GROUP:OBI:<http://purl.obolibrary.org/obo/obi>"@en ;
-                rdfs:isDefinedBy obo:iao.owl ;
-                rdfs:label "example of usage"@en .
+<http://purl.obolibrary.org/obo/IAO_0000112> rdf:type owl:AnnotationProperty ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000111> "example of usage"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000122> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000115> "A phrase describing how a term should be used and/or a citation to a work which uses it. May also include other kinds of examples that facilitate immediate understanding, such as widely know prototypes or instances of a class, or cases where a relation is said to hold."@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON:Daniel Schober"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000119> "GROUP:OBI:<http://purl.obolibrary.org/obo/obi>"@en ;
+                                             rdfs:isDefinedBy <http://purl.obolibrary.org/obo/iao.owl> ;
+                                             rdfs:label "example of usage"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000114
-obo:IAO_0000114 rdf:type owl:AnnotationProperty ;
-                obo:IAO_0000111 "has curation status"@en ;
-                obo:IAO_0000117 "PERSON:Alan Ruttenberg"@en ,
-                                "PERSON:Bill Bug"@en ,
-                                "PERSON:Melanie Courtot"@en ;
-                rdfs:label "has curation status"@en .
+<http://purl.obolibrary.org/obo/IAO_0000114> rdf:type owl:AnnotationProperty ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000111> "has curation status"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON:Alan Ruttenberg"@en ,
+                                                                                          "PERSON:Bill Bug"@en ,
+                                                                                          "PERSON:Melanie Courtot"@en ;
+                                             rdfs:label "has curation status"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000115
-obo:IAO_0000115 rdf:type owl:AnnotationProperty ;
-                obo:IAO_0000111 "definition"@en ;
-                obo:IAO_0000114 obo:IAO_0000122 ;
-                obo:IAO_0000115 "The official definition, explaining the meaning of a class or property. Shall be Aristotelian, formalized and normalized. Can be augmented with colloquial definitions."@en ;
-                obo:IAO_0000116 """2012-04-05: 
+<http://purl.obolibrary.org/obo/IAO_0000115> rdf:type owl:AnnotationProperty ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000111> "definition"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000122> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000115> "The official definition, explaining the meaning of a class or property. Shall be Aristotelian, formalized and normalized. Can be augmented with colloquial definitions."@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000116> """2012-04-05: 
 Barry Smith
 
 The official OBI definition, explaining the meaning of a class or property: 'Shall be Aristotelian, formalized and normalized. Can be augmented with colloquial definitions'  is terrible.
@@ -88,151 +82,151 @@ We don't have definitions of 'meaning' or 'expression' or 'property'. For 'refer
 Personally, I am more comfortable weakening definition to documentation, with instructions as to what is desirable. 
 
 We also have the outstanding issue of how to aim different definitions to different audiences. A clinical audience reading chebi wants a different sort of definition documentation/definition from a chemistry trained audience, and similarly there is a need for a definition that is adequate for an ontologist to work with.  """@en ;
-                obo:IAO_0000117 "PERSON:Daniel Schober"@en ;
-                obo:IAO_0000119 "GROUP:OBI:<http://purl.obolibrary.org/obo/obi>"@en ;
-                rdfs:isDefinedBy obo:iao.owl ;
-                rdfs:label "definition" ,
-                           "definition"@en .
+                                             <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON:Daniel Schober"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000119> "GROUP:OBI:<http://purl.obolibrary.org/obo/obi>"@en ;
+                                             rdfs:isDefinedBy <http://purl.obolibrary.org/obo/iao.owl> ;
+                                             rdfs:label "definition" ,
+                                                        "definition"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000116
-obo:IAO_0000116 rdf:type owl:AnnotationProperty ;
-                obo:IAO_0000111 "editor note"@en ;
-                obo:IAO_0000114 obo:IAO_0000122 ;
-                obo:IAO_0000115 "An administrative note intended for its editor. It may not be included in the publication version of the ontology, so it should contain nothing necessary for end users to understand the ontology."@en ;
-                obo:IAO_0000117 "PERSON:Daniel Schober"@en ;
-                obo:IAO_0000119 "GROUP:OBI:<http://purl.obofoundry.org/obo/obi>"@en ;
-                rdfs:isDefinedBy obo:iao.owl ;
-                rdfs:label "editor note"@en .
+<http://purl.obolibrary.org/obo/IAO_0000116> rdf:type owl:AnnotationProperty ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000111> "editor note"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000122> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000115> "An administrative note intended for its editor. It may not be included in the publication version of the ontology, so it should contain nothing necessary for end users to understand the ontology."@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON:Daniel Schober"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000119> "GROUP:OBI:<http://purl.obofoundry.org/obo/obi>"@en ;
+                                             rdfs:isDefinedBy <http://purl.obolibrary.org/obo/iao.owl> ;
+                                             rdfs:label "editor note"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000117
-obo:IAO_0000117 rdf:type owl:AnnotationProperty ;
-                obo:IAO_0000111 "term editor"@en ;
-                obo:IAO_0000114 obo:IAO_0000122 ;
-                obo:IAO_0000115 "Name of editor entering the term in the file. The term editor is a point of contact for information regarding the term. The term editor may be, but is not always, the author of the definition, which may have been worked upon by several people"@en ;
-                obo:IAO_0000116 "20110707, MC: label update to term editor and definition modified accordingly. See https://github.com/information-artifact-ontology/IAO/issues/115."@en ;
-                obo:IAO_0000117 "PERSON:Daniel Schober"@en ;
-                obo:IAO_0000119 "GROUP:OBI:<http://purl.obolibrary.org/obo/obi>"@en ;
-                rdfs:isDefinedBy obo:iao.owl ;
-                rdfs:label "definition editor" ,
-                           "definition editor"@en ,
-                           "term editor" ,
-                           "term editor"@en .
+<http://purl.obolibrary.org/obo/IAO_0000117> rdf:type owl:AnnotationProperty ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000111> "term editor"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000122> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000115> "Name of editor entering the term in the file. The term editor is a point of contact for information regarding the term. The term editor may be, but is not always, the author of the definition, which may have been worked upon by several people"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000116> "20110707, MC: label update to term editor and definition modified accordingly. See https://github.com/information-artifact-ontology/IAO/issues/115."@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON:Daniel Schober"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000119> "GROUP:OBI:<http://purl.obolibrary.org/obo/obi>"@en ;
+                                             rdfs:isDefinedBy <http://purl.obolibrary.org/obo/iao.owl> ;
+                                             rdfs:label "definition editor" ,
+                                                        "definition editor"@en ,
+                                                        "term editor" ,
+                                                        "term editor"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000118
-obo:IAO_0000118 rdf:type owl:AnnotationProperty ;
-                obo:IAO_0000111 "alternative term"@en ;
-                obo:IAO_0000114 obo:IAO_0000125 ;
-                obo:IAO_0000115 "An alternative name for a class or property which means the same thing as the preferred name (semantically equivalent)"@en ;
-                obo:IAO_0000117 "PERSON:Daniel Schober"@en ;
-                obo:IAO_0000119 "GROUP:OBI:<http://purl.obolibrary.org/obo/obi>"@en ;
-                rdfs:isDefinedBy obo:iao.owl ;
-                rdfs:label "alternative term"@en .
+<http://purl.obolibrary.org/obo/IAO_0000118> rdf:type owl:AnnotationProperty ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000111> "alternative term"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000125> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000115> "An alternative name for a class or property which means the same thing as the preferred name (semantically equivalent)"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON:Daniel Schober"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000119> "GROUP:OBI:<http://purl.obolibrary.org/obo/obi>"@en ;
+                                             rdfs:isDefinedBy <http://purl.obolibrary.org/obo/iao.owl> ;
+                                             rdfs:label "alternative term"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000119
-obo:IAO_0000119 rdf:type owl:AnnotationProperty ;
-                obo:IAO_0000111 "definition source"@en ;
-                obo:IAO_0000114 obo:IAO_0000122 ;
-                obo:IAO_0000115 "Formal citation, e.g. identifier in external database to indicate / attribute source(s) for the definition. Free text indicate / attribute source(s) for the definition. EXAMPLE: Author Name, URI, MeSH Term C04, PUBMED ID, Wiki uri on 31.01.2007"@en ;
-                obo:IAO_0000117 "PERSON:Daniel Schober"@en ;
-                obo:IAO_0000119 "Discussion on obo-discuss mailing-list, see http://bit.ly/hgm99w"@en ,
-                                "GROUP:OBI:<http://purl.obolibrary.org/obo/obi>"@en ;
-                rdfs:isDefinedBy obo:iao.owl ;
-                rdfs:label "definition source"@en .
+<http://purl.obolibrary.org/obo/IAO_0000119> rdf:type owl:AnnotationProperty ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000111> "definition source"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000122> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000115> "Formal citation, e.g. identifier in external database to indicate / attribute source(s) for the definition. Free text indicate / attribute source(s) for the definition. EXAMPLE: Author Name, URI, MeSH Term C04, PUBMED ID, Wiki uri on 31.01.2007"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON:Daniel Schober"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000119> "Discussion on obo-discuss mailing-list, see http://bit.ly/hgm99w"@en ,
+                                                                                          "GROUP:OBI:<http://purl.obolibrary.org/obo/obi>"@en ;
+                                             rdfs:isDefinedBy <http://purl.obolibrary.org/obo/iao.owl> ;
+                                             rdfs:label "definition source"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000231
-obo:IAO_0000231 rdf:type owl:AnnotationProperty ;
-                obo:IAO_0000111 "has obsolescence reason"@en ;
-                obo:IAO_0000115 "Relates an annotation property to an obsolescence reason. The values of obsolescence reasons come from a list of predefined terms, instances of the class obsolescence reason specification."@en ;
-                obo:IAO_0000117 "PERSON:Alan Ruttenberg"@en ,
-                                "PERSON:Melanie Courtot"@en ;
-                rdfs:label "has obsolescence reason"@en .
+<http://purl.obolibrary.org/obo/IAO_0000231> rdf:type owl:AnnotationProperty ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000111> "has obsolescence reason"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000115> "Relates an annotation property to an obsolescence reason. The values of obsolescence reasons come from a list of predefined terms, instances of the class obsolescence reason specification."@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON:Alan Ruttenberg"@en ,
+                                                                                          "PERSON:Melanie Courtot"@en ;
+                                             rdfs:label "has obsolescence reason"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000232
-obo:IAO_0000232 rdf:type owl:AnnotationProperty ;
-                obo:IAO_0000111 "curator note"@en ;
-                obo:IAO_0000114 obo:IAO_0000122 ;
-                obo:IAO_0000115 "An administrative note of use for a curator but of no use for a user"@en ;
-                obo:IAO_0000117 "PERSON:Alan Ruttenberg"@en ;
-                rdfs:isDefinedBy obo:iao.owl ;
-                rdfs:label "curator note"@en .
+<http://purl.obolibrary.org/obo/IAO_0000232> rdf:type owl:AnnotationProperty ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000111> "curator note"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000122> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000115> "An administrative note of use for a curator but of no use for a user"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON:Alan Ruttenberg"@en ;
+                                             rdfs:isDefinedBy <http://purl.obolibrary.org/obo/iao.owl> ;
+                                             rdfs:label "curator note"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000233
-obo:IAO_0000233 rdf:type owl:AnnotationProperty ;
-                obo:IAO_0000111 "term tracker item"@en ;
-                obo:IAO_0000112 "the URI for an OBI Terms ticket at sourceforge, such as https://sourceforge.net/p/obi/obi-terms/772/"@en ;
-                obo:IAO_0000114 obo:IAO_0000125 ;
-                obo:IAO_0000115 "An IRI or similar locator for a request or discussion of an ontology term."@en ;
-                obo:IAO_0000117 "Person: Jie Zheng, Chris Stoeckert, Alan Ruttenberg"@en ;
-                obo:IAO_0000119 "Person: Jie Zheng, Chris Stoeckert, Alan Ruttenberg"@en ;
-                rdfs:comment "The 'tracker item' can associate a tracker with a specific ontology term."@en ;
-                rdfs:label "term tracker item"@en .
+<http://purl.obolibrary.org/obo/IAO_0000233> rdf:type owl:AnnotationProperty ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000111> "term tracker item"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000112> "the URI for an OBI Terms ticket at sourceforge, such as https://sourceforge.net/p/obi/obi-terms/772/"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000125> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000115> "An IRI or similar locator for a request or discussion of an ontology term."@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000117> "Person: Jie Zheng, Chris Stoeckert, Alan Ruttenberg"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000119> "Person: Jie Zheng, Chris Stoeckert, Alan Ruttenberg"@en ;
+                                             rdfs:comment "The 'tracker item' can associate a tracker with a specific ontology term."@en ;
+                                             rdfs:label "term tracker item"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000234
-obo:IAO_0000234 rdf:type owl:AnnotationProperty ;
-                obo:IAO_0000111 "ontology term requester"@en ;
-                obo:IAO_0000114 obo:IAO_0000125 ;
-                obo:IAO_0000115 "The name of the person, project, or organization that motivated inclusion of an ontology term by requesting its addition."@en ;
-                obo:IAO_0000117 "Person: Jie Zheng, Chris Stoeckert, Alan Ruttenberg"@en ;
-                obo:IAO_0000119 "Person: Jie Zheng, Chris Stoeckert, Alan Ruttenberg"@en ;
-                rdfs:comment "The 'term requester' can credit the person, organization or project who request the ontology term." ;
-                rdfs:label "ontology term requester"@en .
+<http://purl.obolibrary.org/obo/IAO_0000234> rdf:type owl:AnnotationProperty ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000111> "ontology term requester"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000125> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000115> "The name of the person, project, or organization that motivated inclusion of an ontology term by requesting its addition."@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000117> "Person: Jie Zheng, Chris Stoeckert, Alan Ruttenberg"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000119> "Person: Jie Zheng, Chris Stoeckert, Alan Ruttenberg"@en ;
+                                             rdfs:comment "The 'term requester' can credit the person, organization or project who request the ontology term." ;
+                                             rdfs:label "ontology term requester"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000412
-obo:IAO_0000412 rdf:type owl:AnnotationProperty ;
-                obo:IAO_0000111 "imported from"@en ;
-                obo:IAO_0000114 obo:IAO_0000125 ;
-                obo:IAO_0000115 "For external terms/classes, the ontology from which the term was imported"@en ;
-                obo:IAO_0000117 "PERSON:Alan Ruttenberg"@en ,
-                                "PERSON:Melanie Courtot"@en ;
-                obo:IAO_0000119 "GROUP:OBI:<http://purl.obolibrary.org/obo/obi>"@en ;
-                rdfs:isDefinedBy obo:iao.owl ;
-                rdfs:label "imported from"@en .
+<http://purl.obolibrary.org/obo/IAO_0000412> rdf:type owl:AnnotationProperty ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000111> "imported from"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000125> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000115> "For external terms/classes, the ontology from which the term was imported"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON:Alan Ruttenberg"@en ,
+                                                                                          "PERSON:Melanie Courtot"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000119> "GROUP:OBI:<http://purl.obolibrary.org/obo/obi>"@en ;
+                                             rdfs:isDefinedBy <http://purl.obolibrary.org/obo/iao.owl> ;
+                                             rdfs:label "imported from"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000600
-obo:IAO_0000600 rdf:type owl:AnnotationProperty ;
-                obo:IAO_0000111 "elucidation"@en ;
-                obo:IAO_0000117 "person:Alan Ruttenberg"@en ;
-                obo:IAO_0000119 "Person:Barry Smith"@en ;
-                obo:IAO_0000600 "Primitive terms in a highest-level ontology such as BFO are terms which are so basic to our understanding of reality that there is no way of defining them in a non-circular fashion. For these, therefore, we can provide only elucidations, supplemented by examples and by axioms"@en ;
-                rdfs:isDefinedBy obo:iao.owl ;
-                rdfs:label "elucidation"@en .
+<http://purl.obolibrary.org/obo/IAO_0000600> rdf:type owl:AnnotationProperty ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000111> "elucidation"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000117> "person:Alan Ruttenberg"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000119> "Person:Barry Smith"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000600> "Primitive terms in a highest-level ontology such as BFO are terms which are so basic to our understanding of reality that there is no way of defining them in a non-circular fashion. For these, therefore, we can provide only elucidations, supplemented by examples and by axioms"@en ;
+                                             rdfs:isDefinedBy <http://purl.obolibrary.org/obo/iao.owl> ;
+                                             rdfs:label "elucidation"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0006011
-obo:IAO_0006011 rdf:type owl:AnnotationProperty ;
-                obo:IAO_0000111 "may be identical to"@en ;
-                obo:IAO_0000115 "A annotation relationship between two terms in an ontology that may refer to the same (natural) type but where more evidence is required before terms are merged."@en ;
-                obo:IAO_0000117 "David Osumi-Sutherland"@en ;
-                obo:IAO_0000233 "#40"@en ;
-                obo:IAO_0000234 "VFB"@en ;
-                rdfs:comment "Edges asserting this should be annotated with to record evidence supporting the assertion and its provenance."@en ;
-                rdfs:label "may be identical to"@en .
+<http://purl.obolibrary.org/obo/IAO_0006011> rdf:type owl:AnnotationProperty ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000111> "may be identical to"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000115> "A annotation relationship between two terms in an ontology that may refer to the same (natural) type but where more evidence is required before terms are merged."@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000117> "David Osumi-Sutherland"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000233> "#40"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000234> "VFB"@en ;
+                                             rdfs:comment "Edges asserting this should be annotated with to record evidence supporting the assertion and its provenance."@en ;
+                                             rdfs:label "may be identical to"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0100001
-obo:IAO_0100001 rdf:type owl:AnnotationProperty ;
-                obo:IAO_0000111 "term replaced by"@en ;
-                obo:IAO_0000114 obo:IAO_0000125 ;
-                obo:IAO_0000115 "Use on obsolete terms, relating the term to another term that can be used as a substitute"@en ;
-                obo:IAO_0000117 "Person:Alan Ruttenberg"@en ;
-                obo:IAO_0000119 "Person:Alan Ruttenberg"@en ;
-                rdfs:comment "Add as annotation triples in the granting ontology"@en ;
-                rdfs:label "term replaced by"@en .
+<http://purl.obolibrary.org/obo/IAO_0100001> rdf:type owl:AnnotationProperty ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000111> "term replaced by"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000125> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000115> "Use on obsolete terms, relating the term to another term that can be used as a substitute"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000117> "Person:Alan Ruttenberg"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000119> "Person:Alan Ruttenberg"@en ;
+                                             rdfs:comment "Add as annotation triples in the granting ontology"@en ;
+                                             rdfs:label "term replaced by"@en .
 
 
 ###  http://purl.obolibrary.org/obo/RO_0001900
-obo:RO_0001900 rdf:type owl:AnnotationProperty ;
-               rdfs:label "temporal interpretation"@en .
+<http://purl.obolibrary.org/obo/RO_0001900> rdf:type owl:AnnotationProperty ;
+                                            rdfs:label "temporal interpretation"@en .
 
 
 ###  http://purl.org/dc/elements/1.1/contributor
@@ -268,52 +262,52 @@ obo:RO_0001900 rdf:type owl:AnnotationProperty ;
 
 
 ###  http://www.w3.org/2003/06/sw-vocab-status/ns#term_status
-ns:term_status rdf:type owl:AnnotationProperty .
+<http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> rdf:type owl:AnnotationProperty .
 
 
 ###  http://www.w3.org/2004/02/skos/core#altLabel
-skos:altLabel rdf:type owl:AnnotationProperty .
+<http://www.w3.org/2004/02/skos/core#altLabel> rdf:type owl:AnnotationProperty .
 
 
 ###  http://www.w3.org/2004/02/skos/core#definition
-skos:definition rdf:type owl:AnnotationProperty .
+<http://www.w3.org/2004/02/skos/core#definition> rdf:type owl:AnnotationProperty .
 
 
 ###  http://www.w3.org/2004/02/skos/core#example
-skos:example rdf:type owl:AnnotationProperty .
+<http://www.w3.org/2004/02/skos/core#example> rdf:type owl:AnnotationProperty .
 
 
 ###  http://www.w3.org/2004/02/skos/core#prefLabel
-skos:prefLabel rdf:type owl:AnnotationProperty .
+<http://www.w3.org/2004/02/skos/core#prefLabel> rdf:type owl:AnnotationProperty .
 
 
 ###  http://www.w3.org/2004/02/skos/core#scopeNote
-skos:scopeNote rdf:type owl:AnnotationProperty .
+<http://www.w3.org/2004/02/skos/core#scopeNote> rdf:type owl:AnnotationProperty .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000026
-aeon:AEON_0000026 rdf:type owl:AnnotationProperty ;
-                  obo:IAO_0000117 "Philip Strömert"^^xsd:string ;
-                  <http://purl.org/dc/elements/1.1/date> "2020-10-14T15:31:27Z"^^xsd:dateTime ;
-                  rdfs:label "maps to"@de .
+:AEON_0000026 rdf:type owl:AnnotationProperty ;
+              <http://purl.obolibrary.org/obo/IAO_0000117> "Philip Strömert"^^xsd:string ;
+              <http://purl.org/dc/elements/1.1/date> "2020-10-14T15:31:27Z"^^xsd:dateTime ;
+              rdfs:label "maps to"@de .
 
 
 ###  https://github.com/tibonto/aeon#SMW_datatype
-aeon:SMW_datatype rdf:type owl:AnnotationProperty .
+:SMW_datatype rdf:type owl:AnnotationProperty .
 
 
 ###  https://github.com/tibonto/aeon#SMW_import_info
-aeon:SMW_import_info rdf:type owl:AnnotationProperty .
+:SMW_import_info rdf:type owl:AnnotationProperty .
 
 
 ###  https://github.com/tibonto/aeon#WikidataLabel
-aeon:WikidataLabel rdf:type owl:AnnotationProperty ;
-                   obo:IAO_0000115 "WikidataLabel is used to map a class or property to a certain label in the Wikidata namespace." .
+:WikidataLabel rdf:type owl:AnnotationProperty ;
+               <http://purl.obolibrary.org/obo/IAO_0000115> "WikidataLabel is used to map a class or property to a certain label in the Wikidata namespace." .
 
 
 ###  https://github.com/tibonto/aeon#WikidataURI
-aeon:WikidataURI rdf:type owl:AnnotationProperty ;
-                 obo:IAO_0000115 "WikidataURI is used to map a class or property to the URI in the Wikidata namespace." .
+:WikidataURI rdf:type owl:AnnotationProperty ;
+             <http://purl.obolibrary.org/obo/IAO_0000115> "WikidataURI is used to map a class or property to the URI in the Wikidata namespace." .
 
 
 #################################################################
@@ -321,387 +315,387 @@ aeon:WikidataURI rdf:type owl:AnnotationProperty ;
 #################################################################
 
 ###  http://purl.obolibrary.org/obo/BFO_0000050
-obo:BFO_0000050 rdf:type owl:ObjectProperty ;
-                rdfs:subPropertyOf owl:topObjectProperty ;
-                owl:inverseOf obo:BFO_0000051 ;
-                obo:IAO_0000111 "is part of"@en ;
-                obo:IAO_0000112 "my brain is part of my body (continuant parthood, two material entities)"@en ,
-                                "my stomach cavity is part of my stomach (continuant parthood, immaterial entity is part of material entity)"@en ,
-                                "this day is part of this year (occurrent parthood)"@en ;
-                obo:IAO_0000115 "a core relation that holds between a part and its whole"@en ;
-                obo:IAO_0000116 "Everything is part of itself. Any part of any part of a thing is itself part of that thing. Two distinct things cannot be part of each other."@en ,
-                                "Occurrents are not subject to change and so parthood between occurrents holds for all the times that the part exists. Many continuants are subject to change, so parthood between continuants will only hold at certain times, but this is difficult to specify in OWL. See https://code.google.com/p/obo-relations/wiki/ROAndTime"@en ,
-                                """Parthood requires the part and the whole to have compatible classes: only an occurrent can be part of an occurrent; only a process can be part of a process; only a continuant can be part of a continuant; only an independent continuant can be part of an independent continuant; only an immaterial entity can be part of an immaterial entity; only a specifically dependent continuant can be part of a specifically dependent continuant; only a generically dependent continuant can be part of a generically dependent continuant. (This list is not exhaustive.)
+<http://purl.obolibrary.org/obo/BFO_0000050> rdf:type owl:ObjectProperty ;
+                                             rdfs:subPropertyOf owl:topObjectProperty ;
+                                             owl:inverseOf <http://purl.obolibrary.org/obo/BFO_0000051> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000111> "is part of"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000112> "my brain is part of my body (continuant parthood, two material entities)"@en ,
+                                                                                          "my stomach cavity is part of my stomach (continuant parthood, immaterial entity is part of material entity)"@en ,
+                                                                                          "this day is part of this year (occurrent parthood)"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000115> "a core relation that holds between a part and its whole"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000116> "Everything is part of itself. Any part of any part of a thing is itself part of that thing. Two distinct things cannot be part of each other."@en ,
+                                                                                          "Occurrents are not subject to change and so parthood between occurrents holds for all the times that the part exists. Many continuants are subject to change, so parthood between continuants will only hold at certain times, but this is difficult to specify in OWL. See https://code.google.com/p/obo-relations/wiki/ROAndTime"@en ,
+                                                                                          """Parthood requires the part and the whole to have compatible classes: only an occurrent can be part of an occurrent; only a process can be part of a process; only a continuant can be part of a continuant; only an independent continuant can be part of an independent continuant; only an immaterial entity can be part of an immaterial entity; only a specifically dependent continuant can be part of a specifically dependent continuant; only a generically dependent continuant can be part of a generically dependent continuant. (This list is not exhaustive.)
 
 A continuant cannot be part of an occurrent: use 'participates in'. An occurrent cannot be part of a continuant: use 'has participant'. A material entity cannot be part of an immaterial entity: use 'has location'. A specifically dependent continuant cannot be part of an independent continuant: use 'inheres in'. An independent continuant cannot be part of a specifically dependent continuant: use 'bearer of'."""@en ;
-                obo:IAO_0000118 "part_of"@en ;
-                obo:IAO_0000412 "http://purl.obolibrary.org/obo/ro/releases/2020-12-18/ro.owl"^^xsd:string ;
-                rdfs:label "part of"@en ;
-                rdfs:seeAlso <http://ontologydesignpatterns.org/wiki/Community:Parts_and_Collections> ,
-                             <http://ontologydesignpatterns.org/wiki/Submissions:PartOf> ,
-                             "http://www.obofoundry.org/ro/#OBO_REL:part_of" .
+                                             <http://purl.obolibrary.org/obo/IAO_0000118> "part_of"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/ro/releases/2020-12-18/ro.owl"^^xsd:string ;
+                                             rdfs:label "part of"@en ;
+                                             rdfs:seeAlso <http://ontologydesignpatterns.org/wiki/Community:Parts_and_Collections> ,
+                                                          <http://ontologydesignpatterns.org/wiki/Submissions:PartOf> ,
+                                                          "http://www.obofoundry.org/ro/#OBO_REL:part_of" .
 
 
 ###  http://purl.obolibrary.org/obo/BFO_0000051
-obo:BFO_0000051 rdf:type owl:ObjectProperty ;
-                rdfs:subPropertyOf owl:topObjectProperty ;
-                rdf:type owl:TransitiveProperty ;
-                obo:IAO_0000111 "has part"@en ;
-                obo:IAO_0000112 "my body has part my brain (continuant parthood, two material entities)"@en ,
-                                "my stomach has part my stomach cavity (continuant parthood, material entity has part immaterial entity)"@en ,
-                                "this year has part this day (occurrent parthood)"@en ;
-                obo:IAO_0000115 "a core relation that holds between a whole and its part"@en ;
-                obo:IAO_0000116 "Everything has itself as a part. Any part of any part of a thing is itself part of that thing. Two distinct things cannot have each other as a part."@en ,
-                                "Occurrents are not subject to change and so parthood between occurrents holds for all the times that the part exists. Many continuants are subject to change, so parthood between continuants will only hold at certain times, but this is difficult to specify in OWL. See https://code.google.com/p/obo-relations/wiki/ROAndTime"@en ,
-                                """Parthood requires the part and the whole to have compatible classes: only an occurrent have an occurrent as part; only a process can have a process as part; only a continuant can have a continuant as part; only an independent continuant can have an independent continuant as part; only a specifically dependent continuant can have a specifically dependent continuant as part; only a generically dependent continuant can have a generically dependent continuant as part. (This list is not exhaustive.)
+<http://purl.obolibrary.org/obo/BFO_0000051> rdf:type owl:ObjectProperty ;
+                                             rdfs:subPropertyOf owl:topObjectProperty ;
+                                             rdf:type owl:TransitiveProperty ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000111> "has part"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000112> "my body has part my brain (continuant parthood, two material entities)"@en ,
+                                                                                          "my stomach has part my stomach cavity (continuant parthood, material entity has part immaterial entity)"@en ,
+                                                                                          "this year has part this day (occurrent parthood)"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000115> "a core relation that holds between a whole and its part"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000116> "Everything has itself as a part. Any part of any part of a thing is itself part of that thing. Two distinct things cannot have each other as a part."@en ,
+                                                                                          "Occurrents are not subject to change and so parthood between occurrents holds for all the times that the part exists. Many continuants are subject to change, so parthood between continuants will only hold at certain times, but this is difficult to specify in OWL. See https://code.google.com/p/obo-relations/wiki/ROAndTime"@en ,
+                                                                                          """Parthood requires the part and the whole to have compatible classes: only an occurrent have an occurrent as part; only a process can have a process as part; only a continuant can have a continuant as part; only an independent continuant can have an independent continuant as part; only a specifically dependent continuant can have a specifically dependent continuant as part; only a generically dependent continuant can have a generically dependent continuant as part. (This list is not exhaustive.)
 
 A continuant cannot have an occurrent as part: use 'participates in'. An occurrent cannot have a continuant as part: use 'has participant'. An immaterial entity cannot have a material entity as part: use 'location of'. An independent continuant cannot have a specifically dependent continuant as part: use 'bearer of'. A specifically dependent continuant cannot have an independent continuant as part: use 'inheres in'."""@en ;
-                obo:IAO_0000118 "has_part"@en ;
-                obo:IAO_0000412 "http://purl.obolibrary.org/obo/ro/releases/2020-12-18/ro.owl"^^xsd:string ;
-                rdfs:label "has part"@en .
+                                             <http://purl.obolibrary.org/obo/IAO_0000118> "has_part"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/ro/releases/2020-12-18/ro.owl"^^xsd:string ;
+                                             rdfs:label "has part"@en .
 
 
 ###  http://purl.obolibrary.org/obo/BFO_0000054
-obo:BFO_0000054 rdf:type owl:ObjectProperty ;
-                rdfs:subPropertyOf owl:topObjectProperty ;
-                owl:inverseOf obo:BFO_0000055 ;
-                rdfs:domain obo:BFO_0000017 ;
-                rdfs:range obo:BFO_0000015 ;
-                obo:IAO_0000111 "realized in"@en ;
-                obo:IAO_0000112 "this disease is realized in this disease course"@en ,
-                                "this fragility is realized in this shattering"@en ,
-                                "this investigator role is realized in this investigation"@en ;
-                obo:IAO_0000118 "is realized by"@en ,
-                                "realized_in"@en ;
-                obo:IAO_0000412 "http://purl.obolibrary.org/obo/ro/releases/2020-12-18/ro.owl"^^xsd:string ;
-                obo:IAO_0000600 "[copied from inverse property 'realizes'] to say that b realizes c at t is to assert that there is some material entity d & b is a process which has participant d at t & c is a disposition or role of which d is bearer_of at t& the type instantiated by b is correlated with the type instantiated by c. (axiom label in BFO2 Reference: [059-003])"@en ;
-                rdfs:comment "Paraphrase of elucidation: a relation between a realizable entity and a process, where there is some material entity that is bearer of the realizable entity and participates in the process, and the realizable entity comes to be realized in the course of the process" ;
-                rdfs:isDefinedBy obo:bfo.owl ;
-                rdfs:label "realized in"@en .
+<http://purl.obolibrary.org/obo/BFO_0000054> rdf:type owl:ObjectProperty ;
+                                             rdfs:subPropertyOf owl:topObjectProperty ;
+                                             owl:inverseOf <http://purl.obolibrary.org/obo/BFO_0000055> ;
+                                             rdfs:domain <http://purl.obolibrary.org/obo/BFO_0000017> ;
+                                             rdfs:range <http://purl.obolibrary.org/obo/BFO_0000015> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000111> "realized in"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000112> "this disease is realized in this disease course"@en ,
+                                                                                          "this fragility is realized in this shattering"@en ,
+                                                                                          "this investigator role is realized in this investigation"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000118> "is realized by"@en ,
+                                                                                          "realized_in"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/ro/releases/2020-12-18/ro.owl"^^xsd:string ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000600> "[copied from inverse property 'realizes'] to say that b realizes c at t is to assert that there is some material entity d & b is a process which has participant d at t & c is a disposition or role of which d is bearer_of at t& the type instantiated by b is correlated with the type instantiated by c. (axiom label in BFO2 Reference: [059-003])"@en ;
+                                             rdfs:comment "Paraphrase of elucidation: a relation between a realizable entity and a process, where there is some material entity that is bearer of the realizable entity and participates in the process, and the realizable entity comes to be realized in the course of the process" ;
+                                             rdfs:isDefinedBy <http://purl.obolibrary.org/obo/bfo.owl> ;
+                                             rdfs:label "realized in"@en .
 
 
 ###  http://purl.obolibrary.org/obo/BFO_0000055
-obo:BFO_0000055 rdf:type owl:ObjectProperty ;
-                rdfs:subPropertyOf owl:topObjectProperty ;
-                rdfs:domain obo:BFO_0000015 ;
-                rdfs:range obo:BFO_0000017 ;
-                obo:IAO_0000111 "realizes"@en ;
-                obo:IAO_0000112 "this disease course realizes this disease"@en ,
-                                "this investigation realizes this investigator role"@en ,
-                                "this shattering realizes this fragility"@en ;
-                obo:IAO_0000412 "http://purl.obolibrary.org/obo/ro/releases/2020-12-18/ro.owl"^^xsd:string ;
-                obo:IAO_0000600 "to say that b realizes c at t is to assert that there is some material entity d & b is a process which has participant d at t & c is a disposition or role of which d is bearer_of at t& the type instantiated by b is correlated with the type instantiated by c. (axiom label in BFO2 Reference: [059-003])"@en ;
-                rdfs:comment "Paraphrase of elucidation: a relation between a process and a realizable entity, where there is some material entity that is bearer of the realizable entity and participates in the process, and the realizable entity comes to be realized in the course of the process" ;
-                rdfs:isDefinedBy obo:iao.owl ;
-                rdfs:label "realizes"@en .
+<http://purl.obolibrary.org/obo/BFO_0000055> rdf:type owl:ObjectProperty ;
+                                             rdfs:subPropertyOf owl:topObjectProperty ;
+                                             rdfs:domain <http://purl.obolibrary.org/obo/BFO_0000015> ;
+                                             rdfs:range <http://purl.obolibrary.org/obo/BFO_0000017> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000111> "realizes"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000112> "this disease course realizes this disease"@en ,
+                                                                                          "this investigation realizes this investigator role"@en ,
+                                                                                          "this shattering realizes this fragility"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/ro/releases/2020-12-18/ro.owl"^^xsd:string ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000600> "to say that b realizes c at t is to assert that there is some material entity d & b is a process which has participant d at t & c is a disposition or role of which d is bearer_of at t& the type instantiated by b is correlated with the type instantiated by c. (axiom label in BFO2 Reference: [059-003])"@en ;
+                                             rdfs:comment "Paraphrase of elucidation: a relation between a process and a realizable entity, where there is some material entity that is bearer of the realizable entity and participates in the process, and the realizable entity comes to be realized in the course of the process" ;
+                                             rdfs:isDefinedBy <http://purl.obolibrary.org/obo/iao.owl> ;
+                                             rdfs:label "realizes"@en .
 
 
 ###  http://purl.obolibrary.org/obo/BFO_0000066
-obo:BFO_0000066 rdf:type owl:ObjectProperty ;
-                rdfs:subPropertyOf owl:topObjectProperty ;
-                owl:inverseOf obo:BFO_0000067 ;
-                rdfs:domain obo:BFO_0000003 ;
-                rdfs:range obo:BFO_0000004 ;
-                obo:IAO_0000111 "occurs in"@en ;
-                obo:IAO_0000115 "b occurs_in c =def b is a process and c is a material entity or immaterial entity& there exists a spatiotemporal region r and b occupies_spatiotemporal_region r.& forall(t) if b exists_at t then c exists_at t & there exist spatial regions s and s’ where & b spatially_projects_onto s at t& c is occupies_spatial_region s’ at t& s is a proper_continuant_part_of s’ at t"@en ;
-                obo:IAO_0000118 "occurs_in"@en ,
-                                "unfolds in"@en ,
-                                "unfolds_in"@en ;
-                obo:IAO_0000412 "http://purl.obolibrary.org/obo/ro/releases/2020-12-18/ro.owl"^^xsd:string ;
-                rdfs:comment "Paraphrase of definition: a relation between a process and an independent continuant, in which the process takes place entirely within the independent continuant" ;
-                rdfs:isDefinedBy obo:bfo.owl ;
-                rdfs:label "occurs in"@en .
+<http://purl.obolibrary.org/obo/BFO_0000066> rdf:type owl:ObjectProperty ;
+                                             rdfs:subPropertyOf owl:topObjectProperty ;
+                                             owl:inverseOf <http://purl.obolibrary.org/obo/BFO_0000067> ;
+                                             rdfs:domain <http://purl.obolibrary.org/obo/BFO_0000003> ;
+                                             rdfs:range <http://purl.obolibrary.org/obo/BFO_0000004> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000111> "occurs in"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000115> "b occurs_in c =def b is a process and c is a material entity or immaterial entity& there exists a spatiotemporal region r and b occupies_spatiotemporal_region r.& forall(t) if b exists_at t then c exists_at t & there exist spatial regions s and s’ where & b spatially_projects_onto s at t& c is occupies_spatial_region s’ at t& s is a proper_continuant_part_of s’ at t"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000118> "occurs_in"@en ,
+                                                                                          "unfolds in"@en ,
+                                                                                          "unfolds_in"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/ro/releases/2020-12-18/ro.owl"^^xsd:string ;
+                                             rdfs:comment "Paraphrase of definition: a relation between a process and an independent continuant, in which the process takes place entirely within the independent continuant" ;
+                                             rdfs:isDefinedBy <http://purl.obolibrary.org/obo/bfo.owl> ;
+                                             rdfs:label "occurs in"@en .
 
 
 ###  http://purl.obolibrary.org/obo/BFO_0000067
-obo:BFO_0000067 rdf:type owl:ObjectProperty ;
-                rdfs:subPropertyOf owl:topObjectProperty ;
-                rdfs:domain obo:BFO_0000004 ;
-                rdfs:range obo:BFO_0000003 ;
-                obo:IAO_0000111 "site of"@en ;
-                obo:IAO_0000115 "[copied from inverse property 'occurs in'] b occurs_in c =def b is a process and c is a material entity or immaterial entity& there exists a spatiotemporal region r and b occupies_spatiotemporal_region r.& forall(t) if b exists_at t then c exists_at t & there exist spatial regions s and s’ where & b spatially_projects_onto s at t& c is occupies_spatial_region s’ at t& s is a proper_continuant_part_of s’ at t"@en ;
-                obo:IAO_0000412 "http://purl.obolibrary.org/obo/ro/releases/2020-12-18/ro.owl"^^xsd:string ;
-                rdfs:comment "Paraphrase of definition: a relation between an independent continuant and a process, in which the process takes place entirely within the independent continuant" ;
-                rdfs:isDefinedBy obo:bfo.owl ;
-                rdfs:label "contains process"@en .
+<http://purl.obolibrary.org/obo/BFO_0000067> rdf:type owl:ObjectProperty ;
+                                             rdfs:subPropertyOf owl:topObjectProperty ;
+                                             rdfs:domain <http://purl.obolibrary.org/obo/BFO_0000004> ;
+                                             rdfs:range <http://purl.obolibrary.org/obo/BFO_0000003> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000111> "site of"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000115> "[copied from inverse property 'occurs in'] b occurs_in c =def b is a process and c is a material entity or immaterial entity& there exists a spatiotemporal region r and b occupies_spatiotemporal_region r.& forall(t) if b exists_at t then c exists_at t & there exist spatial regions s and s’ where & b spatially_projects_onto s at t& c is occupies_spatial_region s’ at t& s is a proper_continuant_part_of s’ at t"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/ro/releases/2020-12-18/ro.owl"^^xsd:string ;
+                                             rdfs:comment "Paraphrase of definition: a relation between an independent continuant and a process, in which the process takes place entirely within the independent continuant" ;
+                                             rdfs:isDefinedBy <http://purl.obolibrary.org/obo/bfo.owl> ;
+                                             rdfs:label "contains process"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000136
-obo:IAO_0000136 rdf:type owl:ObjectProperty ;
-                rdfs:subPropertyOf owl:topObjectProperty ;
-                rdfs:domain obo:IAO_0000030 ;
-                obo:IAO_0000112 "This document is about information artifacts and their representations"@en ;
-                obo:IAO_0000114 obo:IAO_0000125 ;
-                obo:IAO_0000115 "A (currently) primitive relation that relates an information artifact to an entity."@en ;
-                obo:IAO_0000116 """7/6/2009 Alan Ruttenberg. Following discussion with Jonathan Rees, and introduction of \"mentions\" relation. Weaken the is_about relationship to be primitive. 
+<http://purl.obolibrary.org/obo/IAO_0000136> rdf:type owl:ObjectProperty ;
+                                             rdfs:subPropertyOf owl:topObjectProperty ;
+                                             rdfs:domain <http://purl.obolibrary.org/obo/IAO_0000030> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000112> "This document is about information artifacts and their representations"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000125> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000115> "A (currently) primitive relation that relates an information artifact to an entity."@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000116> """7/6/2009 Alan Ruttenberg. Following discussion with Jonathan Rees, and introduction of \"mentions\" relation. Weaken the is_about relationship to be primitive. 
 
 We will try to build it back up by elaborating the various subproperties that are more precisely defined.
 
 Some currently missing phenomena that should be considered \"about\" are predications - \"The only person who knows the answer is sitting beside me\" , Allegory, Satire, and other literary forms that can be topical without explicitly mentioning the topic."""@en ;
-                obo:IAO_0000117 "person:Alan Ruttenberg"@en ;
-                obo:IAO_0000119 "Smith, Ceusters, Ruttenberg, 2000 years of philosophy"@en ;
-                obo:IAO_0000412 "http://purl.obolibrary.org/obo/iao/2020-12-09/iao.owl"^^xsd:string ;
-                rdfs:label "is about"@en ;
-                aeon:AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P921\", \"label\": \"main_subjectLabel\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Property:Field\", \"label\": \"Field\"}, \"gnd\": {\"uri\": \"https://d-nb.info/standards/elementset/gnd#topic\", \"label\": \"Topic that is related to a corporate body, conference, person, family, subject heading or work.\"}}"^^xsd:string ;
-                aeon:SMW_datatype "Text" ;
-                aeon:SMW_import_info "Controlled vocabulary in [[MediaWiki:Smw_allows_list_Subject]] [[Category:IAO]] [[Category:Imported vocabulary]]" .
+                                             <http://purl.obolibrary.org/obo/IAO_0000117> "person:Alan Ruttenberg"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000119> "Smith, Ceusters, Ruttenberg, 2000 years of philosophy"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/iao/2020-12-09/iao.owl"^^xsd:string ;
+                                             rdfs:label "is about"@en ;
+                                             :AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P921\", \"label\": \"main_subjectLabel\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Property:Field\", \"label\": \"Field\"}, \"gnd\": {\"uri\": \"https://d-nb.info/standards/elementset/gnd#topic\", \"label\": \"Topic that is related to a corporate body, conference, person, family, subject heading or work.\"}}"^^xsd:string ;
+                                             :SMW_datatype "Text" ;
+                                             :SMW_import_info "Controlled vocabulary in [[MediaWiki:Smw_allows_list_Subject]] [[Category:IAO]] [[Category:Imported vocabulary]]" .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000219
-obo:IAO_0000219 rdf:type owl:ObjectProperty ;
-                rdfs:subPropertyOf obo:IAO_0000136 ;
-                owl:inverseOf obo:IAO_0000235 ;
-                rdfs:domain obo:IAO_0000030 ;
-                rdfs:range obo:BFO_0000001 ;
-                obo:IAO_0000112 "A person's name denotes the person. A variable name in a computer program denotes some piece of memory. Lexically equivalent strings can denote different things, for instance \"Alan\" can denote different people. In each case of use, there is a case of the denotation relation obtaining, between \"Alan\" and the person that is being named."@en ;
-                obo:IAO_0000115 "A relation obtaining between an information content entity and some portion of reality. Denotation is what happens when someone creates an information content entity E in order to specifically refer to something. The only relation between E and the thing is that E can be used to 'pick out' the thing. This relation connects those two together. Freedictionary.com sense 3: To signify directly; refer to specifically"@en ;
-                obo:IAO_0000116 """2009-11-10 Alan Ruttenberg. Old definition said the following to emphasize the generic nature of this relation. We no longer have 'specifically denotes', which would have been primitive, so make this relation primitive.
+<http://purl.obolibrary.org/obo/IAO_0000219> rdf:type owl:ObjectProperty ;
+                                             rdfs:subPropertyOf <http://purl.obolibrary.org/obo/IAO_0000136> ;
+                                             owl:inverseOf <http://purl.obolibrary.org/obo/IAO_0000235> ;
+                                             rdfs:domain <http://purl.obolibrary.org/obo/IAO_0000030> ;
+                                             rdfs:range <http://purl.obolibrary.org/obo/BFO_0000001> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000112> "A person's name denotes the person. A variable name in a computer program denotes some piece of memory. Lexically equivalent strings can denote different things, for instance \"Alan\" can denote different people. In each case of use, there is a case of the denotation relation obtaining, between \"Alan\" and the person that is being named."@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000115> "A relation obtaining between an information content entity and some portion of reality. Denotation is what happens when someone creates an information content entity E in order to specifically refer to something. The only relation between E and the thing is that E can be used to 'pick out' the thing. This relation connects those two together. Freedictionary.com sense 3: To signify directly; refer to specifically"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000116> """2009-11-10 Alan Ruttenberg. Old definition said the following to emphasize the generic nature of this relation. We no longer have 'specifically denotes', which would have been primitive, so make this relation primitive.
 g denotes r =def 
 r is a portion of reality
 there is some c that is a concretization of g 
 every c that is a concretization of g specifically denotes r"""@en ;
-                obo:IAO_0000117 "person:Alan Ruttenberg"@en ;
-                obo:IAO_0000119 "Conversations with Barry Smith, Werner Ceusters, Bjoern Peters, Michel Dumontier, Melanie Courtot, James Malone, Bill Hogan"@en ;
-                obo:IAO_0000412 "http://purl.obolibrary.org/obo/iao/2020-12-09/iao.owl"^^xsd:string ;
-                rdfs:comment ""@en ;
-                rdfs:label "denotes"@en .
+                                             <http://purl.obolibrary.org/obo/IAO_0000117> "person:Alan Ruttenberg"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000119> "Conversations with Barry Smith, Werner Ceusters, Bjoern Peters, Michel Dumontier, Melanie Courtot, James Malone, Bill Hogan"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/iao/2020-12-09/iao.owl"^^xsd:string ;
+                                             rdfs:comment ""@en ;
+                                             rdfs:label "denotes"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000235
-obo:IAO_0000235 rdf:type owl:ObjectProperty ;
-                rdfs:subPropertyOf owl:topObjectProperty ;
-                rdfs:domain obo:BFO_0000001 ;
-                rdfs:range obo:IAO_0000030 ;
-                obo:IAO_0000115 "inverse of the relation 'denotes'"@en ;
-                obo:IAO_0000117 "Person: Jie Zheng, Chris Stoeckert, Mike Conlon"@en ;
-                obo:IAO_0000233 <https://github.com/information-artifact-ontology/IAO/issues/206> ;
-                obo:IAO_0000412 "http://purl.obolibrary.org/obo/iao/2020-12-09/iao.owl"^^xsd:string ;
-                rdfs:comment "Definiton: Some entity is denoted by an information content entity."@en ;
-                rdfs:label "denoted by"@en .
+<http://purl.obolibrary.org/obo/IAO_0000235> rdf:type owl:ObjectProperty ;
+                                             rdfs:subPropertyOf owl:topObjectProperty ;
+                                             rdfs:domain <http://purl.obolibrary.org/obo/BFO_0000001> ;
+                                             rdfs:range <http://purl.obolibrary.org/obo/IAO_0000030> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000115> "inverse of the relation 'denotes'"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000117> "Person: Jie Zheng, Chris Stoeckert, Mike Conlon"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000233> <https://github.com/information-artifact-ontology/IAO/issues/206> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/iao/2020-12-09/iao.owl"^^xsd:string ;
+                                             rdfs:comment "Definiton: Some entity is denoted by an information content entity."@en ;
+                                             rdfs:label "denoted by"@en .
 
 
 ###  http://purl.obolibrary.org/obo/RO_0000052
-obo:RO_0000052 rdf:type owl:ObjectProperty ;
-               rdfs:subPropertyOf owl:topObjectProperty ;
-               owl:inverseOf obo:RO_0000053 ;
-               rdfs:domain obo:BFO_0000020 ;
-               rdfs:range obo:BFO_0000004 ;
-               obo:IAO_0000111 "inheres in"@en ;
-               obo:IAO_0000112 "this fragility inheres in this vase"@en ,
-                               "this red color inheres in this apple"@en ;
-               obo:IAO_0000115 "a relation between a specifically dependent continuant (the dependent) and an independent continuant (the bearer), in which the dependent specifically depends on the bearer for its existence"@en ;
-               obo:IAO_0000116 "A dependent inheres in its bearer at all times for which the dependent exists."@en ;
-               obo:IAO_0000118 "inheres_in"@en ;
-               obo:IAO_0000412 "http://purl.obolibrary.org/obo/ro/releases/2020-12-18/ro.owl"^^xsd:string ;
-               rdfs:label "inheres in"@en .
+<http://purl.obolibrary.org/obo/RO_0000052> rdf:type owl:ObjectProperty ;
+                                            rdfs:subPropertyOf owl:topObjectProperty ;
+                                            owl:inverseOf <http://purl.obolibrary.org/obo/RO_0000053> ;
+                                            rdfs:domain <http://purl.obolibrary.org/obo/BFO_0000020> ;
+                                            rdfs:range <http://purl.obolibrary.org/obo/BFO_0000004> ;
+                                            <http://purl.obolibrary.org/obo/IAO_0000111> "inheres in"@en ;
+                                            <http://purl.obolibrary.org/obo/IAO_0000112> "this fragility inheres in this vase"@en ,
+                                                                                         "this red color inheres in this apple"@en ;
+                                            <http://purl.obolibrary.org/obo/IAO_0000115> "a relation between a specifically dependent continuant (the dependent) and an independent continuant (the bearer), in which the dependent specifically depends on the bearer for its existence"@en ;
+                                            <http://purl.obolibrary.org/obo/IAO_0000116> "A dependent inheres in its bearer at all times for which the dependent exists."@en ;
+                                            <http://purl.obolibrary.org/obo/IAO_0000118> "inheres_in"@en ;
+                                            <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/ro/releases/2020-12-18/ro.owl"^^xsd:string ;
+                                            rdfs:label "inheres in"@en .
 
 
 ###  http://purl.obolibrary.org/obo/RO_0000053
-obo:RO_0000053 rdf:type owl:ObjectProperty ;
-               rdfs:subPropertyOf owl:topObjectProperty ;
-               rdfs:domain obo:BFO_0000004 ;
-               rdfs:range obo:BFO_0000020 ;
-               obo:IAO_0000111 "bearer of"@en ;
-               obo:IAO_0000112 "this apple is bearer of this red color"@en ,
-                               "this vase is bearer of this fragility"@en ;
-               obo:IAO_0000115 "a relation between an independent continuant (the bearer) and a specifically dependent continuant (the dependent), in which the dependent specifically depends on the bearer for its existence"@en ;
-               obo:IAO_0000116 "A bearer can have many dependents, and its dependents can exist for different periods of time, but none of its dependents can exist when the bearer does not exist."@en ;
-               obo:IAO_0000118 "bearer_of"@en ,
-                               "is bearer of"@en ;
-               obo:IAO_0000412 "http://purl.obolibrary.org/obo/ro/releases/2020-12-18/ro.owl"^^xsd:string ;
-               obo:RO_0001900 obo:RO_0001901 ;
-               rdfs:label "bearer of"@en .
+<http://purl.obolibrary.org/obo/RO_0000053> rdf:type owl:ObjectProperty ;
+                                            rdfs:subPropertyOf owl:topObjectProperty ;
+                                            rdfs:domain <http://purl.obolibrary.org/obo/BFO_0000004> ;
+                                            rdfs:range <http://purl.obolibrary.org/obo/BFO_0000020> ;
+                                            <http://purl.obolibrary.org/obo/IAO_0000111> "bearer of"@en ;
+                                            <http://purl.obolibrary.org/obo/IAO_0000112> "this apple is bearer of this red color"@en ,
+                                                                                         "this vase is bearer of this fragility"@en ;
+                                            <http://purl.obolibrary.org/obo/IAO_0000115> "a relation between an independent continuant (the bearer) and a specifically dependent continuant (the dependent), in which the dependent specifically depends on the bearer for its existence"@en ;
+                                            <http://purl.obolibrary.org/obo/IAO_0000116> "A bearer can have many dependents, and its dependents can exist for different periods of time, but none of its dependents can exist when the bearer does not exist."@en ;
+                                            <http://purl.obolibrary.org/obo/IAO_0000118> "bearer_of"@en ,
+                                                                                         "is bearer of"@en ;
+                                            <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/ro/releases/2020-12-18/ro.owl"^^xsd:string ;
+                                            <http://purl.obolibrary.org/obo/RO_0001900> <http://purl.obolibrary.org/obo/RO_0001901> ;
+                                            rdfs:label "bearer of"@en .
 
 
 ###  http://purl.obolibrary.org/obo/RO_0000056
-obo:RO_0000056 rdf:type owl:ObjectProperty ;
-               rdfs:subPropertyOf owl:topObjectProperty ;
-               owl:inverseOf obo:RO_0000057 ;
-               rdfs:domain obo:BFO_0000002 ;
-               rdfs:range obo:BFO_0000003 ;
-               obo:IAO_0000111 "participates in"@en ;
-               obo:IAO_0000112 "this blood clot participates in this blood coagulation"@en ,
-                               "this input material (or this output material) participates in this process"@en ,
-                               "this investigator participates in this investigation"@en ;
-               obo:IAO_0000115 "a relation between a continuant and a process, in which the continuant is somehow involved in the process"@en ;
-               obo:IAO_0000118 "participates_in"@en ;
-               obo:IAO_0000412 "http://purl.obolibrary.org/obo/ro/releases/2020-12-18/ro.owl"^^xsd:string ;
-               rdfs:label "participates in"@en .
+<http://purl.obolibrary.org/obo/RO_0000056> rdf:type owl:ObjectProperty ;
+                                            rdfs:subPropertyOf owl:topObjectProperty ;
+                                            owl:inverseOf <http://purl.obolibrary.org/obo/RO_0000057> ;
+                                            rdfs:domain <http://purl.obolibrary.org/obo/BFO_0000002> ;
+                                            rdfs:range <http://purl.obolibrary.org/obo/BFO_0000003> ;
+                                            <http://purl.obolibrary.org/obo/IAO_0000111> "participates in"@en ;
+                                            <http://purl.obolibrary.org/obo/IAO_0000112> "this blood clot participates in this blood coagulation"@en ,
+                                                                                         "this input material (or this output material) participates in this process"@en ,
+                                                                                         "this investigator participates in this investigation"@en ;
+                                            <http://purl.obolibrary.org/obo/IAO_0000115> "a relation between a continuant and a process, in which the continuant is somehow involved in the process"@en ;
+                                            <http://purl.obolibrary.org/obo/IAO_0000118> "participates_in"@en ;
+                                            <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/ro/releases/2020-12-18/ro.owl"^^xsd:string ;
+                                            rdfs:label "participates in"@en .
 
 
 ###  http://purl.obolibrary.org/obo/RO_0000057
-obo:RO_0000057 rdf:type owl:ObjectProperty ;
-               rdfs:subPropertyOf owl:topObjectProperty ;
-               rdfs:domain obo:BFO_0000003 ;
-               rdfs:range obo:BFO_0000002 ;
-               obo:IAO_0000111 "has participant"@en ;
-               obo:IAO_0000112 "this blood coagulation has participant this blood clot"@en ,
-                               "this investigation has participant this investigator"@en ,
-                               "this process has participant this input material (or this output material)"@en ;
-               obo:IAO_0000115 "a relation between a process and a continuant, in which the continuant is somehow involved in the process"@en ;
-               obo:IAO_0000116 "Has_participant is a primitive instance-level relation between a process, a continuant, and a time at which the continuant participates in some way in the process. The relation obtains, for example, when this particular process of oxygen exchange across this particular alveolar membrane has_participant this particular sample of hemoglobin at this particular time."@en ;
-               obo:IAO_0000118 "has_participant"@en ;
-               obo:IAO_0000412 "http://purl.obolibrary.org/obo/ro/releases/2020-12-18/ro.owl"^^xsd:string ;
-               <http://purl.org/dc/elements/1.1/source> "http://www.obofoundry.org/ro/#OBO_REL:has_participant" ;
-               rdfs:label "has participant"@en .
+<http://purl.obolibrary.org/obo/RO_0000057> rdf:type owl:ObjectProperty ;
+                                            rdfs:subPropertyOf owl:topObjectProperty ;
+                                            rdfs:domain <http://purl.obolibrary.org/obo/BFO_0000003> ;
+                                            rdfs:range <http://purl.obolibrary.org/obo/BFO_0000002> ;
+                                            <http://purl.obolibrary.org/obo/IAO_0000111> "has participant"@en ;
+                                            <http://purl.obolibrary.org/obo/IAO_0000112> "this blood coagulation has participant this blood clot"@en ,
+                                                                                         "this investigation has participant this investigator"@en ,
+                                                                                         "this process has participant this input material (or this output material)"@en ;
+                                            <http://purl.obolibrary.org/obo/IAO_0000115> "a relation between a process and a continuant, in which the continuant is somehow involved in the process"@en ;
+                                            <http://purl.obolibrary.org/obo/IAO_0000116> "Has_participant is a primitive instance-level relation between a process, a continuant, and a time at which the continuant participates in some way in the process. The relation obtains, for example, when this particular process of oxygen exchange across this particular alveolar membrane has_participant this particular sample of hemoglobin at this particular time."@en ;
+                                            <http://purl.obolibrary.org/obo/IAO_0000118> "has_participant"@en ;
+                                            <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/ro/releases/2020-12-18/ro.owl"^^xsd:string ;
+                                            <http://purl.org/dc/elements/1.1/source> "http://www.obofoundry.org/ro/#OBO_REL:has_participant" ;
+                                            rdfs:label "has participant"@en .
 
 
 ###  http://purl.obolibrary.org/obo/RO_0000081
-obo:RO_0000081 rdf:type owl:ObjectProperty ;
-               rdfs:subPropertyOf obo:RO_0000052 ;
-               owl:inverseOf obo:RO_0000087 ;
-               rdfs:domain obo:BFO_0000023 ;
-               rdfs:range obo:BFO_0000004 ;
-               obo:IAO_0000112 "this investigator role is a role of this person"@en ;
-               obo:IAO_0000115 "a relation between a role and an independent continuant (the bearer), in which the role specifically depends on the bearer for its existence"@en ;
-               obo:IAO_0000116 "A role inheres in its bearer at all times for which the role exists, however the role need not be realized at all the times that the role exists."@en ;
-               obo:IAO_0000118 "is role of"@en ,
-                               "role_of"@en ;
-               obo:IAO_0000412 "http://purl.obolibrary.org/obo/ro/releases/2020-12-18/ro.owl"^^xsd:string ;
-               rdfs:label "role of"@en .
+<http://purl.obolibrary.org/obo/RO_0000081> rdf:type owl:ObjectProperty ;
+                                            rdfs:subPropertyOf <http://purl.obolibrary.org/obo/RO_0000052> ;
+                                            owl:inverseOf <http://purl.obolibrary.org/obo/RO_0000087> ;
+                                            rdfs:domain <http://purl.obolibrary.org/obo/BFO_0000023> ;
+                                            rdfs:range <http://purl.obolibrary.org/obo/BFO_0000004> ;
+                                            <http://purl.obolibrary.org/obo/IAO_0000112> "this investigator role is a role of this person"@en ;
+                                            <http://purl.obolibrary.org/obo/IAO_0000115> "a relation between a role and an independent continuant (the bearer), in which the role specifically depends on the bearer for its existence"@en ;
+                                            <http://purl.obolibrary.org/obo/IAO_0000116> "A role inheres in its bearer at all times for which the role exists, however the role need not be realized at all the times that the role exists."@en ;
+                                            <http://purl.obolibrary.org/obo/IAO_0000118> "is role of"@en ,
+                                                                                         "role_of"@en ;
+                                            <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/ro/releases/2020-12-18/ro.owl"^^xsd:string ;
+                                            rdfs:label "role of"@en .
 
 
 ###  http://purl.obolibrary.org/obo/RO_0000087
-obo:RO_0000087 rdf:type owl:ObjectProperty ;
-               rdfs:subPropertyOf obo:RO_0000053 ;
-               rdfs:domain obo:BFO_0000004 ;
-               rdfs:range obo:BFO_0000023 ;
-               obo:IAO_0000112 "this person has role this investigator role (more colloquially: this person has this role of investigator)"@en ;
-               obo:IAO_0000115 "a relation between an independent continuant (the bearer) and a role, in which the role specifically depends on the bearer for its existence"@en ;
-               obo:IAO_0000116 "A bearer can have many roles, and its roles can exist for different periods of time, but none of its roles can exist when the bearer does not exist. A role need not be realized at all the times that the role exists."@en ;
-               obo:IAO_0000118 "has_role"@en ;
-               obo:IAO_0000412 "http://purl.obolibrary.org/obo/ro/releases/2020-12-18/ro.owl"^^xsd:string ;
-               rdfs:label "has role"@en .
+<http://purl.obolibrary.org/obo/RO_0000087> rdf:type owl:ObjectProperty ;
+                                            rdfs:subPropertyOf <http://purl.obolibrary.org/obo/RO_0000053> ;
+                                            rdfs:domain <http://purl.obolibrary.org/obo/BFO_0000004> ;
+                                            rdfs:range <http://purl.obolibrary.org/obo/BFO_0000023> ;
+                                            <http://purl.obolibrary.org/obo/IAO_0000112> "this person has role this investigator role (more colloquially: this person has this role of investigator)"@en ;
+                                            <http://purl.obolibrary.org/obo/IAO_0000115> "a relation between an independent continuant (the bearer) and a role, in which the role specifically depends on the bearer for its existence"@en ;
+                                            <http://purl.obolibrary.org/obo/IAO_0000116> "A bearer can have many roles, and its roles can exist for different periods of time, but none of its roles can exist when the bearer does not exist. A role need not be realized at all the times that the role exists."@en ;
+                                            <http://purl.obolibrary.org/obo/IAO_0000118> "has_role"@en ;
+                                            <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/ro/releases/2020-12-18/ro.owl"^^xsd:string ;
+                                            rdfs:label "has role"@en .
 
 
 ###  http://purl.obolibrary.org/obo/RO_0002012
-obo:RO_0002012 rdf:type owl:ObjectProperty ;
-               rdfs:subPropertyOf obo:BFO_0000050 ;
-               rdfs:domain obo:BFO_0000003 ;
-               rdfs:range obo:BFO_0000003 ;
-               obo:IAO_0000115 "A part of relation that applies only between occurents." ;
-               obo:IAO_0000412 "http://purl.obolibrary.org/obo/ro/releases/2021-03-08/ro.owl"^^xsd:string ;
-               rdfs:label "occurent part of" .
+<http://purl.obolibrary.org/obo/RO_0002012> rdf:type owl:ObjectProperty ;
+                                            rdfs:subPropertyOf <http://purl.obolibrary.org/obo/BFO_0000050> ;
+                                            rdfs:domain <http://purl.obolibrary.org/obo/BFO_0000003> ;
+                                            rdfs:range <http://purl.obolibrary.org/obo/BFO_0000003> ;
+                                            <http://purl.obolibrary.org/obo/IAO_0000115> "A part of relation that applies only between occurents." ;
+                                            <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/ro/releases/2021-03-08/ro.owl"^^xsd:string ;
+                                            rdfs:label "occurent part of" .
 
 
 ###  http://purl.obolibrary.org/obo/RO_0002234
-obo:RO_0002234 rdf:type owl:ObjectProperty ;
-               rdfs:subPropertyOf obo:RO_0000057 ;
-               rdfs:domain obo:BFO_0000003 ;
-               rdfs:range obo:BFO_0000002 ;
-               obo:IAO_0000114 obo:IAO_0000125 ;
-               obo:IAO_0000115 "p has output c iff c is a participant in p, c is present at the end of p, and c is not present at the beginning of p." ;
-               obo:IAO_0000117 "Chris Mungall" ;
-               obo:IAO_0000118 "produces" ;
-               obo:IAO_0000412 "http://purl.obolibrary.org/obo/ro/releases/2020-12-18/ro.owl"^^xsd:string ;
-               rdfs:label "has output"@en .
+<http://purl.obolibrary.org/obo/RO_0002234> rdf:type owl:ObjectProperty ;
+                                            rdfs:subPropertyOf <http://purl.obolibrary.org/obo/RO_0000057> ;
+                                            rdfs:domain <http://purl.obolibrary.org/obo/BFO_0000003> ;
+                                            rdfs:range <http://purl.obolibrary.org/obo/BFO_0000002> ;
+                                            <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000125> ;
+                                            <http://purl.obolibrary.org/obo/IAO_0000115> "p has output c iff c is a participant in p, c is present at the end of p, and c is not present at the beginning of p." ;
+                                            <http://purl.obolibrary.org/obo/IAO_0000117> "Chris Mungall" ;
+                                            <http://purl.obolibrary.org/obo/IAO_0000118> "produces" ;
+                                            <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/ro/releases/2020-12-18/ro.owl"^^xsd:string ;
+                                            rdfs:label "has output"@en .
 
 
 ###  http://purl.obolibrary.org/obo/RO_0002350
-obo:RO_0002350 rdf:type owl:ObjectProperty ;
-               rdfs:subPropertyOf obo:BFO_0000050 ;
-               obo:IAO_0000112 "An organism that is a member of a population of organisms" ;
-               obo:IAO_0000115 "is member of is a mereological relation between a item and a collection." ;
-               obo:IAO_0000118 "is member of" ,
-                               "member part of" ;
-               obo:IAO_0000119 "SIO" ;
-               obo:IAO_0000412 "http://purl.obolibrary.org/obo/ro/releases/2020-12-18/ro.owl"^^xsd:string ;
-               obo:RO_0001900 obo:RO_0001901 ;
-               rdfs:label "member of"@en .
+<http://purl.obolibrary.org/obo/RO_0002350> rdf:type owl:ObjectProperty ;
+                                            rdfs:subPropertyOf <http://purl.obolibrary.org/obo/BFO_0000050> ;
+                                            <http://purl.obolibrary.org/obo/IAO_0000112> "An organism that is a member of a population of organisms" ;
+                                            <http://purl.obolibrary.org/obo/IAO_0000115> "is member of is a mereological relation between a item and a collection." ;
+                                            <http://purl.obolibrary.org/obo/IAO_0000118> "is member of" ,
+                                                                                         "member part of" ;
+                                            <http://purl.obolibrary.org/obo/IAO_0000119> "SIO" ;
+                                            <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/ro/releases/2020-12-18/ro.owl"^^xsd:string ;
+                                            <http://purl.obolibrary.org/obo/RO_0001900> <http://purl.obolibrary.org/obo/RO_0001901> ;
+                                            rdfs:label "member of"@en .
 
 
 ###  http://purl.obolibrary.org/obo/RO_0002351
-obo:RO_0002351 rdf:type owl:ObjectProperty ;
-               rdfs:subPropertyOf obo:BFO_0000051 ;
-               obo:IAO_0000115 "has member is a mereological relation between a collection and an item." ;
-               obo:IAO_0000119 "SIO" ;
-               obo:IAO_0000412 "http://purl.obolibrary.org/obo/ro/releases/2020-12-18/ro.owl"^^xsd:string ;
-               obo:RO_0001900 obo:RO_0001901 ;
-               rdfs:label "has member"@en .
+<http://purl.obolibrary.org/obo/RO_0002351> rdf:type owl:ObjectProperty ;
+                                            rdfs:subPropertyOf <http://purl.obolibrary.org/obo/BFO_0000051> ;
+                                            <http://purl.obolibrary.org/obo/IAO_0000115> "has member is a mereological relation between a collection and an item." ;
+                                            <http://purl.obolibrary.org/obo/IAO_0000119> "SIO" ;
+                                            <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/ro/releases/2020-12-18/ro.owl"^^xsd:string ;
+                                            <http://purl.obolibrary.org/obo/RO_0001900> <http://purl.obolibrary.org/obo/RO_0001901> ;
+                                            rdfs:label "has member"@en .
 
 
 ###  http://purl.obolibrary.org/obo/RO_0002353
-obo:RO_0002353 rdf:type owl:ObjectProperty ;
-               rdfs:subPropertyOf obo:RO_0000056 ;
-               rdfs:domain obo:BFO_0000002 ;
-               rdfs:range obo:BFO_0000003 ;
-               obo:IAO_0000115 "inverse of has output" ;
-               obo:IAO_0000117 "Chris Mungall" ;
-               obo:IAO_0000412 "http://purl.obolibrary.org/obo/ro/releases/2020-12-18/ro.owl"^^xsd:string ;
-               rdfs:label "output of"@en .
+<http://purl.obolibrary.org/obo/RO_0002353> rdf:type owl:ObjectProperty ;
+                                            rdfs:subPropertyOf <http://purl.obolibrary.org/obo/RO_0000056> ;
+                                            rdfs:domain <http://purl.obolibrary.org/obo/BFO_0000002> ;
+                                            rdfs:range <http://purl.obolibrary.org/obo/BFO_0000003> ;
+                                            <http://purl.obolibrary.org/obo/IAO_0000115> "inverse of has output" ;
+                                            <http://purl.obolibrary.org/obo/IAO_0000117> "Chris Mungall" ;
+                                            <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/ro/releases/2020-12-18/ro.owl"^^xsd:string ;
+                                            rdfs:label "output of"@en .
 
 
 ###  http://purl.obolibrary.org/obo/TXPO_0002523
-obo:TXPO_0002523 rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf obo:BFO_0000051 ;
-                 obo:IAO_0000115 "\"has ocurrent part\" is a relation that holds between a whole occurrent (process) and its part." ;
-                 obo:IAO_0000232 "There is no RO relation 'has occurent part' which can serve as the inverse of http://purl.obolibrary.org/obo/RO_0002012 (occurent part of). One might use the BFO2020 (BFO_0000132), or more precicesly BFO_0000138 (proper occurent part of). But this will generate problems due to the incompatibility as of now (Feb 2021) between BFO2020 and RO."@en ;
-                 obo:IAO_0000412 "http://purl.obolibrary.org/obo/txpo/releases/2020-03-03/txpo.owl"^^xsd:string ;
-                 rdfs:label "has occurrent part" .
+<http://purl.obolibrary.org/obo/TXPO_0002523> rdf:type owl:ObjectProperty ;
+                                              rdfs:subPropertyOf <http://purl.obolibrary.org/obo/BFO_0000051> ;
+                                              <http://purl.obolibrary.org/obo/IAO_0000115> "\"has ocurrent part\" is a relation that holds between a whole occurrent (process) and its part." ;
+                                              <http://purl.obolibrary.org/obo/IAO_0000232> "There is no RO relation 'has occurent part' which can serve as the inverse of http://purl.obolibrary.org/obo/RO_0002012 (occurent part of). One might use the BFO2020 (BFO_0000132), or more precicesly BFO_0000138 (proper occurent part of). But this will generate problems due to the incompatibility as of now (Feb 2021) between BFO2020 and RO."@en ;
+                                              <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/txpo/releases/2020-03-03/txpo.owl"^^xsd:string ;
+                                              rdfs:label "has occurrent part" .
 
 
 ###  http://www.w3.org/2002/07/owl#topObjectProperty
-owl:topObjectProperty obo:IAO_0000115 """'has academic field' is a primitive, instance-level relation obtaining between a planned process and the skos:Concept subclass 'academic field'. 
+owl:topObjectProperty <http://purl.obolibrary.org/obo/IAO_0000115> """'has academic field' is a primitive, instance-level relation obtaining between a planned process and the skos:Concept subclass 'academic field'. 
 To say p has academic field x =def. p is a planned process, there is some x that is an academic field of p."""@en .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000032
-aeon:AEON_0000032 rdf:type owl:ObjectProperty ;
-                  owl:inverseOf aeon:event_type_of ;
-                  rdfs:domain aeon:AEON_0000001 ;
-                  rdfs:range aeon:AEON_0000004 ;
-                  obo:IAO_0000115 "A relation obtaining between a planned process and a skos:Concept that is used to descibe the social format of an 'academic event'."@en ;
-                  obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
-                  rdfs:label "has event type"@en ;
-                  aeon:AEON_0000026 "{\"wikidata\": {\"uri\": null, \"label\": \"event_type\"}, \"openresearch\": {\"uri\": null, \"label\": \"Type\"}}"^^xsd:string ;
-                  aeon:SMW_datatype "Text" ;
-                  aeon:SMW_import_info """The allowed value list for this property is defined in [[MediaWiki:Smw_allows_list_has_event_type]].
+:AEON_0000032 rdf:type owl:ObjectProperty ;
+              owl:inverseOf :event_type_of ;
+              rdfs:domain :AEON_0000001 ;
+              rdfs:range :AEON_0000004 ;
+              <http://purl.obolibrary.org/obo/IAO_0000115> "A relation obtaining between a planned process and a skos:Concept that is used to descibe the social format of an 'academic event'."@en ;
+              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"@en ;
+              rdfs:label "has event type"@en ;
+              :AEON_0000026 "{\"wikidata\": {\"uri\": null, \"label\": \"event_type\"}, \"openresearch\": {\"uri\": null, \"label\": \"Type\"}}"^^xsd:string ;
+              :SMW_datatype "Text" ;
+              :SMW_import_info """The allowed value list for this property is defined in [[MediaWiki:Smw_allows_list_has_event_type]].
 [[Category:AEON]] [[Category:Imported vocabulary]]""" ;
-                  aeon:WikidataLabel "event_type" .
+              :WikidataLabel "event_type" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000033
-aeon:AEON_0000033 rdf:type owl:ObjectProperty ;
-                  rdfs:subPropertyOf obo:IAO_0000235 ;
-                  rdfs:domain obo:BFO_0000001 ;
-                  rdfs:range aeon:AEON_0000034 ;
-                  obo:IAO_0000115 "A relation obtaining between an entity and a distributed identifier that is used to denote the entity."@en ;
-                  obo:IAO_0000117 "PERSON: Philip Strömert"@en ,
-                                  "Philip Stroemert"^^xsd:string ;
-                  rdfs:label "has distributed identifier"@en ;
-                  ns:term_status obo:IAO_0000423 .
+:AEON_0000033 rdf:type owl:ObjectProperty ;
+              rdfs:subPropertyOf <http://purl.obolibrary.org/obo/IAO_0000235> ;
+              rdfs:domain <http://purl.obolibrary.org/obo/BFO_0000001> ;
+              rdfs:range :AEON_0000034 ;
+              <http://purl.obolibrary.org/obo/IAO_0000115> "A relation obtaining between an entity and a distributed identifier that is used to denote the entity."@en ;
+              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"@en ,
+                                                           "Philip Stroemert"^^xsd:string ;
+              rdfs:label "has distributed identifier"@en ;
+              <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> <http://purl.obolibrary.org/obo/IAO_0000423> .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000040
-aeon:AEON_0000040 rdf:type owl:ObjectProperty ;
-                  owl:inverseOf aeon:academic_field_of ;
-                  rdfs:domain obo:OBI_0000011 ;
-                  rdfs:range aeon:AEON_0000027 ;
-                  obo:IAO_0000115 "A relation obtaining between a planned process and a skos:Concept that is used to descibe the scientific subject of the planned process according to some controlled vocabulary or thesaurus."@en ;
-                  obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
-                  rdfs:label "has academic field"@en .
+:AEON_0000040 rdf:type owl:ObjectProperty ;
+              owl:inverseOf :academic_field_of ;
+              rdfs:domain <http://purl.obolibrary.org/obo/OBI_0000011> ;
+              rdfs:range :AEON_0000027 ;
+              <http://purl.obolibrary.org/obo/IAO_0000115> "A relation obtaining between a planned process and a skos:Concept that is used to descibe the scientific subject of the planned process according to some controlled vocabulary or thesaurus."@en ;
+              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"@en ;
+              rdfs:label "has academic field"@en .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000041
-aeon:AEON_0000041 rdf:type owl:ObjectProperty ;
-                  owl:inverseOf aeon:topic_of ;
-                  rdfs:domain obo:OBI_0000011 ;
-                  rdfs:range aeon:AEON_0000028 ;
-                  obo:IAO_0000117 "A relation obtaining between a planned process and a skos:Concept that is used to descibe the theme of the planned process."@en ,
-                                  "PERSON: Philip Strömert"@en ;
-                  rdfs:label "has topic"@en .
+:AEON_0000041 rdf:type owl:ObjectProperty ;
+              owl:inverseOf :topic_of ;
+              rdfs:domain <http://purl.obolibrary.org/obo/OBI_0000011> ;
+              rdfs:range :AEON_0000028 ;
+              <http://purl.obolibrary.org/obo/IAO_0000117> "A relation obtaining between a planned process and a skos:Concept that is used to descibe the theme of the planned process."@en ,
+                                                           "PERSON: Philip Strömert"@en ;
+              rdfs:label "has topic"@en .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000043
-aeon:AEON_0000043 rdf:type owl:ObjectProperty ;
-                  rdfs:subPropertyOf owl:topObjectProperty ;
-                  rdfs:domain aeon:AEON_0000001 ;
-                  rdfs:range aeon:AEON_0000030 ;
-                  obo:IAO_0000115 "A relation obtaining between a planned process and an 'information content entity' that is about the amount of money one has to pay in order to be an allowed participant of the planned process."@en ;
-                  obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
-                  rdfs:label "has fee"@en ;
-                  aeon:SMW_datatype "Text" ;
-                  aeon:SMW_import_info """The allowed value list for this property is defined in [[MediaWiki:Smw_allows_list_Has_fee]].
+:AEON_0000043 rdf:type owl:ObjectProperty ;
+              rdfs:subPropertyOf owl:topObjectProperty ;
+              rdfs:domain :AEON_0000001 ;
+              rdfs:range :AEON_0000030 ;
+              <http://purl.obolibrary.org/obo/IAO_0000115> "A relation obtaining between a planned process and an 'information content entity' that is about the amount of money one has to pay in order to be an allowed participant of the planned process."@en ;
+              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"@en ;
+              rdfs:label "has fee"@en ;
+              :SMW_datatype "Text" ;
+              :SMW_import_info """The allowed value list for this property is defined in [[MediaWiki:Smw_allows_list_Has_fee]].
 
 [[partOfSubobject::Template:Subobject Fee]]
 
@@ -709,220 +703,220 @@ aeon:AEON_0000043 rdf:type owl:ObjectProperty ;
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000045
-aeon:AEON_0000045 rdf:type owl:ObjectProperty ;
-                  rdfs:subPropertyOf obo:RO_0000057 ;
-                  owl:inverseOf aeon:contibutes_to ;
-                  rdfs:domain obo:OBI_0000011 ;
-                  rdfs:range aeon:contributor ;
-                  obo:IAO_0000115 "'has contributor' is a relation obtaining between a planned process and a person or organization that holds a contributor role which is being realized by the planned process. A contribution to a planned process takes place when someone works on the planning or realization of a planned process."@en ,
-                                  "A relation obtaining between an entity and its corresponding Wikidata entity identifier."@en ;
-                  obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
-                  rdfs:label "has contributor"@en ;
-                  aeon:SMW_datatype "Page" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:AEON_0000045 rdf:type owl:ObjectProperty ;
+              rdfs:subPropertyOf <http://purl.obolibrary.org/obo/RO_0000057> ;
+              owl:inverseOf :contibutes_to ;
+              rdfs:domain <http://purl.obolibrary.org/obo/OBI_0000011> ;
+              rdfs:range :contributor ;
+              <http://purl.obolibrary.org/obo/IAO_0000115> "'has contributor' is a relation obtaining between a planned process and a person or organization that holds a contributor role which is being realized by the planned process. A contribution to a planned process takes place when someone works on the planning or realization of a planned process."@en ,
+                                                           "A relation obtaining between an entity and its corresponding Wikidata entity identifier."@en ;
+              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"@en ;
+              rdfs:label "has contributor"@en ;
+              :SMW_datatype "Page" ;
+              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000046
-aeon:AEON_0000046 rdf:type owl:ObjectProperty ;
-                  rdfs:subPropertyOf aeon:AEON_0000045 ;
-                  owl:inverseOf aeon:attends_at ;
-                  rdfs:domain obo:OBI_0000011 ;
-                  rdfs:range aeon:attendee ;
-                  obo:IAO_0000115 "A relation obtaining between a planned process and a person that holds an attendee role which is being realized by the planned process."@en ;
-                  obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
-                  rdfs:label "has attendee"@en ;
-                  aeon:AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P710\", \"label\": \"participantLabel\"}}"^^xsd:string ;
-                  aeon:SMW_datatype "Page" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" ;
-                  aeon:WikidataLabel "participantLabel" ;
-                  aeon:WikidataURI "https://www.wikidata.org/wiki/Property:P710" .
+:AEON_0000046 rdf:type owl:ObjectProperty ;
+              rdfs:subPropertyOf :AEON_0000045 ;
+              owl:inverseOf :attends_at ;
+              rdfs:domain <http://purl.obolibrary.org/obo/OBI_0000011> ;
+              rdfs:range :attendee ;
+              <http://purl.obolibrary.org/obo/IAO_0000115> "A relation obtaining between a planned process and a person that holds an attendee role which is being realized by the planned process."@en ;
+              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"@en ;
+              rdfs:label "has attendee"@en ;
+              :AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P710\", \"label\": \"participantLabel\"}}"^^xsd:string ;
+              :SMW_datatype "Page" ;
+              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" ;
+              :WikidataLabel "participantLabel" ;
+              :WikidataURI "https://www.wikidata.org/wiki/Property:P710" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000047
-aeon:AEON_0000047 rdf:type owl:ObjectProperty ;
-                  rdfs:subPropertyOf aeon:AEON_0000045 ;
-                  owl:inverseOf aeon:moderates_at ;
-                  rdfs:domain obo:OBI_0000011 ;
-                  rdfs:range aeon:moderator ;
-                  obo:IAO_0000115 "A relation obtaining between a planned process and a person that holds a moderator role which is being realized by the planned process."@en ;
-                  obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
-                  rdfs:label "has moderator"@en ;
-                  aeon:SMW_datatype "Page" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:AEON_0000047 rdf:type owl:ObjectProperty ;
+              rdfs:subPropertyOf :AEON_0000045 ;
+              owl:inverseOf :moderates_at ;
+              rdfs:domain <http://purl.obolibrary.org/obo/OBI_0000011> ;
+              rdfs:range :moderator ;
+              <http://purl.obolibrary.org/obo/IAO_0000115> "A relation obtaining between a planned process and a person that holds a moderator role which is being realized by the planned process."@en ;
+              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"@en ;
+              rdfs:label "has moderator"@en ;
+              :SMW_datatype "Page" ;
+              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000048
-aeon:AEON_0000048 rdf:type owl:ObjectProperty ;
-                  rdfs:subPropertyOf aeon:AEON_0000045 ;
-                  owl:inverseOf aeon:organizes ;
-                  rdfs:domain obo:OBI_0000011 ;
-                  rdfs:range aeon:organizer ;
-                  obo:IAO_0000115 "A relation obtaining between a planned process and a person or organization that holds an organizer role which is being realized by the planned process."@en ;
-                  obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
-                  rdfs:label "has organizer"@en ;
-                  aeon:AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P664\", \"label\": \"organizerLabel\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Property:Has_organizer\", \"label\": \"Has_organizer\"},\"crossref\": {\"api_proceedings_endpoint_uri\": \"https://api.crossref.org/types/proceedings/works?select=event\", \"json_api_key\": {\"event\": \"sponsor\"}}}"^^xsd:string ;
-                  aeon:SMW_datatype "Page" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" ;
-                  aeon:WikidataLabel "organizerLabel" ;
-                  aeon:WikidataURI "https://www.wikidata.org/wiki/Property:P664" .
+:AEON_0000048 rdf:type owl:ObjectProperty ;
+              rdfs:subPropertyOf :AEON_0000045 ;
+              owl:inverseOf :organizes ;
+              rdfs:domain <http://purl.obolibrary.org/obo/OBI_0000011> ;
+              rdfs:range :organizer ;
+              <http://purl.obolibrary.org/obo/IAO_0000115> "A relation obtaining between a planned process and a person or organization that holds an organizer role which is being realized by the planned process."@en ;
+              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"@en ;
+              rdfs:label "has organizer"@en ;
+              :AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P664\", \"label\": \"organizerLabel\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Property:Has_organizer\", \"label\": \"Has_organizer\"},\"crossref\": {\"api_proceedings_endpoint_uri\": \"https://api.crossref.org/types/proceedings/works?select=event\", \"json_api_key\": {\"event\": \"sponsor\"}}}"^^xsd:string ;
+              :SMW_datatype "Page" ;
+              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" ;
+              :WikidataLabel "organizerLabel" ;
+              :WikidataURI "https://www.wikidata.org/wiki/Property:P664" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000049
-aeon:AEON_0000049 rdf:type owl:ObjectProperty ;
-                  rdfs:subPropertyOf aeon:AEON_0000045 ;
-                  owl:inverseOf aeon:reviews_at ;
-                  rdfs:domain obo:OBI_0000011 ;
-                  rdfs:range aeon:reviewer ;
-                  obo:IAO_0000115 "A relation obtaining between a planned process and a person that holds a reviewer role which is being realized by the planned process."@en ;
-                  obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
-                  rdfs:label "has reviewer"@en ;
-                  aeon:SMW_datatype "Page" ;
-                  aeon:SMW_import_info """[[partOfSubobject::Template:Subobject Contributor]]
+:AEON_0000049 rdf:type owl:ObjectProperty ;
+              rdfs:subPropertyOf :AEON_0000045 ;
+              owl:inverseOf :reviews_at ;
+              rdfs:domain <http://purl.obolibrary.org/obo/OBI_0000011> ;
+              rdfs:range :reviewer ;
+              <http://purl.obolibrary.org/obo/IAO_0000115> "A relation obtaining between a planned process and a person that holds a reviewer role which is being realized by the planned process."@en ;
+              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"@en ;
+              rdfs:label "has reviewer"@en ;
+              :SMW_datatype "Page" ;
+              :SMW_import_info """[[partOfSubobject::Template:Subobject Contributor]]
 
 [[Category:AEON]] [[Category:Imported vocabulary]]""" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000050
-aeon:AEON_0000050 rdf:type owl:ObjectProperty ;
-                  rdfs:subPropertyOf aeon:AEON_0000045 ;
-                  owl:inverseOf aeon:speaks_at ;
-                  rdfs:domain obo:OBI_0000011 ;
-                  rdfs:range aeon:speaker ;
-                  obo:IAO_0000115 "A relation obtaining between a planned process and a person that holds a presenter role which is being realized by the planned process."@en ;
-                  obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
-                  rdfs:label "has presenter"@en ;
-                  aeon:AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P823\", \"label\": \"speaker\"}}"^^xsd:string ;
-                  aeon:SMW_datatype "Page" ;
-                  aeon:SMW_import_info """[[partOfSubobject::Template:Subobject Contributor]]
+:AEON_0000050 rdf:type owl:ObjectProperty ;
+              rdfs:subPropertyOf :AEON_0000045 ;
+              owl:inverseOf :speaks_at ;
+              rdfs:domain <http://purl.obolibrary.org/obo/OBI_0000011> ;
+              rdfs:range :speaker ;
+              <http://purl.obolibrary.org/obo/IAO_0000115> "A relation obtaining between a planned process and a person that holds a presenter role which is being realized by the planned process."@en ;
+              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"@en ;
+              rdfs:label "has presenter"@en ;
+              :AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P823\", \"label\": \"speaker\"}}"^^xsd:string ;
+              :SMW_datatype "Page" ;
+              :SMW_import_info """[[partOfSubobject::Template:Subobject Contributor]]
 
 [[Category:AEON]] [[Category:Imported vocabulary]]""" ;
-                  aeon:WikidataLabel "speaker" ;
-                  aeon:WikidataURI "https://www.wikidata.org/wiki/Property:P823" .
+              :WikidataLabel "speaker" ;
+              :WikidataURI "https://www.wikidata.org/wiki/Property:P823" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000051
-aeon:AEON_0000051 rdf:type owl:ObjectProperty ;
-                  rdfs:subPropertyOf aeon:AEON_0000045 ;
-                  owl:inverseOf aeon:sponsors ;
-                  rdfs:domain obo:OBI_0000011 ;
-                  rdfs:range aeon:sponsor ;
-                  obo:IAO_0000115 "A relation obtaining between a planned process and a person or organization that holds a sponsor role which is being realized by the planned process."@en ;
-                  obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
-                  rdfs:label "has sponsor"@en ;
-                  aeon:SMW_datatype "Page" ;
-                  aeon:SMW_import_info """[[partOfSubobject::Template:Subobject Sponsor]]
+:AEON_0000051 rdf:type owl:ObjectProperty ;
+              rdfs:subPropertyOf :AEON_0000045 ;
+              owl:inverseOf :sponsors ;
+              rdfs:domain <http://purl.obolibrary.org/obo/OBI_0000011> ;
+              rdfs:range :sponsor ;
+              <http://purl.obolibrary.org/obo/IAO_0000115> "A relation obtaining between a planned process and a person or organization that holds a sponsor role which is being realized by the planned process."@en ;
+              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"@en ;
+              rdfs:label "has sponsor"@en ;
+              :SMW_datatype "Page" ;
+              :SMW_import_info """[[partOfSubobject::Template:Subobject Sponsor]]
 
 [[Category:AEON]] [[Category:Imported vocabulary]]""" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000052
-aeon:AEON_0000052 rdf:type owl:ObjectProperty ;
-                  rdfs:subPropertyOf aeon:AEON_0000048 ;
-                  owl:inverseOf aeon:committee_member_in ;
-                  rdfs:domain obo:OBI_0000011 ;
-                  rdfs:range aeon:committee_member ;
-                  obo:IAO_0000115 "A relation obtaining between a planned process and a person that holds a committee member role which is being realized by the planned process."@en ;
-                  obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
-                  rdfs:label "has committee member"@en ;
-                  aeon:SMW_datatype "Page" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:AEON_0000052 rdf:type owl:ObjectProperty ;
+              rdfs:subPropertyOf :AEON_0000048 ;
+              owl:inverseOf :committee_member_in ;
+              rdfs:domain <http://purl.obolibrary.org/obo/OBI_0000011> ;
+              rdfs:range :committee_member ;
+              <http://purl.obolibrary.org/obo/IAO_0000115> "A relation obtaining between a planned process and a person that holds a committee member role which is being realized by the planned process."@en ;
+              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"@en ;
+              rdfs:label "has committee member"@en ;
+              :SMW_datatype "Page" ;
+              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000053
-aeon:AEON_0000053 rdf:type owl:ObjectProperty ;
-                  rdfs:subPropertyOf aeon:AEON_0000048 ;
-                  owl:inverseOf aeon:contact_person_of ;
-                  rdfs:domain obo:OBI_0000011 ;
-                  rdfs:range aeon:contact_person ;
-                  obo:IAO_0000115 "A relation obtaining between a planned process and a person that holds a contact person role which is being realized by the planned process."@en ;
-                  obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
-                  rdfs:label "has contact person"@en ;
-                  aeon:SMW_datatype "Page" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:AEON_0000053 rdf:type owl:ObjectProperty ;
+              rdfs:subPropertyOf :AEON_0000048 ;
+              owl:inverseOf :contact_person_of ;
+              rdfs:domain <http://purl.obolibrary.org/obo/OBI_0000011> ;
+              rdfs:range :contact_person ;
+              <http://purl.obolibrary.org/obo/IAO_0000115> "A relation obtaining between a planned process and a person that holds a contact person role which is being realized by the planned process."@en ;
+              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"@en ;
+              rdfs:label "has contact person"@en ;
+              :SMW_datatype "Page" ;
+              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000054
-aeon:AEON_0000054 rdf:type owl:ObjectProperty ;
-                  rdfs:subPropertyOf aeon:AEON_0000050 ;
-                  owl:inverseOf aeon:holds_keynote_at ;
-                  rdfs:domain obo:OBI_0000011 ;
-                  rdfs:range aeon:keynote_speaker ;
-                  obo:IAO_0000115 "A relation between a planned process and a person that holds a keynote speaker role which is being realized by the planned process."@en ;
-                  obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
-                  rdfs:label "has keynote speaker"@en ;
-                  aeon:SMW_datatype "Page" ;
-                  aeon:SMW_import_info """[[partOfSubobject::Template:Subobject Contributor]]
+:AEON_0000054 rdf:type owl:ObjectProperty ;
+              rdfs:subPropertyOf :AEON_0000050 ;
+              owl:inverseOf :holds_keynote_at ;
+              rdfs:domain <http://purl.obolibrary.org/obo/OBI_0000011> ;
+              rdfs:range :keynote_speaker ;
+              <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a planned process and a person that holds a keynote speaker role which is being realized by the planned process."@en ;
+              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"@en ;
+              rdfs:label "has keynote speaker"@en ;
+              :SMW_datatype "Page" ;
+              :SMW_import_info """[[partOfSubobject::Template:Subobject Contributor]]
                          
 [[Category:AEON]] [[Category:Imported vocabulary]]""" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000055
-aeon:AEON_0000055 rdf:type owl:ObjectProperty ;
-                  rdfs:subPropertyOf aeon:AEON_0000052 ;
-                  owl:inverseOf aeon:committee_chair_in ;
-                  rdfs:domain obo:OBI_0000011 ;
-                  rdfs:range aeon:committee_chair ;
-                  obo:IAO_0000115 "A relation obtaining between a planned process and a person that holds a committee chair role which is being realized by the planned process."@en ;
-                  obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
-                  rdfs:label "has committee chair"@en ;
-                  aeon:SMW_datatype "Page" ;
-                  aeon:SMW_import_info """[[partOfSubobject::Template:Subobject Contributor]]
+:AEON_0000055 rdf:type owl:ObjectProperty ;
+              rdfs:subPropertyOf :AEON_0000052 ;
+              owl:inverseOf :committee_chair_in ;
+              rdfs:domain <http://purl.obolibrary.org/obo/OBI_0000011> ;
+              rdfs:range :committee_chair ;
+              <http://purl.obolibrary.org/obo/IAO_0000115> "A relation obtaining between a planned process and a person that holds a committee chair role which is being realized by the planned process."@en ;
+              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"@en ;
+              rdfs:label "has committee chair"@en ;
+              :SMW_datatype "Page" ;
+              :SMW_import_info """[[partOfSubobject::Template:Subobject Contributor]]
 
 [[Category:AEON]] [[Category:Imported vocabulary]]""" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000075
-aeon:AEON_0000075 rdf:type owl:ObjectProperty ;
-                  rdfs:subPropertyOf obo:IAO_0000235 ;
-                  rdfs:domain obo:IAO_0000027 ;
-                  rdfs:range aeon:AEON_0000016 ;
-                  obo:IAO_0000115 "A relation obtaining between a data item and its corresponding digital object identifier."@en ;
-                  obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
-                  rdfs:label "has DOI"@en ;
-                  ns:term_status obo:IAO_0000423 ;
-                  aeon:SMW_datatype "External identifier" ;
-                  aeon:SMW_import_info """External formatter uri [[External formatter uri::https://doi.org/$1]]
+:AEON_0000075 rdf:type owl:ObjectProperty ;
+              rdfs:subPropertyOf <http://purl.obolibrary.org/obo/IAO_0000235> ;
+              rdfs:domain <http://purl.obolibrary.org/obo/IAO_0000027> ;
+              rdfs:range :AEON_0000016 ;
+              <http://purl.obolibrary.org/obo/IAO_0000115> "A relation obtaining between a data item and its corresponding digital object identifier."@en ;
+              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"@en ;
+              rdfs:label "has DOI"@en ;
+              <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> <http://purl.obolibrary.org/obo/IAO_0000423> ;
+              :SMW_datatype "External identifier" ;
+              :SMW_import_info """External formatter uri [[External formatter uri::https://doi.org/$1]]
 
 [[Category:AEON]] [[Category:Imported vocabulary]]""" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000076
-aeon:AEON_0000076 rdf:type owl:ObjectProperty ;
-                  rdfs:subPropertyOf obo:IAO_0000235 ;
-                  rdfs:domain obo:BFO_0000001 ;
-                  rdfs:range aeon:AEON_0000017 ;
-                  obo:IAO_0000115 "A relation obtaining between an entity and the identifier used by the German national library to denote the entity."@en ;
-                  obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
-                  rdfs:label "has GND"@en ;
-                  ns:term_status obo:IAO_0000423 ;
-                  aeon:AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P227\", \"label\": \"GND_ID\"}, \"gnd\": {\"uri\": \"https://d-nb.info/standards/elementset/gnd#gndIdentifier\", \"label\": \"GND-Identifier\"}}"^^xsd:string ;
-                  aeon:SMW_datatype "External identifier" ;
-                  aeon:SMW_import_info """External formatter uri [[External formatter uri::http://d-nb.info/gnd/$1]]
+:AEON_0000076 rdf:type owl:ObjectProperty ;
+              rdfs:subPropertyOf <http://purl.obolibrary.org/obo/IAO_0000235> ;
+              rdfs:domain <http://purl.obolibrary.org/obo/BFO_0000001> ;
+              rdfs:range :AEON_0000017 ;
+              <http://purl.obolibrary.org/obo/IAO_0000115> "A relation obtaining between an entity and the identifier used by the German national library to denote the entity."@en ;
+              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"@en ;
+              rdfs:label "has GND"@en ;
+              <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> <http://purl.obolibrary.org/obo/IAO_0000423> ;
+              :AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P227\", \"label\": \"GND_ID\"}, \"gnd\": {\"uri\": \"https://d-nb.info/standards/elementset/gnd#gndIdentifier\", \"label\": \"GND-Identifier\"}}"^^xsd:string ;
+              :SMW_datatype "External identifier" ;
+              :SMW_import_info """External formatter uri [[External formatter uri::http://d-nb.info/gnd/$1]]
 
 [[partOfSubobject::Template:Subobject External_Process_ID]]
 [[partOfSubobject::Template:Subobject Person_ID]]
 [[partOfSubobject::Template:Subobject Organization_ID]]
 
 [[Category:AEON]] [[Category:Imported vocabulary]]""" ;
-                  aeon:WikidataLabel "GND_ID" ;
-                  aeon:WikidataURI "https://www.wikidata.org/wiki/Property:P227" .
+              :WikidataLabel "GND_ID" ;
+              :WikidataURI "https://www.wikidata.org/wiki/Property:P227" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000077
-aeon:AEON_0000077 rdf:type owl:ObjectProperty ;
-                  rdfs:subPropertyOf obo:IAO_0000235 ;
-                  rdfs:domain [ rdf:type owl:Class ;
-                                owl:unionOf ( obo:NCBITaxon_9606
-                                              obo:OBI_0000245
-                                            )
-                              ] ;
-                  rdfs:range aeon:AEON_0000018 ;
-                  obo:IAO_0000115 "A relation obtaining between a person or organization and the 'international standard name identifier' used to denote the entity."@en ;
-                  obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
-                  rdfs:label "has ISNI"@en ;
-                  ns:term_status obo:IAO_0000423 ;
-                  aeon:SMW_datatype "External identifier" ;
-                  aeon:SMW_import_info """External formatter uri [[External formatter uri::https://isni.org/isni/$1]]
+:AEON_0000077 rdf:type owl:ObjectProperty ;
+              rdfs:subPropertyOf <http://purl.obolibrary.org/obo/IAO_0000235> ;
+              rdfs:domain [ rdf:type owl:Class ;
+                            owl:unionOf ( <http://purl.obolibrary.org/obo/NCBITaxon_9606>
+                                          <http://purl.obolibrary.org/obo/OBI_0000245>
+                                        )
+                          ] ;
+              rdfs:range :AEON_0000018 ;
+              <http://purl.obolibrary.org/obo/IAO_0000115> "A relation obtaining between a person or organization and the 'international standard name identifier' used to denote the entity."@en ;
+              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"@en ;
+              rdfs:label "has ISNI"@en ;
+              <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> <http://purl.obolibrary.org/obo/IAO_0000423> ;
+              :SMW_datatype "External identifier" ;
+              :SMW_import_info """External formatter uri [[External formatter uri::https://isni.org/isni/$1]]
 
 [[partOfSubobject::Template:Subobject Person_ID]]
 [[partOfSubobject::Template:Subobject Organization_ID]]
@@ -931,16 +925,16 @@ aeon:AEON_0000077 rdf:type owl:ObjectProperty ;
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000078
-aeon:AEON_0000078 rdf:type owl:ObjectProperty ;
-                  rdfs:subPropertyOf obo:IAO_0000235 ;
-                  rdfs:domain obo:NCBITaxon_9606 ;
-                  rdfs:range aeon:AEON_0000019 ;
-                  obo:IAO_0000115 "A relation obtaining between a person and the 'open researcher and contributor identifier' used to denote the entity."@en ;
-                  obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
-                  rdfs:label "has ORCID"@en ;
-                  ns:term_status obo:IAO_0000423 ;
-                  aeon:SMW_datatype "External identifier" ;
-                  aeon:SMW_import_info """External formatter uri [[External formatter uri::https://orcid.org/$1]]
+:AEON_0000078 rdf:type owl:ObjectProperty ;
+              rdfs:subPropertyOf <http://purl.obolibrary.org/obo/IAO_0000235> ;
+              rdfs:domain <http://purl.obolibrary.org/obo/NCBITaxon_9606> ;
+              rdfs:range :AEON_0000019 ;
+              <http://purl.obolibrary.org/obo/IAO_0000115> "A relation obtaining between a person and the 'open researcher and contributor identifier' used to denote the entity."@en ;
+              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"@en ;
+              rdfs:label "has ORCID"@en ;
+              <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> <http://purl.obolibrary.org/obo/IAO_0000423> ;
+              :SMW_datatype "External identifier" ;
+              :SMW_import_info """External formatter uri [[External formatter uri::https://orcid.org/$1]]
 
 [[partOfSubobject::Template:Subobject Person_ID]]
 
@@ -948,16 +942,16 @@ aeon:AEON_0000078 rdf:type owl:ObjectProperty ;
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000079
-aeon:AEON_0000079 rdf:type owl:ObjectProperty ;
-                  rdfs:subPropertyOf obo:IAO_0000235 ;
-                  rdfs:domain obo:OBI_0000245 ;
-                  rdfs:range aeon:AEON_0000020 ;
-                  obo:IAO_0000115 "A relation obtaining between a person and the 'research organization registry identifier' used to denote the entity."@en ;
-                  obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
-                  rdfs:label "has ROR"@en ;
-                  ns:term_status obo:IAO_0000423 ;
-                  aeon:SMW_datatype "External identifier" ;
-                  aeon:SMW_import_info """External formatter uri [[External formatter uri::https://ror.org/$1]]
+:AEON_0000079 rdf:type owl:ObjectProperty ;
+              rdfs:subPropertyOf <http://purl.obolibrary.org/obo/IAO_0000235> ;
+              rdfs:domain <http://purl.obolibrary.org/obo/OBI_0000245> ;
+              rdfs:range :AEON_0000020 ;
+              <http://purl.obolibrary.org/obo/IAO_0000115> "A relation obtaining between a person and the 'research organization registry identifier' used to denote the entity."@en ;
+              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"@en ;
+              rdfs:label "has ROR"@en ;
+              <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> <http://purl.obolibrary.org/obo/IAO_0000423> ;
+              :SMW_datatype "External identifier" ;
+              :SMW_import_info """External formatter uri [[External formatter uri::https://ror.org/$1]]
 
 [[partOfSubobject::Template:Subobject Organization_ID]]
 
@@ -965,329 +959,329 @@ aeon:AEON_0000079 rdf:type owl:ObjectProperty ;
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000080
-aeon:AEON_0000080 rdf:type owl:ObjectProperty ;
-                  rdfs:subPropertyOf obo:IAO_0000235 ;
-                  rdfs:domain obo:BFO_0000001 ;
-                  rdfs:range aeon:AEON_0000021 ;
-                  obo:IAO_0000115 "A relation obtaining between an entity and its corresponding Wikidata entity identifier."@en ;
-                  obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
-                  rdfs:label "has Wikidata QID"@en ;
-                  ns:term_status obo:IAO_0000423 ;
-                  aeon:AEON_0000026 "{\"wikidata\": {\"uri\": null, \"label\": \"itemID\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Property:Wikidataid\", \"label\": \"Wikidataid\"}}"^^xsd:string ;
-                  aeon:SMW_datatype "External identifier" ;
-                  aeon:SMW_import_info """External formatter uri [[External formatter uri::https://www.wikidata.org/wiki/$1]]
+:AEON_0000080 rdf:type owl:ObjectProperty ;
+              rdfs:subPropertyOf <http://purl.obolibrary.org/obo/IAO_0000235> ;
+              rdfs:domain <http://purl.obolibrary.org/obo/BFO_0000001> ;
+              rdfs:range :AEON_0000021 ;
+              <http://purl.obolibrary.org/obo/IAO_0000115> "A relation obtaining between an entity and its corresponding Wikidata entity identifier."@en ;
+              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"@en ;
+              rdfs:label "has Wikidata QID"@en ;
+              <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> <http://purl.obolibrary.org/obo/IAO_0000423> ;
+              :AEON_0000026 "{\"wikidata\": {\"uri\": null, \"label\": \"itemID\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Property:Wikidataid\", \"label\": \"Wikidataid\"}}"^^xsd:string ;
+              :SMW_datatype "External identifier" ;
+              :SMW_import_info """External formatter uri [[External formatter uri::https://www.wikidata.org/wiki/$1]]
 
 [[partOfSubobject::Template:Subobject Process_External_ID]]
 [[partOfSubobject::Template:Subobject Person_ID]]
 [[partOfSubobject::Template:Subobject Organization_ID]]
 
 [[Category:AEON]] [[Category:Imported vocabulary]]""" ;
-                  aeon:WikidataLabel "itemID" .
+              :WikidataLabel "itemID" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000081
-aeon:AEON_0000081 rdf:type owl:ObjectProperty ;
-                  rdfs:subPropertyOf obo:TXPO_0002523 ;
-                  owl:inverseOf aeon:AEON_0000084 ;
-                  rdfs:domain aeon:AEON_0000002 ;
-                  rdfs:range aeon:AEON_0000001 ;
-                  obo:IAO_0000115 "A relation obtaining between an academic event series and an academic event. It is used to express that the academic event is part of a specific event series."@en ;
-                  rdfs:label "has academic event"@en ;
-                  aeon:SMW_datatype "Page" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:AEON_0000081 rdf:type owl:ObjectProperty ;
+              rdfs:subPropertyOf <http://purl.obolibrary.org/obo/TXPO_0002523> ;
+              owl:inverseOf :AEON_0000084 ;
+              rdfs:domain :AEON_0000002 ;
+              rdfs:range :AEON_0000001 ;
+              <http://purl.obolibrary.org/obo/IAO_0000115> "A relation obtaining between an academic event series and an academic event. It is used to express that the academic event is part of a specific event series."@en ;
+              rdfs:label "has academic event"@en ;
+              :SMW_datatype "Page" ;
+              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000082
-aeon:AEON_0000082 rdf:type owl:ObjectProperty ;
-                  rdfs:subPropertyOf obo:RO_0002012 ;
-                  owl:inverseOf aeon:has_collocated_event ;
-                  rdfs:domain aeon:AEON_0000001 ;
-                  rdfs:range aeon:AEON_0000001 ;
-                  obo:IAO_0000115 "see inverse property"@en ;
-                  obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
-                  rdfs:label "collocated event of"@en ;
-                  aeon:SMW_datatype "Page" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:AEON_0000082 rdf:type owl:ObjectProperty ;
+              rdfs:subPropertyOf <http://purl.obolibrary.org/obo/RO_0002012> ;
+              owl:inverseOf :has_collocated_event ;
+              rdfs:domain :AEON_0000001 ;
+              rdfs:range :AEON_0000001 ;
+              <http://purl.obolibrary.org/obo/IAO_0000115> "see inverse property"@en ;
+              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"@en ;
+              rdfs:label "collocated event of"@en ;
+              :SMW_datatype "Page" ;
+              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000083
-aeon:AEON_0000083 rdf:type owl:ObjectProperty ;
-                  rdfs:subPropertyOf obo:RO_0002012 ;
-                  owl:inverseOf aeon:has_joint_event ;
-                  rdfs:domain aeon:AEON_0000001 ;
-                  rdfs:range aeon:AEON_0000001 ;
-                  obo:IAO_0000115 "see inverse property"@en ;
-                  obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
-                  rdfs:label "joint event of"@en ;
-                  aeon:SMW_datatype "Page" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:AEON_0000083 rdf:type owl:ObjectProperty ;
+              rdfs:subPropertyOf <http://purl.obolibrary.org/obo/RO_0002012> ;
+              owl:inverseOf :has_joint_event ;
+              rdfs:domain :AEON_0000001 ;
+              rdfs:range :AEON_0000001 ;
+              <http://purl.obolibrary.org/obo/IAO_0000115> "see inverse property"@en ;
+              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"@en ;
+              rdfs:label "joint event of"@en ;
+              :SMW_datatype "Page" ;
+              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000084
-aeon:AEON_0000084 rdf:type owl:ObjectProperty ;
-                  rdfs:subPropertyOf obo:RO_0002012 ;
-                  rdfs:domain aeon:AEON_0000001 ;
-                  rdfs:range aeon:AEON_0000002 ;
-                  obo:IAO_0000115 "see inverse property"@en ;
-                  obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
-                  rdfs:label "part of series"@en ;
-                  aeon:AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P179\", \"label\": \"part_of_the_seriesLabel\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Property:Event_in_series\", \"label\": \"Event_in_series\"}}"^^xsd:string ;
-                  aeon:SMW_datatype "Page" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:AEON_0000084 rdf:type owl:ObjectProperty ;
+              rdfs:subPropertyOf <http://purl.obolibrary.org/obo/RO_0002012> ;
+              rdfs:domain :AEON_0000001 ;
+              rdfs:range :AEON_0000002 ;
+              <http://purl.obolibrary.org/obo/IAO_0000115> "see inverse property"@en ;
+              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"@en ;
+              rdfs:label "part of series"@en ;
+              :AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P179\", \"label\": \"part_of_the_seriesLabel\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Property:Event_in_series\", \"label\": \"Event_in_series\"}}"^^xsd:string ;
+              :SMW_datatype "Page" ;
+              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000085
-aeon:AEON_0000085 rdf:type owl:ObjectProperty ;
-                  rdfs:subPropertyOf obo:RO_0002012 ;
-                  owl:inverseOf aeon:has_umbrella_event ;
-                  rdfs:domain aeon:AEON_0000001 ;
-                  rdfs:range aeon:AEON_0000001 ;
-                  obo:IAO_0000115 "see inverse property"@en ;
-                  obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
-                  rdfs:label "umbrella event of"@en ;
-                  aeon:SMW_datatype "Page" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:AEON_0000085 rdf:type owl:ObjectProperty ;
+              rdfs:subPropertyOf <http://purl.obolibrary.org/obo/RO_0002012> ;
+              owl:inverseOf :has_umbrella_event ;
+              rdfs:domain :AEON_0000001 ;
+              rdfs:range :AEON_0000001 ;
+              <http://purl.obolibrary.org/obo/IAO_0000115> "see inverse property"@en ;
+              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"@en ;
+              rdfs:label "umbrella event of"@en ;
+              :SMW_datatype "Page" ;
+              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000086
-aeon:AEON_0000086 rdf:type owl:ObjectProperty ;
-                  rdfs:subPropertyOf obo:BFO_0000066 ;
-                  rdfs:domain aeon:AEON_0000001 ;
-                  rdfs:range aeon:AEON_0000023 ;
-                  rdfs:label "occurs in country"@en ;
-                  aeon:AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P17\", \"label\": \"countryLabel\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Property:Has_location_country\", \"label\": \"Has_location_country\"}}"^^xsd:string ;
-                  aeon:SMW_datatype "Text" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" ;
-                  aeon:WikidataLabel "countryLabel" ;
-                  aeon:WikidataURI "https://www.wikidata.org/wiki/Property:P17" .
+:AEON_0000086 rdf:type owl:ObjectProperty ;
+              rdfs:subPropertyOf <http://purl.obolibrary.org/obo/BFO_0000066> ;
+              rdfs:domain :AEON_0000001 ;
+              rdfs:range :AEON_0000023 ;
+              rdfs:label "occurs in country"@en ;
+              :AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P17\", \"label\": \"countryLabel\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Property:Has_location_country\", \"label\": \"Has_location_country\"}}"^^xsd:string ;
+              :SMW_datatype "Text" ;
+              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" ;
+              :WikidataLabel "countryLabel" ;
+              :WikidataURI "https://www.wikidata.org/wiki/Property:P17" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000087
-aeon:AEON_0000087 rdf:type owl:ObjectProperty ;
-                  rdfs:subPropertyOf obo:BFO_0000066 ;
-                  rdfs:domain aeon:AEON_0000001 ;
-                  rdfs:range aeon:AEON_0000022 ;
-                  rdfs:label "occurs in city"@en ;
-                  aeon:AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P276\", \"label\": \"locationLabel\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Property:Has_location_city\", \"label\": \"Has_location_city\"}, \"gnd\": {\"uri\": \"https://d-nb.info/standards/elementset/gnd#placeOfConferenceOrEvent\", \"label\": \"Place of conference or event\"}}"^^xsd:string ;
-                  aeon:SMW_datatype "Text" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:AEON_0000087 rdf:type owl:ObjectProperty ;
+              rdfs:subPropertyOf <http://purl.obolibrary.org/obo/BFO_0000066> ;
+              rdfs:domain :AEON_0000001 ;
+              rdfs:range :AEON_0000022 ;
+              rdfs:label "occurs in city"@en ;
+              :AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P276\", \"label\": \"locationLabel\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Property:Has_location_city\", \"label\": \"Has_location_city\"}, \"gnd\": {\"uri\": \"https://d-nb.info/standards/elementset/gnd#placeOfConferenceOrEvent\", \"label\": \"Place of conference or event\"}}"^^xsd:string ;
+              :SMW_datatype "Text" ;
+              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000088
-aeon:AEON_0000088 rdf:type owl:ObjectProperty ;
-                  rdfs:subPropertyOf obo:BFO_0000066 ;
-                  rdfs:domain aeon:AEON_0000001 ;
-                  rdfs:range aeon:AEON_0000024 ;
-                  rdfs:label "occurs in state"@en ;
-                  aeon:AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P131\", \"label\": \"located_in_the_administrative_territorial_entityLabel\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Property:Has_location_state\", \"label\": \"Has_location_state\"}}"^^xsd:string ;
-                  aeon:SMW_datatype "Text" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:AEON_0000088 rdf:type owl:ObjectProperty ;
+              rdfs:subPropertyOf <http://purl.obolibrary.org/obo/BFO_0000066> ;
+              rdfs:domain :AEON_0000001 ;
+              rdfs:range :AEON_0000024 ;
+              rdfs:label "occurs in state"@en ;
+              :AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P131\", \"label\": \"located_in_the_administrative_territorial_entityLabel\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Property:Has_location_state\", \"label\": \"Has_location_state\"}}"^^xsd:string ;
+              :SMW_datatype "Text" ;
+              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000089
-aeon:AEON_0000089 rdf:type owl:ObjectProperty ;
-                  rdfs:subPropertyOf obo:BFO_0000066 ;
-                  rdfs:domain aeon:AEON_0000001 ;
-                  rdfs:range aeon:AEON_0000025 ;
-                  rdfs:label "occurs in venue"@en ;
-                  aeon:SMW_datatype "Text" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:AEON_0000089 rdf:type owl:ObjectProperty ;
+              rdfs:subPropertyOf <http://purl.obolibrary.org/obo/BFO_0000066> ;
+              rdfs:domain :AEON_0000001 ;
+              rdfs:range :AEON_0000025 ;
+              rdfs:label "occurs in venue"@en ;
+              :SMW_datatype "Text" ;
+              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000090
-aeon:AEON_0000090 rdf:type owl:ObjectProperty ;
-                  rdfs:subPropertyOf obo:BFO_0000066 ;
-                  rdfs:domain aeon:AEON_0000001 ;
-                  rdfs:range aeon:AEON_0000029 ;
-                  rdfs:label "occurs in virtual place"@en ;
-                  aeon:SMW_datatype "URL" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:AEON_0000090 rdf:type owl:ObjectProperty ;
+              rdfs:subPropertyOf <http://purl.obolibrary.org/obo/BFO_0000066> ;
+              rdfs:domain :AEON_0000001 ;
+              rdfs:range :AEON_0000029 ;
+              rdfs:label "occurs in virtual place"@en ;
+              :SMW_datatype "URL" ;
+              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#academic_field_of
-aeon:academic_field_of rdf:type owl:ObjectProperty ;
-                       rdfs:domain aeon:AEON_0000027 ;
-                       rdfs:range obo:OBI_0000011 ;
-                       obo:IAO_0000115 "see inverse property"@en ;
-                       obo:IAO_0000117 "StroemertP"^^xsd:string ;
-                       rdfs:label "academicfield of"@en .
+:academic_field_of rdf:type owl:ObjectProperty ;
+                   rdfs:domain :AEON_0000027 ;
+                   rdfs:range <http://purl.obolibrary.org/obo/OBI_0000011> ;
+                   <http://purl.obolibrary.org/obo/IAO_0000115> "see inverse property"@en ;
+                   <http://purl.obolibrary.org/obo/IAO_0000117> "StroemertP"^^xsd:string ;
+                   rdfs:label "academicfield of"@en .
 
 
 ###  https://github.com/tibonto/aeon#attends_at
-aeon:attends_at rdf:type owl:ObjectProperty ;
-                rdfs:subPropertyOf aeon:contibutes_to ;
-                rdfs:domain aeon:attendee ;
-                rdfs:range obo:OBI_0000011 ;
-                obo:IAO_0000115 "see inverse relation"@en ;
-                obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string ;
-                rdfs:label "attentds at"@en .
+:attends_at rdf:type owl:ObjectProperty ;
+            rdfs:subPropertyOf :contibutes_to ;
+            rdfs:domain :attendee ;
+            rdfs:range <http://purl.obolibrary.org/obo/OBI_0000011> ;
+            <http://purl.obolibrary.org/obo/IAO_0000115> "see inverse relation"@en ;
+            <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string ;
+            rdfs:label "attentds at"@en .
 
 
 ###  https://github.com/tibonto/aeon#committee_chair_in
-aeon:committee_chair_in rdf:type owl:ObjectProperty ;
-                        rdfs:subPropertyOf aeon:committee_member_in ;
-                        rdfs:domain aeon:committee_chair ;
-                        rdfs:range obo:OBI_0000011 ;
-                        obo:IAO_0000115 "see inverse relation"@en ;
-                        obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string ;
-                        rdfs:label "committee chair in"@en .
+:committee_chair_in rdf:type owl:ObjectProperty ;
+                    rdfs:subPropertyOf :committee_member_in ;
+                    rdfs:domain :committee_chair ;
+                    rdfs:range <http://purl.obolibrary.org/obo/OBI_0000011> ;
+                    <http://purl.obolibrary.org/obo/IAO_0000115> "see inverse relation"@en ;
+                    <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string ;
+                    rdfs:label "committee chair in"@en .
 
 
 ###  https://github.com/tibonto/aeon#committee_member_in
-aeon:committee_member_in rdf:type owl:ObjectProperty ;
-                         rdfs:subPropertyOf aeon:organizes ;
-                         rdfs:domain aeon:committee_member ;
-                         rdfs:range obo:OBI_0000011 ;
-                         obo:IAO_0000115 "see inverse relation"@en ;
-                         obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string ;
-                         rdfs:label "committee member in"@en .
+:committee_member_in rdf:type owl:ObjectProperty ;
+                     rdfs:subPropertyOf :organizes ;
+                     rdfs:domain :committee_member ;
+                     rdfs:range <http://purl.obolibrary.org/obo/OBI_0000011> ;
+                     <http://purl.obolibrary.org/obo/IAO_0000115> "see inverse relation"@en ;
+                     <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string ;
+                     rdfs:label "committee member in"@en .
 
 
 ###  https://github.com/tibonto/aeon#contact_person_of
-aeon:contact_person_of rdf:type owl:ObjectProperty ;
-                       rdfs:subPropertyOf aeon:organizes ;
-                       rdfs:domain aeon:contact_person ;
-                       rdfs:range obo:OBI_0000011 ;
-                       obo:IAO_0000115 "see inverse relation"@en ;
-                       obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string ;
-                       rdfs:label "contact person of"@en .
+:contact_person_of rdf:type owl:ObjectProperty ;
+                   rdfs:subPropertyOf :organizes ;
+                   rdfs:domain :contact_person ;
+                   rdfs:range <http://purl.obolibrary.org/obo/OBI_0000011> ;
+                   <http://purl.obolibrary.org/obo/IAO_0000115> "see inverse relation"@en ;
+                   <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string ;
+                   rdfs:label "contact person of"@en .
 
 
 ###  https://github.com/tibonto/aeon#contibutes_to
-aeon:contibutes_to rdf:type owl:ObjectProperty ;
-                   rdfs:subPropertyOf obo:RO_0000056 ;
-                   rdfs:domain aeon:contributor ;
-                   rdfs:range obo:OBI_0000011 ;
-                   obo:IAO_0000115 "see inverse relation"@en ;
-                   obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string ;
-                   rdfs:label "contributes to"@en .
+:contibutes_to rdf:type owl:ObjectProperty ;
+               rdfs:subPropertyOf <http://purl.obolibrary.org/obo/RO_0000056> ;
+               rdfs:domain :contributor ;
+               rdfs:range <http://purl.obolibrary.org/obo/OBI_0000011> ;
+               <http://purl.obolibrary.org/obo/IAO_0000115> "see inverse relation"@en ;
+               <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string ;
+               rdfs:label "contributes to"@en .
 
 
 ###  https://github.com/tibonto/aeon#event_type_of
-aeon:event_type_of rdf:type owl:ObjectProperty ;
-                   rdfs:domain aeon:AEON_0000004 ;
-                   rdfs:range aeon:AEON_0000001 ;
-                   obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string ;
-                   rdfs:label "event type of"@en .
+:event_type_of rdf:type owl:ObjectProperty ;
+               rdfs:domain :AEON_0000004 ;
+               rdfs:range :AEON_0000001 ;
+               <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string ;
+               rdfs:label "event type of"@en .
 
 
 ###  https://github.com/tibonto/aeon#has_WikiCFP_ID
-aeon:has_WikiCFP_ID rdf:type owl:ObjectProperty ;
-                    rdfs:subPropertyOf obo:IAO_0000235 ;
-                    rdfs:domain [ rdf:type owl:Class ;
-                                  owl:unionOf ( aeon:AEON_0000001
-                                                aeon:AEON_0000002
-                                              )
-                                ] ;
-                    rdfs:range aeon:wikiCFP_ID ;
-                    obo:IAO_0000115 "A relation obtaining between an academic event or event series and its corresponding WikiCFP identifier."@en ;
-                    obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string ;
-                    rdfs:label "has WikiCFP ID"@en ;
-                    ns:term_status obo:IAO_0000423 ;
-                    aeon:AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P5127\", \"label\": \"WikiCFP_conference_series_ID\"}}" .
+:has_WikiCFP_ID rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf <http://purl.obolibrary.org/obo/IAO_0000235> ;
+                rdfs:domain [ rdf:type owl:Class ;
+                              owl:unionOf ( :AEON_0000001
+                                            :AEON_0000002
+                                          )
+                            ] ;
+                rdfs:range :wikiCFP_ID ;
+                <http://purl.obolibrary.org/obo/IAO_0000115> "A relation obtaining between an academic event or event series and its corresponding WikiCFP identifier."@en ;
+                <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string ;
+                rdfs:label "has WikiCFP ID"@en ;
+                <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> <http://purl.obolibrary.org/obo/IAO_0000423> ;
+                :AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P5127\", \"label\": \"WikiCFP_conference_series_ID\"}}" .
 
 
 ###  https://github.com/tibonto/aeon#has_collocated_event
-aeon:has_collocated_event rdf:type owl:ObjectProperty ;
-                          rdfs:subPropertyOf obo:TXPO_0002523 ;
-                          rdfs:domain aeon:AEON_0000001 ;
-                          rdfs:range aeon:AEON_0000001 ;
-                          obo:IAO_0000115 """A relation obtaining between an academic event and another academic event. 
+:has_collocated_event rdf:type owl:ObjectProperty ;
+                      rdfs:subPropertyOf <http://purl.obolibrary.org/obo/TXPO_0002523> ;
+                      rdfs:domain :AEON_0000001 ;
+                      rdfs:range :AEON_0000001 ;
+                      <http://purl.obolibrary.org/obo/IAO_0000115> """A relation obtaining between an academic event and another academic event. 
 A collocated event is an event that takes place at the same location and time as another academic event."""@en ;
-                          obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string ;
-                          rdfs:label "has collocated event"@en .
+                      <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string ;
+                      rdfs:label "has collocated event"@en .
 
 
 ###  https://github.com/tibonto/aeon#has_joint_event
-aeon:has_joint_event rdf:type owl:ObjectProperty ;
-                     rdfs:subPropertyOf obo:TXPO_0002523 ;
-                     rdfs:domain aeon:AEON_0000001 ;
-                     rdfs:range aeon:AEON_0000001 ;
-                     obo:IAO_0000115 """A relation obtaining between an academic event and another academic event. 
+:has_joint_event rdf:type owl:ObjectProperty ;
+                 rdfs:subPropertyOf <http://purl.obolibrary.org/obo/TXPO_0002523> ;
+                 rdfs:domain :AEON_0000001 ;
+                 rdfs:range :AEON_0000001 ;
+                 <http://purl.obolibrary.org/obo/IAO_0000115> """A relation obtaining between an academic event and another academic event. 
 A joint event is an event that shares some of the planning and organizing logistics with another academic event, but is otherwise independent from it."""@en ;
-                     obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string ;
-                     rdfs:label "has joint event"@en .
+                 <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string ;
+                 rdfs:label "has joint event"@en .
 
 
 ###  https://github.com/tibonto/aeon#has_umbrella_event
-aeon:has_umbrella_event rdf:type owl:ObjectProperty ;
-                        rdfs:subPropertyOf obo:TXPO_0002523 ;
-                        rdfs:domain aeon:AEON_0000001 ;
-                        rdfs:range aeon:AEON_0000001 ;
-                        obo:IAO_0000115 """A relation obtaining between an academic event and another academic event or eent series. 
+:has_umbrella_event rdf:type owl:ObjectProperty ;
+                    rdfs:subPropertyOf <http://purl.obolibrary.org/obo/TXPO_0002523> ;
+                    rdfs:domain :AEON_0000001 ;
+                    rdfs:range :AEON_0000001 ;
+                    <http://purl.obolibrary.org/obo/IAO_0000115> """A relation obtaining between an academic event and another academic event or eent series. 
 An umbrelle event is a superordinate event that combines several smaller academic events at the same time
 To say p 'has umbrella event' d =def. there exists an academic event d that is a 
 superordinate event of p and that there must be other academic events that have the same relation.."""@en ;
-                        obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string ;
-                        rdfs:label "has umbrella event"@en .
+                    <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string ;
+                    rdfs:label "has umbrella event"@en .
 
 
 ###  https://github.com/tibonto/aeon#holds_keynote_at
-aeon:holds_keynote_at rdf:type owl:ObjectProperty ;
-                      rdfs:subPropertyOf aeon:speaks_at ;
-                      rdfs:domain aeon:keynote_speaker ;
-                      rdfs:range obo:OBI_0000011 ;
-                      obo:IAO_0000115 "see inverse relation"@en ;
-                      obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string ;
-                      rdfs:label "holds keynote speech at"@en .
+:holds_keynote_at rdf:type owl:ObjectProperty ;
+                  rdfs:subPropertyOf :speaks_at ;
+                  rdfs:domain :keynote_speaker ;
+                  rdfs:range <http://purl.obolibrary.org/obo/OBI_0000011> ;
+                  <http://purl.obolibrary.org/obo/IAO_0000115> "see inverse relation"@en ;
+                  <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string ;
+                  rdfs:label "holds keynote speech at"@en .
 
 
 ###  https://github.com/tibonto/aeon#moderates_at
-aeon:moderates_at rdf:type owl:ObjectProperty ;
-                  rdfs:subPropertyOf aeon:contibutes_to ;
-                  rdfs:domain aeon:moderator ;
-                  rdfs:range obo:OBI_0000011 ;
-                  obo:IAO_0000115 "see inverse relation"@en ;
-                  obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string ;
-                  rdfs:label "moderates at"@en .
+:moderates_at rdf:type owl:ObjectProperty ;
+              rdfs:subPropertyOf :contibutes_to ;
+              rdfs:domain :moderator ;
+              rdfs:range <http://purl.obolibrary.org/obo/OBI_0000011> ;
+              <http://purl.obolibrary.org/obo/IAO_0000115> "see inverse relation"@en ;
+              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string ;
+              rdfs:label "moderates at"@en .
 
 
 ###  https://github.com/tibonto/aeon#organizes
-aeon:organizes rdf:type owl:ObjectProperty ;
-               rdfs:subPropertyOf aeon:contibutes_to ;
-               rdfs:domain aeon:organizer ;
-               rdfs:range obo:OBI_0000011 ;
-               obo:IAO_0000115 "see inverse relation"@en ;
-               obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string ;
-               rdfs:label "organizes"@en .
+:organizes rdf:type owl:ObjectProperty ;
+           rdfs:subPropertyOf :contibutes_to ;
+           rdfs:domain :organizer ;
+           rdfs:range <http://purl.obolibrary.org/obo/OBI_0000011> ;
+           <http://purl.obolibrary.org/obo/IAO_0000115> "see inverse relation"@en ;
+           <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string ;
+           rdfs:label "organizes"@en .
 
 
 ###  https://github.com/tibonto/aeon#reviews_at
-aeon:reviews_at rdf:type owl:ObjectProperty ;
-                rdfs:subPropertyOf aeon:contibutes_to ;
-                rdfs:domain aeon:reviewer ;
-                rdfs:range obo:OBI_0000011 ;
-                obo:IAO_0000115 "see inverse relation"@en ;
-                obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string ;
-                rdfs:label "reviews at"@en .
+:reviews_at rdf:type owl:ObjectProperty ;
+            rdfs:subPropertyOf :contibutes_to ;
+            rdfs:domain :reviewer ;
+            rdfs:range <http://purl.obolibrary.org/obo/OBI_0000011> ;
+            <http://purl.obolibrary.org/obo/IAO_0000115> "see inverse relation"@en ;
+            <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string ;
+            rdfs:label "reviews at"@en .
 
 
 ###  https://github.com/tibonto/aeon#speaks_at
-aeon:speaks_at rdf:type owl:ObjectProperty ;
-               rdfs:subPropertyOf aeon:contibutes_to ;
-               rdfs:domain aeon:speaker ;
-               rdfs:range obo:OBI_0000011 ;
-               obo:IAO_0000115 "see inverse relation"@en ;
-               obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string ;
-               rdfs:label "presents at"@en .
+:speaks_at rdf:type owl:ObjectProperty ;
+           rdfs:subPropertyOf :contibutes_to ;
+           rdfs:domain :speaker ;
+           rdfs:range <http://purl.obolibrary.org/obo/OBI_0000011> ;
+           <http://purl.obolibrary.org/obo/IAO_0000115> "see inverse relation"@en ;
+           <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string ;
+           rdfs:label "presents at"@en .
 
 
 ###  https://github.com/tibonto/aeon#sponsors
-aeon:sponsors rdf:type owl:ObjectProperty ;
-              rdfs:subPropertyOf aeon:contibutes_to ;
-              rdfs:domain aeon:sponsor ;
-              rdfs:range obo:OBI_0000011 ;
-              obo:IAO_0000115 "see inverse relation"@en ;
-              obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string .
+:sponsors rdf:type owl:ObjectProperty ;
+          rdfs:subPropertyOf :contibutes_to ;
+          rdfs:domain :sponsor ;
+          rdfs:range <http://purl.obolibrary.org/obo/OBI_0000011> ;
+          <http://purl.obolibrary.org/obo/IAO_0000115> "see inverse relation"@en ;
+          <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string .
 
 
 ###  https://github.com/tibonto/aeon#topic_of
-aeon:topic_of rdf:type owl:ObjectProperty ;
-              rdfs:domain aeon:AEON_0000028 ;
-              rdfs:range obo:OBI_0000011 ;
-              obo:IAO_0000115 "see inverse property"@en ;
-              obo:IAO_0000117 "StroemertP"^^xsd:string ;
-              rdfs:label "topic of"@en .
+:topic_of rdf:type owl:ObjectProperty ;
+          rdfs:domain :AEON_0000028 ;
+          rdfs:range <http://purl.obolibrary.org/obo/OBI_0000011> ;
+          <http://purl.obolibrary.org/obo/IAO_0000115> "see inverse property"@en ;
+          <http://purl.obolibrary.org/obo/IAO_0000117> "StroemertP"^^xsd:string ;
+          rdfs:label "topic of"@en .
 
 
 #################################################################
@@ -1299,22 +1293,22 @@ owl:topDataProperty rdfs:range rdfs:Literal .
 
 
 ###  https://github.com/tibonto/aeon#CORE_ranking
-aeon:CORE_ranking rdf:type owl:DatatypeProperty ;
-                  rdfs:subPropertyOf aeon:metric ;
-                  rdfs:domain aeon:AEON_0000001 ;
-                  rdfs:label "CORE ranking"@en ;
-                  aeon:SMW_datatype "Text" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:CORE_ranking rdf:type owl:DatatypeProperty ;
+              rdfs:subPropertyOf :metric ;
+              rdfs:domain :AEON_0000001 ;
+              rdfs:label "CORE ranking"@en ;
+              :SMW_datatype "Text" ;
+              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#ID
-aeon:ID rdf:type owl:DatatypeProperty ;
-        rdfs:subPropertyOf owl:topDataProperty ;
-        rdfs:domain obo:IAO_0020000 ;
-        obo:IAO_0000115 "The literal value of an identifier."@en ;
-        rdfs:label "identifier"@en ;
-        aeon:SMW_datatype "Text" ;
-        aeon:SMW_import_info """[[partOfSubobject::Template:Subobject External_Process_ID]]
+:ID rdf:type owl:DatatypeProperty ;
+    rdfs:subPropertyOf owl:topDataProperty ;
+    rdfs:domain <http://purl.obolibrary.org/obo/IAO_0020000> ;
+    <http://purl.obolibrary.org/obo/IAO_0000115> "The literal value of an identifier."@en ;
+    rdfs:label "identifier"@en ;
+    :SMW_datatype "Text" ;
+    :SMW_import_info """[[partOfSubobject::Template:Subobject External_Process_ID]]
 [[partOfSubobject::Template:Subobject Person_ID]]
 [[partOfSubobject::Template:Subobject Organization_ID]]
 
@@ -1322,14 +1316,14 @@ aeon:ID rdf:type owl:DatatypeProperty ;
 
 
 ###  https://github.com/tibonto/aeon#ID_URL
-aeon:ID_URL rdf:type owl:DatatypeProperty ;
-            rdfs:subPropertyOf aeon:ID ;
-            rdfs:domain obo:IAO_0020000 ;
-            rdfs:range xsd:anyURI ;
-            rdfs:comment "The literal value of the full URL used by the identifier scheme, based on the concatination of base URL and ID (ID_URL:value = ID_base_URL:value + ID:value)."@en ;
-            rdfs:label "identifier URI"@en ;
-            aeon:SMW_datatype "URL" ;
-            aeon:SMW_import_info """[[partOfSubobject::Template:Subobject External_Process_ID]]
+:ID_URL rdf:type owl:DatatypeProperty ;
+        rdfs:subPropertyOf :ID ;
+        rdfs:domain <http://purl.obolibrary.org/obo/IAO_0020000> ;
+        rdfs:range xsd:anyURI ;
+        rdfs:comment "The literal value of the full URL used by the identifier scheme, based on the concatination of base URL and ID (ID_URL:value = ID_base_URL:value + ID:value)."@en ;
+        rdfs:label "identifier URI"@en ;
+        :SMW_datatype "URL" ;
+        :SMW_import_info """[[partOfSubobject::Template:Subobject External_Process_ID]]
 [[partOfSubobject::Template:Subobject Person_ID]]
 [[partOfSubobject::Template:Subobject Organization_ID]]
 
@@ -1337,14 +1331,14 @@ aeon:ID_URL rdf:type owl:DatatypeProperty ;
 
 
 ###  https://github.com/tibonto/aeon#ID_base_URL
-aeon:ID_base_URL rdf:type owl:DatatypeProperty ;
-                 rdfs:subPropertyOf aeon:ID ;
-                 rdfs:domain obo:IAO_0020000 ;
-                 rdfs:range xsd:anyURI ;
-                 rdfs:comment "The literal value of the base URL used by the identifier scheme."@en ;
-                 rdfs:label "identifier base URI"@en ;
-                 aeon:SMW_datatype "URL" ;
-                 aeon:SMW_import_info """[[partOfSubobject::Template:Subobject External_Process_ID]]
+:ID_base_URL rdf:type owl:DatatypeProperty ;
+             rdfs:subPropertyOf :ID ;
+             rdfs:domain <http://purl.obolibrary.org/obo/IAO_0020000> ;
+             rdfs:range xsd:anyURI ;
+             rdfs:comment "The literal value of the base URL used by the identifier scheme."@en ;
+             rdfs:label "identifier base URI"@en ;
+             :SMW_datatype "URL" ;
+             :SMW_import_info """[[partOfSubobject::Template:Subobject External_Process_ID]]
 [[partOfSubobject::Template:Subobject Person_ID]]
 [[partOfSubobject::Template:Subobject Organization_ID]]
 
@@ -1352,209 +1346,209 @@ aeon:ID_base_URL rdf:type owl:DatatypeProperty ;
 
 
 ###  https://github.com/tibonto/aeon#abstract_deadline
-aeon:abstract_deadline rdf:type owl:DatatypeProperty ;
-                       rdfs:subPropertyOf aeon:deadline ;
-                       rdfs:domain aeon:AEON_0000001 ;
-                       rdfs:range xsd:dateTimeStamp ;
-                       rdfs:label "abstract deadline"@en ;
-                       aeon:SMW_datatype "Date" ;
-                       aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:abstract_deadline rdf:type owl:DatatypeProperty ;
+                   rdfs:subPropertyOf :deadline ;
+                   rdfs:domain :AEON_0000001 ;
+                   rdfs:range xsd:dateTimeStamp ;
+                   rdfs:label "abstract deadline"@en ;
+                   :SMW_datatype "Date" ;
+                   :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#acceptance_rate
-aeon:acceptance_rate rdf:type owl:DatatypeProperty ;
-                     rdfs:subPropertyOf aeon:metric ;
-                     rdfs:domain aeon:AEON_0000001 ;
-                     rdfs:label "acceptance rate"@en ;
-                     aeon:SMW_datatype "Number" ;
-                     aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:acceptance_rate rdf:type owl:DatatypeProperty ;
+                 rdfs:subPropertyOf :metric ;
+                 rdfs:domain :AEON_0000001 ;
+                 rdfs:label "acceptance rate"@en ;
+                 :SMW_datatype "Number" ;
+                 :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#accepted_papers
-aeon:accepted_papers rdf:type owl:DatatypeProperty ;
-                     rdfs:subPropertyOf aeon:metric ;
-                     rdfs:domain aeon:AEON_0000001 ;
-                     rdfs:label "accepted papers"@en ;
-                     aeon:SMW_datatype "Number" ;
-                     aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:accepted_papers rdf:type owl:DatatypeProperty ;
+                 rdfs:subPropertyOf :metric ;
+                 rdfs:domain :AEON_0000001 ;
+                 rdfs:label "accepted papers"@en ;
+                 :SMW_datatype "Number" ;
+                 :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#accepted_short_papers
-aeon:accepted_short_papers rdf:type owl:DatatypeProperty ;
-                           rdfs:subPropertyOf aeon:metric ;
-                           rdfs:domain aeon:AEON_0000001 ;
-                           rdfs:label "accepted short papers"@en ;
-                           aeon:SMW_datatype "Number" ;
-                           aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:accepted_short_papers rdf:type owl:DatatypeProperty ;
+                       rdfs:subPropertyOf :metric ;
+                       rdfs:domain :AEON_0000001 ;
+                       rdfs:label "accepted short papers"@en ;
+                       :SMW_datatype "Number" ;
+                       :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#camera-ready_deadline
-aeon:camera-ready_deadline rdf:type owl:DatatypeProperty ;
-                           rdfs:subPropertyOf aeon:deadline ;
-                           rdfs:domain aeon:AEON_0000001 ;
-                           rdfs:range xsd:dateTimeStamp ;
-                           rdfs:label "camera-ready deadline"@en ;
-                           aeon:SMW_datatype "Date" ;
-                           aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:camera-ready_deadline rdf:type owl:DatatypeProperty ;
+                       rdfs:subPropertyOf :deadline ;
+                       rdfs:domain :AEON_0000001 ;
+                       rdfs:range xsd:dateTimeStamp ;
+                       rdfs:label "camera-ready deadline"@en ;
+                       :SMW_datatype "Date" ;
+                       :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#city
-aeon:city rdf:type owl:DatatypeProperty ;
-          rdfs:subPropertyOf aeon:location ;
-          rdfs:domain aeon:AEON_0000022 ;
-          rdfs:label "city"@en ;
-          aeon:SMW_datatype "Text" ;
-          aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:city rdf:type owl:DatatypeProperty ;
+      rdfs:subPropertyOf :location ;
+      rdfs:domain :AEON_0000022 ;
+      rdfs:label "city"@en ;
+      :SMW_datatype "Text" ;
+      :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#contact
-aeon:contact rdf:type owl:DatatypeProperty ;
-             rdfs:subPropertyOf owl:topDataProperty ;
-             rdfs:domain aeon:AEON_0000009 ;
-             rdfs:label "contact"@en ;
-             aeon:SMW_datatype "Text" ;
-             aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:contact rdf:type owl:DatatypeProperty ;
+         rdfs:subPropertyOf owl:topDataProperty ;
+         rdfs:domain :AEON_0000009 ;
+         rdfs:label "contact"@en ;
+         :SMW_datatype "Text" ;
+         :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#contact_email
-aeon:contact_email rdf:type owl:DatatypeProperty ;
-                   rdfs:subPropertyOf aeon:contact ;
-                   rdfs:domain aeon:AEON_0000009 ;
-                   rdfs:label "contact email"@en ;
-                   aeon:SMW_datatype "Email" ;
-                   aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:contact_email rdf:type owl:DatatypeProperty ;
+               rdfs:subPropertyOf :contact ;
+               rdfs:domain :AEON_0000009 ;
+               rdfs:label "contact email"@en ;
+               :SMW_datatype "Email" ;
+               :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#contact_person_name
-aeon:contact_person_name rdf:type owl:DatatypeProperty ;
-                         rdfs:subPropertyOf aeon:contact ;
-                         rdfs:domain aeon:AEON_0000009 ;
-                         rdfs:label "contact person"@en ;
-                         aeon:SMW_datatype "Text" ;
-                         aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:contact_person_name rdf:type owl:DatatypeProperty ;
+                     rdfs:subPropertyOf :contact ;
+                     rdfs:domain :AEON_0000009 ;
+                     rdfs:label "contact person"@en ;
+                     :SMW_datatype "Text" ;
+                     :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#contact_phone
-aeon:contact_phone rdf:type owl:DatatypeProperty ;
-                   rdfs:subPropertyOf aeon:contact ;
-                   rdfs:domain aeon:AEON_0000009 ;
-                   rdfs:label "contact phone"@en ;
-                   aeon:SMW_datatype "Telephone number" ;
-                   aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:contact_phone rdf:type owl:DatatypeProperty ;
+               rdfs:subPropertyOf :contact ;
+               rdfs:domain :AEON_0000009 ;
+               rdfs:label "contact phone"@en ;
+               :SMW_datatype "Telephone number" ;
+               :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#coordinates
-aeon:coordinates rdf:type owl:DatatypeProperty ;
-                 rdfs:subPropertyOf aeon:location ;
-                 rdfs:domain obo:GAZ_00000448 ;
-                 rdfs:label "coordinates"@en ;
-                 aeon:SMW_datatype "Geographic coordinates" ;
-                 aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:coordinates rdf:type owl:DatatypeProperty ;
+             rdfs:subPropertyOf :location ;
+             rdfs:domain <http://purl.obolibrary.org/obo/GAZ_00000448> ;
+             rdfs:label "coordinates"@en ;
+             :SMW_datatype "Geographic coordinates" ;
+             :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#country
-aeon:country rdf:type owl:DatatypeProperty ;
-             rdfs:subPropertyOf aeon:location ;
-             rdfs:domain aeon:AEON_0000023 ;
-             rdfs:label "country"@en ;
-             aeon:SMW_datatype "Text" ;
-             aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:country rdf:type owl:DatatypeProperty ;
+         rdfs:subPropertyOf :location ;
+         rdfs:domain :AEON_0000023 ;
+         rdfs:label "country"@en ;
+         :SMW_datatype "Text" ;
+         :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#deadline
-aeon:deadline rdf:type owl:DatatypeProperty ;
-              rdfs:subPropertyOf owl:topDataProperty ;
-              rdfs:domain aeon:AEON_0000001 ;
-              rdfs:range xsd:dateTime ;
-              rdfs:label "deadline"@en ;
-              aeon:SMW_datatype "Date" ;
-              aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:deadline rdf:type owl:DatatypeProperty ;
+          rdfs:subPropertyOf owl:topDataProperty ;
+          rdfs:domain :AEON_0000001 ;
+          rdfs:range xsd:dateTime ;
+          rdfs:label "deadline"@en ;
+          :SMW_datatype "Date" ;
+          :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#demo_deadline
-aeon:demo_deadline rdf:type owl:DatatypeProperty ;
-                   rdfs:subPropertyOf aeon:deadline ;
-                   rdfs:domain aeon:AEON_0000001 ;
-                   rdfs:range xsd:dateTimeStamp ;
-                   rdfs:label "demo deadline"@en ;
-                   aeon:SMW_datatype "Date" ;
-                   aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:demo_deadline rdf:type owl:DatatypeProperty ;
+               rdfs:subPropertyOf :deadline ;
+               rdfs:domain :AEON_0000001 ;
+               rdfs:range xsd:dateTimeStamp ;
+               rdfs:label "demo deadline"@en ;
+               :SMW_datatype "Date" ;
+               :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#duration
-aeon:duration rdf:type owl:DatatypeProperty ;
-              rdfs:subPropertyOf owl:topDataProperty ;
-              rdfs:domain aeon:AEON_0000001 ;
-              rdfs:label "duration"@en ;
-              aeon:AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P2047\", \"label\": \"duration\"}, \"gnd\": {\"uri\": \"https://d-nb.info/standards/elementset/gnd#dateOfConferenceOrEvent\", \"label\": \"Date of conference or event\"}}"^^xsd:string ;
-              aeon:SMW_datatype "Quantity" ;
-              aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" ;
-              aeon:WikidataLabel "duration" ;
-              aeon:WikidataURI "https://www.wikidata.org/wiki/Property:P2047" .
+:duration rdf:type owl:DatatypeProperty ;
+          rdfs:subPropertyOf owl:topDataProperty ;
+          rdfs:domain :AEON_0000001 ;
+          rdfs:label "duration"@en ;
+          :AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P2047\", \"label\": \"duration\"}, \"gnd\": {\"uri\": \"https://d-nb.info/standards/elementset/gnd#dateOfConferenceOrEvent\", \"label\": \"Date of conference or event\"}}"^^xsd:string ;
+          :SMW_datatype "Quantity" ;
+          :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" ;
+          :WikidataLabel "duration" ;
+          :WikidataURI "https://www.wikidata.org/wiki/Property:P2047" .
 
 
 ###  https://github.com/tibonto/aeon#end_date
-aeon:end_date rdf:type owl:DatatypeProperty ;
-              rdfs:subPropertyOf aeon:duration ;
-              rdfs:domain aeon:AEON_0000001 ;
-              rdfs:range xsd:dateTimeStamp ;
-              rdfs:label "end date"@en ;
-              aeon:AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P582\", \"label\": \"end_time\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Property:End_date\", \"label\": \"End_date\"},\"crossref\": {\"api_proceedings_endpoint_uri\": \"https://api.crossref.org/types/proceedings/works?select=event\", \"json_api_key\": {\"event\": \"end\"}}}"^^xsd:string ;
-              aeon:SMW_datatype "Date" ;
-              aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" ;
-              aeon:WikidataLabel "end_time" ;
-              aeon:WikidataURI "https://www.wikidata.org/wiki/Property:P582" .
+:end_date rdf:type owl:DatatypeProperty ;
+          rdfs:subPropertyOf :duration ;
+          rdfs:domain :AEON_0000001 ;
+          rdfs:range xsd:dateTimeStamp ;
+          rdfs:label "end date"@en ;
+          :AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P582\", \"label\": \"end_time\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Property:End_date\", \"label\": \"End_date\"},\"crossref\": {\"api_proceedings_endpoint_uri\": \"https://api.crossref.org/types/proceedings/works?select=event\", \"json_api_key\": {\"event\": \"end\"}}}"^^xsd:string ;
+          :SMW_datatype "Date" ;
+          :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" ;
+          :WikidataLabel "end_time" ;
+          :WikidataURI "https://www.wikidata.org/wiki/Property:P582" .
 
 
 ###  https://github.com/tibonto/aeon#event_frequency
-aeon:event_frequency rdf:type owl:DatatypeProperty ;
-                     rdfs:subPropertyOf aeon:metric ;
-                     rdfs:domain aeon:AEON_0000002 ;
-                     obo:IAO_0000115 "The event frequency is the literal value of the number of month until the next event in a certain takes place." ;
-                     rdfs:label "event frequency"@en ;
-                     aeon:AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P2257\", \"label\": \"event_interval_inmonths\"}}"^^xsd:string ;
-                     aeon:SMW_datatype "Quantity" ;
-                     aeon:SMW_import_info """[[Corresponds to::1 month]] [[Corresponds to::1 months]] [[display units::months]]
+:event_frequency rdf:type owl:DatatypeProperty ;
+                 rdfs:subPropertyOf :metric ;
+                 rdfs:domain :AEON_0000002 ;
+                 <http://purl.obolibrary.org/obo/IAO_0000115> "The event frequency is the literal value of the number of month until the next event in a certain takes place." ;
+                 rdfs:label "event frequency"@en ;
+                 :AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P2257\", \"label\": \"event_interval_inmonths\"}}"^^xsd:string ;
+                 :SMW_datatype "Quantity" ;
+                 :SMW_import_info """[[Corresponds to::1 month]] [[Corresponds to::1 months]] [[display units::months]]
 
 [[Category:AEON]] [[Category:Imported vocabulary]]""" ;
-                     aeon:WikidataLabel "event_interval_inmonths" ;
-                     aeon:WikidataURI "https://www.wikidata.org/wiki/Property:P2257" .
+                 :WikidataLabel "event_interval_inmonths" ;
+                 :WikidataURI "https://www.wikidata.org/wiki/Property:P2257" .
 
 
 ###  https://github.com/tibonto/aeon#event_number
-aeon:event_number rdf:type owl:DatatypeProperty ;
-                  rdfs:domain aeon:AEON_0000001 ;
-                  rdfs:range xsd:string ;
-                  obo:IAO_0000115 "The ordinal number of an academic event, if it is a part of an event series." ;
-                  rdfs:label "event number"@en ;
-                  aeon:AEON_0000026 "{\"crossref\": {\"api_proceedings_endpoint_uri\": \"https://api.crossref.org/types/proceedings/works?select=event\", \"json_api_key\": {\"event\": \"number\"}}}"^^xsd:string ;
-                  aeon:SMW_datatype "Text" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:event_number rdf:type owl:DatatypeProperty ;
+              rdfs:domain :AEON_0000001 ;
+              rdfs:range xsd:string ;
+              <http://purl.obolibrary.org/obo/IAO_0000115> "The ordinal number of an academic event, if it is a part of an event series." ;
+              rdfs:label "event number"@en ;
+              :AEON_0000026 "{\"crossref\": {\"api_proceedings_endpoint_uri\": \"https://api.crossref.org/types/proceedings/works?select=event\", \"json_api_key\": {\"event\": \"number\"}}}"^^xsd:string ;
+              :SMW_datatype "Text" ;
+              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#event_status
-aeon:event_status rdf:type owl:DatatypeProperty ;
-                  rdfs:subPropertyOf owl:topDataProperty ;
-                  rdfs:domain aeon:AEON_0000001 ;
-                  rdfs:range [ rdf:type rdfs:Datatype ;
-                               owl:oneOf [ rdf:type rdf:List ;
-                                           rdf:first "as scheduled" ;
-                                           rdf:rest [ rdf:type rdf:List ;
-                                                      rdf:first "canceled" ;
-                                                      rdf:rest [ rdf:type rdf:List ;
-                                                                 rdf:first "delayed" ;
-                                                                 rdf:rest [ rdf:type rdf:List ;
-                                                                            rdf:first "planned" ;
-                                                                            rdf:rest [ rdf:type rdf:List ;
-                                                                                       rdf:first "postponed" ;
-                                                                                       rdf:rest rdf:nil
-                                                                                     ]
-                                                                          ]
-                                                               ]
-                                                    ]
-                                         ]
-                             ] ;
-                  rdfs:comment """maps_to: DataCite:dateType 
+:event_status rdf:type owl:DatatypeProperty ;
+              rdfs:subPropertyOf owl:topDataProperty ;
+              rdfs:domain :AEON_0000001 ;
+              rdfs:range [ rdf:type rdfs:Datatype ;
+                           owl:oneOf [ rdf:type rdf:List ;
+                                       rdf:first "as scheduled" ;
+                                       rdf:rest [ rdf:type rdf:List ;
+                                                  rdf:first "canceled" ;
+                                                  rdf:rest [ rdf:type rdf:List ;
+                                                             rdf:first "delayed" ;
+                                                             rdf:rest [ rdf:type rdf:List ;
+                                                                        rdf:first "planned" ;
+                                                                        rdf:rest [ rdf:type rdf:List ;
+                                                                                   rdf:first "postponed" ;
+                                                                                   rdf:rest rdf:nil
+                                                                                 ]
+                                                                      ]
+                                                           ]
+                                                ]
+                                     ]
+                         ] ;
+              rdfs:comment """maps_to: DataCite:dateType 
 ---
 allowed value mapping 
 ConfIDent → DataCite
@@ -1562,52 +1556,52 @@ ConfIDent → DataCite
 scheduled → valid
 postponed → updated
 cancled → withdrawn"""@en ;
-                  rdfs:label "event status"@en ;
-                  aeon:SMW_datatype "Text" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+              rdfs:label "event status"@en ;
+              :SMW_datatype "Text" ;
+              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#event_type_other
-aeon:event_type_other rdf:type owl:DatatypeProperty ;
-                      rdfs:subPropertyOf owl:topDataProperty ;
-                      rdfs:domain aeon:AEON_0000004 ;
-                      rdfs:range xsd:string ;
-                      rdfs:label "event type other"@en ;
-                      aeon:SMW_datatype "Text" ;
-                      aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:event_type_other rdf:type owl:DatatypeProperty ;
+                  rdfs:subPropertyOf owl:topDataProperty ;
+                  rdfs:domain :AEON_0000004 ;
+                  rdfs:range xsd:string ;
+                  rdfs:label "event type other"@en ;
+                  :SMW_datatype "Text" ;
+                  :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#event_year
-aeon:event_year rdf:type owl:DatatypeProperty ;
-                rdfs:domain aeon:AEON_0000001 ;
-                rdfs:range xsd:integer ;
-                obo:IAO_0000115 "The year in which an event takes place."@en ;
-                rdfs:label "event year"@en ;
-                aeon:SMW_datatype "Date" ;
-                aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:event_year rdf:type owl:DatatypeProperty ;
+            rdfs:domain :AEON_0000001 ;
+            rdfs:range xsd:integer ;
+            <http://purl.obolibrary.org/obo/IAO_0000115> "The year in which an event takes place."@en ;
+            rdfs:label "event year"@en ;
+            :SMW_datatype "Date" ;
+            :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#fee
-aeon:fee rdf:type owl:DatatypeProperty ;
-         rdfs:subPropertyOf owl:topDataProperty ;
-         rdfs:domain aeon:AEON_0000030 ;
-         obo:IAO_0000115 "The literal value of the type of fee an aeon:event can have."@en ;
-         obo:IAO_0000600 "There are various type of fees for an event, such as the regular fee, a reduced fee, a member fee and so forth." ;
-         rdfs:label "fee"@en ;
-         aeon:SMW_datatype "Text" ;
-         aeon:SMW_import_info """[[partOfSubobject::Template:Subobject Fee]]
+:fee rdf:type owl:DatatypeProperty ;
+     rdfs:subPropertyOf owl:topDataProperty ;
+     rdfs:domain :AEON_0000030 ;
+     <http://purl.obolibrary.org/obo/IAO_0000115> "The literal value of the type of fee an aeon:event can have."@en ;
+     <http://purl.obolibrary.org/obo/IAO_0000600> "There are various type of fees for an event, such as the regular fee, a reduced fee, a member fee and so forth." ;
+     rdfs:label "fee"@en ;
+     :SMW_datatype "Text" ;
+     :SMW_import_info """[[partOfSubobject::Template:Subobject Fee]]
 
 [[Category:AEON]] [[Category:Imported vocabulary]]""" .
 
 
 ###  https://github.com/tibonto/aeon#fee_currency
-aeon:fee_currency rdf:type owl:DatatypeProperty ;
-                  rdfs:subPropertyOf aeon:fee ;
-                  rdfs:domain aeon:AEON_0000030 ;
-                  rdfs:comment "This property should have a value from the controlled list defined by the ISO_4217 standard (https://en.wikipedia.org/wiki/ISO_4217)." ;
-                  rdfs:label "fee currency"@en ;
-                  aeon:SMW_datatype "Text" ;
-                  aeon:SMW_import_info """Controlled vocabulary in [[MediaWiki:Smw_allows_list_Fee_currency]]
+:fee_currency rdf:type owl:DatatypeProperty ;
+              rdfs:subPropertyOf :fee ;
+              rdfs:domain :AEON_0000030 ;
+              rdfs:comment "This property should have a value from the controlled list defined by the ISO_4217 standard (https://en.wikipedia.org/wiki/ISO_4217)." ;
+              rdfs:label "fee currency"@en ;
+              :SMW_datatype "Text" ;
+              :SMW_import_info """Controlled vocabulary in [[MediaWiki:Smw_allows_list_Fee_currency]]
 
 [[partOfSubobject::Template:Subobject Fee]]
 
@@ -1615,36 +1609,36 @@ aeon:fee_currency rdf:type owl:DatatypeProperty ;
 
 
 ###  https://github.com/tibonto/aeon#fee_value
-aeon:fee_value rdf:type owl:DatatypeProperty ;
-               rdfs:subPropertyOf aeon:fee ;
-               rdfs:domain aeon:AEON_0000030 ;
-               rdfs:label "fee value"@en ;
-               aeon:SMW_datatype "Number" ;
-               aeon:SMW_import_info """[[partOfSubobject::Template:Subobject Fee]]
+:fee_value rdf:type owl:DatatypeProperty ;
+           rdfs:subPropertyOf :fee ;
+           rdfs:domain :AEON_0000030 ;
+           rdfs:label "fee value"@en ;
+           :SMW_datatype "Number" ;
+           :SMW_import_info """[[partOfSubobject::Template:Subobject Fee]]
 
 [[Category:AEON]] [[Category:Imported vocabulary]]""" .
 
 
 ###  https://github.com/tibonto/aeon#first_name
-aeon:first_name rdf:type owl:DatatypeProperty ;
-                rdfs:subPropertyOf aeon:personal_name ;
-                rdfs:domain obo:NCBITaxon_9606 ;
-                rdfs:range xsd:string ;
-                obo:IAO_0000115 "The literal value of the first name of a person."@en ;
-                rdfs:label "first name"@en ;
-                aeon:SMW_datatype "Text" ;
-                aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:first_name rdf:type owl:DatatypeProperty ;
+            rdfs:subPropertyOf :personal_name ;
+            rdfs:domain <http://purl.obolibrary.org/obo/NCBITaxon_9606> ;
+            rdfs:range xsd:string ;
+            <http://purl.obolibrary.org/obo/IAO_0000115> "The literal value of the first name of a person."@en ;
+            rdfs:label "first name"@en ;
+            :SMW_datatype "Text" ;
+            :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#landing_page
-aeon:landing_page rdf:type owl:DatatypeProperty ;
-                  rdfs:subPropertyOf aeon:ID ;
-                  rdfs:domain obo:IAO_0020000 ;
-                  rdfs:range xsd:anyURI ;
-                  rdfs:comment "The literal value of the landing page (URL) an ID resolves to when following the ID_URL."@en ;
-                  rdfs:label "identifier landing page"@en ;
-                  aeon:SMW_datatype "URL" ;
-                  aeon:SMW_import_info """[[partOfSubobject::Template:Subobject External_Process_ID]]
+:landing_page rdf:type owl:DatatypeProperty ;
+              rdfs:subPropertyOf :ID ;
+              rdfs:domain <http://purl.obolibrary.org/obo/IAO_0020000> ;
+              rdfs:range xsd:anyURI ;
+              rdfs:comment "The literal value of the landing page (URL) an ID resolves to when following the ID_URL."@en ;
+              rdfs:label "identifier landing page"@en ;
+              :SMW_datatype "URL" ;
+              :SMW_import_info """[[partOfSubobject::Template:Subobject External_Process_ID]]
 [[partOfSubobject::Template:Subobject Person_ID]]
 [[partOfSubobject::Template:Subobject Organization_ID]]
 
@@ -1652,347 +1646,347 @@ aeon:landing_page rdf:type owl:DatatypeProperty ;
 
 
 ###  https://github.com/tibonto/aeon#language
-aeon:language rdf:type owl:DatatypeProperty ;
-              rdfs:subPropertyOf owl:topDataProperty ;
-              rdfs:label "language"@en ;
-              aeon:AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P2936\", \"label\": \"language_usedLabel\"}}"^^xsd:string ;
-              aeon:SMW_datatype "Text" ;
-              aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" ;
-              aeon:WikidataLabel "language_usedLabel" ;
-              aeon:WikidataURI "https://www.wikidata.org/wiki/Property:P2936" .
+:language rdf:type owl:DatatypeProperty ;
+          rdfs:subPropertyOf owl:topDataProperty ;
+          rdfs:label "language"@en ;
+          :AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P2936\", \"label\": \"language_usedLabel\"}}"^^xsd:string ;
+          :SMW_datatype "Text" ;
+          :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" ;
+          :WikidataLabel "language_usedLabel" ;
+          :WikidataURI "https://www.wikidata.org/wiki/Property:P2936" .
 
 
 ###  https://github.com/tibonto/aeon#last_name
-aeon:last_name rdf:type owl:DatatypeProperty ;
-               rdfs:subPropertyOf aeon:personal_name ;
-               rdfs:domain obo:NCBITaxon_9606 ;
-               rdfs:range xsd:string ;
-               obo:IAO_0000115 "The literal value of the last name, or family name, of a person."@en ;
-               rdfs:label "last name"@en ;
-               aeon:SMW_datatype "Text" ;
-               aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:last_name rdf:type owl:DatatypeProperty ;
+           rdfs:subPropertyOf :personal_name ;
+           rdfs:domain <http://purl.obolibrary.org/obo/NCBITaxon_9606> ;
+           rdfs:range xsd:string ;
+           <http://purl.obolibrary.org/obo/IAO_0000115> "The literal value of the last name, or family name, of a person."@en ;
+           rdfs:label "last name"@en ;
+           :SMW_datatype "Text" ;
+           :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#location
-aeon:location rdf:type owl:DatatypeProperty ;
-              rdfs:subPropertyOf owl:topDataProperty ;
-              rdfs:domain obo:BFO_0000029 ;
-              rdfs:label "location"@en ;
-              aeon:SMW_datatype "Text" ;
-              aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:location rdf:type owl:DatatypeProperty ;
+          rdfs:subPropertyOf owl:topDataProperty ;
+          rdfs:domain <http://purl.obolibrary.org/obo/BFO_0000029> ;
+          rdfs:label "location"@en ;
+          :SMW_datatype "Text" ;
+          :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#logo
-aeon:logo rdf:type owl:DatatypeProperty ;
-          rdfs:subPropertyOf owl:topDataProperty ;
-          rdfs:label "logo"@en ;
-          aeon:SMW_datatype "Page" ;
-          aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:logo rdf:type owl:DatatypeProperty ;
+      rdfs:subPropertyOf owl:topDataProperty ;
+      rdfs:label "logo"@en ;
+      :SMW_datatype "Page" ;
+      :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#meeting_URL
-aeon:meeting_URL rdf:type owl:DatatypeProperty ;
-                 rdfs:subPropertyOf aeon:location ;
-                 rdfs:domain aeon:AEON_0000029 ;
-                 rdfs:range xsd:anyURI ;
-                 rdfs:label "meeting URL"@en ;
-                 aeon:SMW_datatype "URL" ;
-                 aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:meeting_URL rdf:type owl:DatatypeProperty ;
+             rdfs:subPropertyOf :location ;
+             rdfs:domain :AEON_0000029 ;
+             rdfs:range xsd:anyURI ;
+             rdfs:label "meeting URL"@en ;
+             :SMW_datatype "URL" ;
+             :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#metric
-aeon:metric rdf:type owl:DatatypeProperty ;
-            rdfs:subPropertyOf owl:topDataProperty ;
-            rdfs:domain obo:OBI_0000011 ;
-            rdfs:label "metric"@en ;
-            aeon:SMW_datatype "Text" ;
-            aeon:SMW_import_info """[[partOfSubobject::Template:Subobject Metric]]
+:metric rdf:type owl:DatatypeProperty ;
+        rdfs:subPropertyOf owl:topDataProperty ;
+        rdfs:domain <http://purl.obolibrary.org/obo/OBI_0000011> ;
+        rdfs:label "metric"@en ;
+        :SMW_datatype "Text" ;
+        :SMW_import_info """[[partOfSubobject::Template:Subobject Metric]]
 
 [[Category:AEON]] [[Category:Imported vocabulary]]""" .
 
 
 ###  https://github.com/tibonto/aeon#name
-aeon:name rdf:type owl:DatatypeProperty ;
-          rdfs:subPropertyOf owl:topDataProperty ;
-          obo:IAO_0000115 "The literal value of the name of a thing."@en ;
-          rdfs:label "name"@en ;
-          aeon:SMW_datatype "Text" ;
-          aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:name rdf:type owl:DatatypeProperty ;
+      rdfs:subPropertyOf owl:topDataProperty ;
+      <http://purl.obolibrary.org/obo/IAO_0000115> "The literal value of the name of a thing."@en ;
+      rdfs:label "name"@en ;
+      :SMW_datatype "Text" ;
+      :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#notification_deadline
-aeon:notification_deadline rdf:type owl:DatatypeProperty ;
-                           rdfs:subPropertyOf aeon:deadline ;
-                           rdfs:domain aeon:AEON_0000001 ;
-                           rdfs:range xsd:dateTimeStamp ;
-                           rdfs:label "notification deadline"@en ;
-                           aeon:SMW_datatype "Date" ;
-                           aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:notification_deadline rdf:type owl:DatatypeProperty ;
+                       rdfs:subPropertyOf :deadline ;
+                       rdfs:domain :AEON_0000001 ;
+                       rdfs:range xsd:dateTimeStamp ;
+                       rdfs:label "notification deadline"@en ;
+                       :SMW_datatype "Date" ;
+                       :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#number_of_attendees
-aeon:number_of_attendees rdf:type owl:DatatypeProperty ;
-                         rdfs:subPropertyOf aeon:metric ;
-                         rdfs:domain aeon:AEON_0000001 ;
-                         rdfs:label "number of attendess"@en ;
-                         aeon:AEON_0000026 "{\"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Property:Attendees\", \"label\": \"Attendees\"}}"^^xsd:string ;
-                         aeon:SMW_datatype "Number" ;
-                         aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:number_of_attendees rdf:type owl:DatatypeProperty ;
+                     rdfs:subPropertyOf :metric ;
+                     rdfs:domain :AEON_0000001 ;
+                     rdfs:label "number of attendess"@en ;
+                     :AEON_0000026 "{\"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Property:Attendees\", \"label\": \"Attendees\"}}"^^xsd:string ;
+                     :SMW_datatype "Number" ;
+                     :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#number_of_tracks
-aeon:number_of_tracks rdf:type owl:DatatypeProperty ;
-                      rdfs:subPropertyOf aeon:metric ;
-                      rdfs:domain aeon:AEON_0000001 ;
-                      rdfs:label "number of tracks"@en ;
-                      aeon:SMW_datatype "Number" ;
-                      aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:number_of_tracks rdf:type owl:DatatypeProperty ;
+                  rdfs:subPropertyOf :metric ;
+                  rdfs:domain :AEON_0000001 ;
+                  rdfs:label "number of tracks"@en ;
+                  :SMW_datatype "Number" ;
+                  :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#organizational_name
-aeon:organizational_name rdf:type owl:DatatypeProperty ;
-                         rdfs:subPropertyOf aeon:name ;
-                         rdfs:domain obo:OBI_0000245 ;
-                         rdfs:range xsd:string ;
-                         obo:IAO_0000115 "The literal value of the name to denote an organization."@en ;
-                         rdfs:label "organizational name"@en ;
-                         aeon:SMW_datatype "Text" ;
-                         aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:organizational_name rdf:type owl:DatatypeProperty ;
+                     rdfs:subPropertyOf :name ;
+                     rdfs:domain <http://purl.obolibrary.org/obo/OBI_0000245> ;
+                     rdfs:range xsd:string ;
+                     <http://purl.obolibrary.org/obo/IAO_0000115> "The literal value of the name to denote an organization."@en ;
+                     rdfs:label "organizational name"@en ;
+                     :SMW_datatype "Text" ;
+                     :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#paper_deadline
-aeon:paper_deadline rdf:type owl:DatatypeProperty ;
-                    rdfs:subPropertyOf aeon:deadline ;
-                    rdfs:domain aeon:AEON_0000001 ;
-                    rdfs:range xsd:dateTimeStamp ;
-                    rdfs:label "paper deadline"@en ;
-                    aeon:SMW_datatype "Date" ;
-                    aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:paper_deadline rdf:type owl:DatatypeProperty ;
+                rdfs:subPropertyOf :deadline ;
+                rdfs:domain :AEON_0000001 ;
+                rdfs:range xsd:dateTimeStamp ;
+                rdfs:label "paper deadline"@en ;
+                :SMW_datatype "Date" ;
+                :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#personal_name
-aeon:personal_name rdf:type owl:DatatypeProperty ;
-                   rdfs:subPropertyOf aeon:name ;
-                   rdfs:domain obo:NCBITaxon_9606 ;
-                   rdfs:range xsd:string ;
-                   obo:IAO_0000115 "The literal value of the name to denote a person."@en ;
-                   rdfs:label "personal name"@en ;
-                   aeon:SMW_datatype "Text" ;
-                   aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:personal_name rdf:type owl:DatatypeProperty ;
+               rdfs:subPropertyOf :name ;
+               rdfs:domain <http://purl.obolibrary.org/obo/NCBITaxon_9606> ;
+               rdfs:range xsd:string ;
+               <http://purl.obolibrary.org/obo/IAO_0000115> "The literal value of the name to denote a person."@en ;
+               rdfs:label "personal name"@en ;
+               :SMW_datatype "Text" ;
+               :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#poster_deadline
-aeon:poster_deadline rdf:type owl:DatatypeProperty ;
-                     rdfs:subPropertyOf aeon:deadline ;
-                     rdfs:domain aeon:AEON_0000001 ;
-                     rdfs:range xsd:dateTimeStamp ;
-                     rdfs:label "poster deadline"@en ;
-                     aeon:SMW_datatype "Date" ;
-                     aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:poster_deadline rdf:type owl:DatatypeProperty ;
+                 rdfs:subPropertyOf :deadline ;
+                 rdfs:domain :AEON_0000001 ;
+                 rdfs:range xsd:dateTimeStamp ;
+                 rdfs:label "poster deadline"@en ;
+                 :SMW_datatype "Date" ;
+                 :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#previous_end_date
-aeon:previous_end_date rdf:type owl:DatatypeProperty ;
-                       rdfs:subPropertyOf aeon:end_date ;
-                       rdfs:domain aeon:AEON_0000001 ;
-                       rdfs:range xsd:dateTime ;
-                       rdfs:label "previous end date"@en ;
-                       aeon:SMW_datatype "Date" ;
-                       aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:previous_end_date rdf:type owl:DatatypeProperty ;
+                   rdfs:subPropertyOf :end_date ;
+                   rdfs:domain :AEON_0000001 ;
+                   rdfs:range xsd:dateTime ;
+                   rdfs:label "previous end date"@en ;
+                   :SMW_datatype "Date" ;
+                   :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#previous_start_date
-aeon:previous_start_date rdf:type owl:DatatypeProperty ;
-                         rdfs:subPropertyOf aeon:start_date ;
-                         rdfs:domain aeon:AEON_0000001 ;
-                         rdfs:range xsd:dateTimeStamp ;
-                         rdfs:label "previous start date"@en ;
-                         aeon:SMW_datatype "Date" ;
-                         aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:previous_start_date rdf:type owl:DatatypeProperty ;
+                     rdfs:subPropertyOf :start_date ;
+                     rdfs:domain :AEON_0000001 ;
+                     rdfs:range xsd:dateTimeStamp ;
+                     rdfs:label "previous start date"@en ;
+                     :SMW_datatype "Date" ;
+                     :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#proceedings_site_count
-aeon:proceedings_site_count rdf:type owl:DatatypeProperty ;
-                            rdfs:subPropertyOf aeon:metric ;
-                            rdfs:domain aeon:AEON_0000001 ;
-                            rdfs:label "proceeding cite count"@en ;
-                            aeon:SMW_datatype "Number" ;
-                            aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:proceedings_site_count rdf:type owl:DatatypeProperty ;
+                        rdfs:subPropertyOf :metric ;
+                        rdfs:domain :AEON_0000001 ;
+                        rdfs:label "proceeding cite count"@en ;
+                        :SMW_datatype "Number" ;
+                        :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#process_acronym
-aeon:process_acronym rdf:type owl:DatatypeProperty ;
-                     rdfs:subPropertyOf aeon:name ;
-                     rdfs:range xsd:string ;
-                     obo:IAO_0000112 "\"DILS 2019\" is the official acronym of the academic event \"13th International Conference on Data Integration in Life Science\""@en ;
-                     obo:IAO_0000115 "The literal value of the official acronym of an aeon:process, that is either an academic event or event series."@en ;
-                     rdfs:label "acronym"@en ;
-                     aeon:AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P1813\", \"label\": \"short_nameLabel\"}, \"gnd\": {\"uri\": \"https://d-nb.info/standards/elementset/gnd#abbreviatedNameForTheConferenceOrEvent\", \"label\": \"Abbreviated name for the conference or event\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Property:Acronym\", \"label\": \"Acronym\"}, \"crossref\": {\"api_proceedings_endpoint_uri\": \"https://api.crossref.org/types/proceedings/works?select=event\", \"json_api_key\": {\"event\": \"acronym\"}}}"^^xsd:string ;
-                     aeon:SMW_datatype "Text" ;
-                     aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" ;
-                     aeon:WikidataLabel "short_nameLabel" ;
-                     aeon:WikidataURI "https://www.wikidata.org/wiki/Property:P1813" .
+:process_acronym rdf:type owl:DatatypeProperty ;
+                 rdfs:subPropertyOf :name ;
+                 rdfs:range xsd:string ;
+                 <http://purl.obolibrary.org/obo/IAO_0000112> "\"DILS 2019\" is the official acronym of the academic event \"13th International Conference on Data Integration in Life Science\""@en ;
+                 <http://purl.obolibrary.org/obo/IAO_0000115> "The literal value of the official acronym of an aeon:process, that is either an academic event or event series."@en ;
+                 rdfs:label "acronym"@en ;
+                 :AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P1813\", \"label\": \"short_nameLabel\"}, \"gnd\": {\"uri\": \"https://d-nb.info/standards/elementset/gnd#abbreviatedNameForTheConferenceOrEvent\", \"label\": \"Abbreviated name for the conference or event\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Property:Acronym\", \"label\": \"Acronym\"}, \"crossref\": {\"api_proceedings_endpoint_uri\": \"https://api.crossref.org/types/proceedings/works?select=event\", \"json_api_key\": {\"event\": \"acronym\"}}}"^^xsd:string ;
+                 :SMW_datatype "Text" ;
+                 :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" ;
+                 :WikidataLabel "short_nameLabel" ;
+                 :WikidataURI "https://www.wikidata.org/wiki/Property:P1813" .
 
 
 ###  https://github.com/tibonto/aeon#process_alternative_name
-aeon:process_alternative_name rdf:type owl:DatatypeProperty ;
-                              rdfs:subPropertyOf aeon:name ;
-                              rdfs:range xsd:string ;
-                              rdfs:comment "The Literal value of an alternative name of an aeon:process, that is either an academic event or event series."@en ;
-                              rdfs:label "alternative name"@en ;
-                              aeon:AEON_0000026 "{\"gnd\": {\"uri\": \"https://d-nb.info/standards/elementset/gnd#variantNameForTheConferenceOrEvent\", \"label\": \"Variant name for the conference or event\"}, \"crossref\": {\"api_proceedings_endpoint_uri\": \"https://api.crossref.org/types/proceedings/works?select=title\", \"json_api_key\": \"title\"}}"^^xsd:string ;
-                              aeon:SMW_datatype "Text" ;
-                              aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:process_alternative_name rdf:type owl:DatatypeProperty ;
+                          rdfs:subPropertyOf :name ;
+                          rdfs:range xsd:string ;
+                          rdfs:comment "The Literal value of an alternative name of an aeon:process, that is either an academic event or event series."@en ;
+                          rdfs:label "alternative name"@en ;
+                          :AEON_0000026 "{\"gnd\": {\"uri\": \"https://d-nb.info/standards/elementset/gnd#variantNameForTheConferenceOrEvent\", \"label\": \"Variant name for the conference or event\"}, \"crossref\": {\"api_proceedings_endpoint_uri\": \"https://api.crossref.org/types/proceedings/works?select=title\", \"json_api_key\": \"title\"}}"^^xsd:string ;
+                          :SMW_datatype "Text" ;
+                          :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#process_former_name
-aeon:process_former_name rdf:type owl:DatatypeProperty ;
-                         rdfs:subPropertyOf aeon:name ;
-                         rdfs:range xsd:string ;
-                         rdfs:comment "The Literal value of the former official name of an aeon:process, that is either an academic event or event series."@en ;
-                         rdfs:label "former name"@en ;
-                         aeon:SMW_datatype "Text" ;
-                         aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:process_former_name rdf:type owl:DatatypeProperty ;
+                     rdfs:subPropertyOf :name ;
+                     rdfs:range xsd:string ;
+                     rdfs:comment "The Literal value of the former official name of an aeon:process, that is either an academic event or event series."@en ;
+                     rdfs:label "former name"@en ;
+                     :SMW_datatype "Text" ;
+                     :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#process_translated_name
-aeon:process_translated_name rdf:type owl:DatatypeProperty ;
-                             rdfs:subPropertyOf aeon:name ;
-                             rdfs:range xsd:string ;
-                             obo:IAO_0000115 "The literal value of the translation of the official name (title) of an aeon:process, that is either an academic event or event series."@en ;
-                             rdfs:label "translated name"@en ;
-                             aeon:SMW_datatype "Text" ;
-                             aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:process_translated_name rdf:type owl:DatatypeProperty ;
+                         rdfs:subPropertyOf :name ;
+                         rdfs:range xsd:string ;
+                         <http://purl.obolibrary.org/obo/IAO_0000115> "The literal value of the translation of the official name (title) of an aeon:process, that is either an academic event or event series."@en ;
+                         rdfs:label "translated name"@en ;
+                         :SMW_datatype "Text" ;
+                         :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#process_website
-aeon:process_website rdf:type owl:DatatypeProperty ;
-                     rdfs:subPropertyOf owl:topDataProperty ;
-                     rdfs:domain obo:OBI_0000011 ;
-                     rdfs:range xsd:anyURI ;
-                     rdfs:label "process website"@en ;
-                     aeon:AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P856\", \"label\": \"official_website\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Property:Homepage\", \"label\": \"Homepage\"}}"^^xsd:string ;
-                     aeon:SMW_datatype "URL" ;
-                     aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" ;
-                     aeon:WikidataLabel "official_website" ;
-                     aeon:WikidataURI "https://www.wikidata.org/wiki/Property:P856" .
+:process_website rdf:type owl:DatatypeProperty ;
+                 rdfs:subPropertyOf owl:topDataProperty ;
+                 rdfs:domain <http://purl.obolibrary.org/obo/OBI_0000011> ;
+                 rdfs:range xsd:anyURI ;
+                 rdfs:label "process website"@en ;
+                 :AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P856\", \"label\": \"official_website\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Property:Homepage\", \"label\": \"Homepage\"}}"^^xsd:string ;
+                 :SMW_datatype "URL" ;
+                 :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" ;
+                 :WikidataLabel "official_website" ;
+                 :WikidataURI "https://www.wikidata.org/wiki/Property:P856" .
 
 
 ###  https://github.com/tibonto/aeon#series_cite_count
-aeon:series_cite_count rdf:type owl:DatatypeProperty ;
-                       rdfs:subPropertyOf aeon:metric ;
-                       rdfs:domain aeon:AEON_0000002 ;
-                       rdfs:label "series cite count"@en ;
-                       aeon:SMW_datatype "Number" ;
-                       aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:series_cite_count rdf:type owl:DatatypeProperty ;
+                   rdfs:subPropertyOf :metric ;
+                   rdfs:domain :AEON_0000002 ;
+                   rdfs:label "series cite count"@en ;
+                   :SMW_datatype "Number" ;
+                   :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#sponsor_type
-aeon:sponsor_type rdf:type owl:DatatypeProperty ;
-                  rdfs:subPropertyOf owl:topDataProperty ;
-                  rdfs:domain aeon:AEON_0000015 ;
-                  rdfs:range xsd:string ;
-                  rdfs:label "sponsor type"@en ;
-                  aeon:SMW_datatype "Text" ;
-                  aeon:SMW_import_info """Controlled vocabulary in [[MediaWiki:Smw _allows_list_Sponsor_type]] 
+:sponsor_type rdf:type owl:DatatypeProperty ;
+              rdfs:subPropertyOf owl:topDataProperty ;
+              rdfs:domain :AEON_0000015 ;
+              rdfs:range xsd:string ;
+              rdfs:label "sponsor type"@en ;
+              :SMW_datatype "Text" ;
+              :SMW_import_info """Controlled vocabulary in [[MediaWiki:Smw _allows_list_Sponsor_type]] 
 
 [[Category:AEON]] [[Category:Imported vocabulary]]""" .
 
 
 ###  https://github.com/tibonto/aeon#start_date
-aeon:start_date rdf:type owl:DatatypeProperty ;
-                rdfs:subPropertyOf aeon:duration ;
-                rdfs:domain aeon:AEON_0000001 ;
-                rdfs:range xsd:dateTime ;
-                rdfs:label "start date"@en ;
-                aeon:AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P580\", \"label\": \"start_time\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Property:Start_date\", \"label\": \"Start_date\"},\"crossref\": {\"api_proceedings_endpoint_uri\": \"https://api.crossref.org/types/proceedings/works?select=event\", \"json_api_key\": {\"event\": \"start\"}}}"^^xsd:string ;
-                aeon:SMW_datatype "Date" ;
-                aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" ;
-                aeon:WikidataLabel "start_time" ;
-                aeon:WikidataURI "https://www.wikidata.org/wiki/Property:P580" .
+:start_date rdf:type owl:DatatypeProperty ;
+            rdfs:subPropertyOf :duration ;
+            rdfs:domain :AEON_0000001 ;
+            rdfs:range xsd:dateTime ;
+            rdfs:label "start date"@en ;
+            :AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P580\", \"label\": \"start_time\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Property:Start_date\", \"label\": \"Start_date\"},\"crossref\": {\"api_proceedings_endpoint_uri\": \"https://api.crossref.org/types/proceedings/works?select=event\", \"json_api_key\": {\"event\": \"start\"}}}"^^xsd:string ;
+            :SMW_datatype "Date" ;
+            :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" ;
+            :WikidataLabel "start_time" ;
+            :WikidataURI "https://www.wikidata.org/wiki/Property:P580" .
 
 
 ###  https://github.com/tibonto/aeon#state
-aeon:state rdf:type owl:DatatypeProperty ;
-           rdfs:subPropertyOf aeon:location ;
-           rdfs:domain aeon:AEON_0000024 ;
-           rdfs:label "state"@en ;
-           aeon:SMW_datatype "Text" ;
-           aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:state rdf:type owl:DatatypeProperty ;
+       rdfs:subPropertyOf :location ;
+       rdfs:domain :AEON_0000024 ;
+       rdfs:label "state"@en ;
+       :SMW_datatype "Text" ;
+       :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#submission_deadline
-aeon:submission_deadline rdf:type owl:DatatypeProperty ;
-                         rdfs:subPropertyOf aeon:deadline ;
-                         rdfs:domain aeon:AEON_0000001 ;
-                         rdfs:range xsd:dateTimeStamp ;
-                         rdfs:label "submission deadline"@en ;
-                         aeon:SMW_datatype "Date" ;
-                         aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:submission_deadline rdf:type owl:DatatypeProperty ;
+                     rdfs:subPropertyOf :deadline ;
+                     rdfs:domain :AEON_0000001 ;
+                     rdfs:range xsd:dateTimeStamp ;
+                     rdfs:label "submission deadline"@en ;
+                     :SMW_datatype "Date" ;
+                     :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#submitted_papers
-aeon:submitted_papers rdf:type owl:DatatypeProperty ;
-                      rdfs:subPropertyOf aeon:metric ;
-                      rdfs:domain aeon:AEON_0000001 ;
-                      rdfs:label "submitted papers"@en ;
-                      aeon:SMW_datatype "Number" ;
-                      aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:submitted_papers rdf:type owl:DatatypeProperty ;
+                  rdfs:subPropertyOf :metric ;
+                  rdfs:domain :AEON_0000001 ;
+                  rdfs:label "submitted papers"@en ;
+                  :SMW_datatype "Number" ;
+                  :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#summary
-aeon:summary rdf:type owl:DatatypeProperty ;
-             rdfs:subPropertyOf owl:topDataProperty ;
-             rdfs:label "summary"@en ;
-             aeon:SMW_datatype "Text" ;
-             aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:summary rdf:type owl:DatatypeProperty ;
+         rdfs:subPropertyOf owl:topDataProperty ;
+         rdfs:label "summary"@en ;
+         :SMW_datatype "Text" ;
+         :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#summary_licence
-aeon:summary_licence rdf:type owl:DatatypeProperty ;
-                     rdfs:subPropertyOf aeon:summary ;
-                     rdfs:label "summary licence"@en ;
-                     aeon:SMW_datatype "Text" ;
-                     aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:summary_licence rdf:type owl:DatatypeProperty ;
+                 rdfs:subPropertyOf :summary ;
+                 rdfs:label "summary licence"@en ;
+                 :SMW_datatype "Text" ;
+                 :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#tutorial_deadline
-aeon:tutorial_deadline rdf:type owl:DatatypeProperty ;
-                       rdfs:subPropertyOf aeon:deadline ;
-                       rdfs:domain aeon:AEON_0000001 ;
-                       rdfs:range xsd:dateTimeStamp ;
-                       rdfs:label "tutorial deadline"@en ;
-                       aeon:SMW_datatype "Date" ;
-                       aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:tutorial_deadline rdf:type owl:DatatypeProperty ;
+                   rdfs:subPropertyOf :deadline ;
+                   rdfs:domain :AEON_0000001 ;
+                   rdfs:range xsd:dateTimeStamp ;
+                   rdfs:label "tutorial deadline"@en ;
+                   :SMW_datatype "Date" ;
+                   :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#venue
-aeon:venue rdf:type owl:DatatypeProperty ;
-           rdfs:subPropertyOf aeon:location ;
-           rdfs:domain aeon:AEON_0000025 ;
-           rdfs:label "venue"@en ;
-           aeon:SMW_datatype "Text" ;
-           aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:venue rdf:type owl:DatatypeProperty ;
+       rdfs:subPropertyOf :location ;
+       rdfs:domain :AEON_0000025 ;
+       rdfs:label "venue"@en ;
+       :SMW_datatype "Text" ;
+       :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#venue_URL
-aeon:venue_URL rdf:type owl:DatatypeProperty ;
-               rdfs:subPropertyOf aeon:venue ;
-               rdfs:domain aeon:AEON_0000025 ;
-               rdfs:range xsd:anyURI ;
-               rdfs:label "venue website"@en ;
-               aeon:SMW_datatype "URL" ;
-               aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:venue_URL rdf:type owl:DatatypeProperty ;
+           rdfs:subPropertyOf :venue ;
+           rdfs:domain :AEON_0000025 ;
+           rdfs:range xsd:anyURI ;
+           rdfs:label "venue website"@en ;
+           :SMW_datatype "URL" ;
+           :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#workshop_deadline
-aeon:workshop_deadline rdf:type owl:DatatypeProperty ;
-                       rdfs:subPropertyOf aeon:deadline ;
-                       rdfs:domain aeon:AEON_0000001 ;
-                       rdfs:range xsd:dateTimeStamp ;
-                       rdfs:label "workshop deadline"@en ;
-                       aeon:SMW_datatype "Date" ;
-                       aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:workshop_deadline rdf:type owl:DatatypeProperty ;
+                   rdfs:subPropertyOf :deadline ;
+                   rdfs:domain :AEON_0000001 ;
+                   rdfs:range xsd:dateTimeStamp ;
+                   rdfs:label "workshop deadline"@en ;
+                   :SMW_datatype "Date" ;
+                   :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 #################################################################
@@ -2000,742 +1994,742 @@ aeon:workshop_deadline rdf:type owl:DatatypeProperty ;
 #################################################################
 
 ###  http://purl.obolibrary.org/obo/BFO_0000001
-obo:BFO_0000001 rdf:type owl:Class ;
-                obo:IAO_0000112 "Julius Caesar"@en ,
-                                "Verdi’s Requiem"@en ,
-                                "the Second World War"@en ,
-                                "your body mass index"@en ;
-                obo:IAO_0000116 "BFO 2 Reference: In all areas of empirical inquiry we encounter general terms of two sorts. First are general terms which refer to universals or types:animaltuberculosissurgical procedurediseaseSecond, are general terms used to refer to groups of entities which instantiate a given universal but do not correspond to the extension of any subuniversal of that universal because there is nothing intrinsic to the entities in question by virtue of which they – and only they – are counted as belonging to the given group. Examples are: animal purchased by the Emperortuberculosis diagnosed on a Wednesdaysurgical procedure performed on a patient from Stockholmperson identified as candidate for clinical trial #2056-555person who is signatory of Form 656-PPVpainting by Leonardo da VinciSuch terms, which represent what are called ‘specializations’ in [81"@en ,
-                                "Entity doesn't have a closure axiom because the subclasses don't necessarily exhaust all possibilites. For example Werner Ceusters 'portions of reality' include 4 sorts, entities (as BFO construes them), universals, configurations, and relations. It is an open question as to whether entities as construed in BFO will at some point also include these other portions of reality. See, for example, 'How to track absolutely everything' at http://www.referent-tracking.com/_RTU/papers/CeustersICbookRevised.pdf"@en ;
-                obo:IAO_0000412 "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
-                obo:IAO_0000600 "An entity is anything that exists or has existed or will exist. (axiom label in BFO2 Reference: [001-001])"@en ;
-                rdfs:comment "per discussion with Barry Smith" ;
-                rdfs:isDefinedBy obo:bfo.owl ;
-                rdfs:label "entity"@en ;
-                rdfs:seeAlso <http://www.referent-tracking.com/_RTU/papers/CeustersICbookRevised.pdf> .
+<http://purl.obolibrary.org/obo/BFO_0000001> rdf:type owl:Class ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000112> "Julius Caesar"@en ,
+                                                                                          "Verdi’s Requiem"@en ,
+                                                                                          "the Second World War"@en ,
+                                                                                          "your body mass index"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000116> "BFO 2 Reference: In all areas of empirical inquiry we encounter general terms of two sorts. First are general terms which refer to universals or types:animaltuberculosissurgical procedurediseaseSecond, are general terms used to refer to groups of entities which instantiate a given universal but do not correspond to the extension of any subuniversal of that universal because there is nothing intrinsic to the entities in question by virtue of which they – and only they – are counted as belonging to the given group. Examples are: animal purchased by the Emperortuberculosis diagnosed on a Wednesdaysurgical procedure performed on a patient from Stockholmperson identified as candidate for clinical trial #2056-555person who is signatory of Form 656-PPVpainting by Leonardo da VinciSuch terms, which represent what are called ‘specializations’ in [81"@en ,
+                                                                                          "Entity doesn't have a closure axiom because the subclasses don't necessarily exhaust all possibilites. For example Werner Ceusters 'portions of reality' include 4 sorts, entities (as BFO construes them), universals, configurations, and relations. It is an open question as to whether entities as construed in BFO will at some point also include these other portions of reality. See, for example, 'How to track absolutely everything' at http://www.referent-tracking.com/_RTU/papers/CeustersICbookRevised.pdf"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000600> "An entity is anything that exists or has existed or will exist. (axiom label in BFO2 Reference: [001-001])"@en ;
+                                             rdfs:comment "per discussion with Barry Smith" ;
+                                             rdfs:isDefinedBy <http://purl.obolibrary.org/obo/bfo.owl> ;
+                                             rdfs:label "entity"@en ;
+                                             rdfs:seeAlso <http://www.referent-tracking.com/_RTU/papers/CeustersICbookRevised.pdf> .
 
 
 ###  http://purl.obolibrary.org/obo/BFO_0000002
-obo:BFO_0000002 rdf:type owl:Class ;
-                rdfs:subClassOf obo:BFO_0000001 ;
-                owl:disjointWith obo:BFO_0000003 ;
-                obo:IAO_0000116 "BFO 2 Reference: Continuant entities are entities which can be sliced to yield parts only along the spatial dimension, yielding for example the parts of your table which we call its legs, its top, its nails. ‘My desk stretches from the window to the door. It has spatial parts, and can be sliced (in space) in two. With respect to time, however, a thing is a continuant.’ [60, p. 240"@en ,
-                                "Continuant doesn't have a closure axiom because the subclasses don't necessarily exhaust all possibilites. For example, in an expansion involving bringing in some of Ceuster's other portions of reality, questions are raised as to whether universals are continuants"@en ;
-                obo:IAO_0000412 "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
-                obo:IAO_0000600 "A continuant is an entity that persists, endures, or continues to exist through time while maintaining its identity. (axiom label in BFO2 Reference: [008-002])"@en ;
-                rdfs:isDefinedBy obo:bfo.owl ;
-                rdfs:label "continuant"@en .
+<http://purl.obolibrary.org/obo/BFO_0000002> rdf:type owl:Class ;
+                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/BFO_0000001> ;
+                                             owl:disjointWith <http://purl.obolibrary.org/obo/BFO_0000003> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000116> "BFO 2 Reference: Continuant entities are entities which can be sliced to yield parts only along the spatial dimension, yielding for example the parts of your table which we call its legs, its top, its nails. ‘My desk stretches from the window to the door. It has spatial parts, and can be sliced (in space) in two. With respect to time, however, a thing is a continuant.’ [60, p. 240"@en ,
+                                                                                          "Continuant doesn't have a closure axiom because the subclasses don't necessarily exhaust all possibilites. For example, in an expansion involving bringing in some of Ceuster's other portions of reality, questions are raised as to whether universals are continuants"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000600> "A continuant is an entity that persists, endures, or continues to exist through time while maintaining its identity. (axiom label in BFO2 Reference: [008-002])"@en ;
+                                             rdfs:isDefinedBy <http://purl.obolibrary.org/obo/bfo.owl> ;
+                                             rdfs:label "continuant"@en .
 
 
 ###  http://purl.obolibrary.org/obo/BFO_0000003
-obo:BFO_0000003 rdf:type owl:Class ;
-                rdfs:subClassOf obo:BFO_0000001 ;
-                obo:IAO_0000116 "BFO 2 Reference: every occurrent that is not a temporal or spatiotemporal region is s-dependent on some independent continuant that is not a spatial region"@en ,
-                                "BFO 2 Reference: s-dependence obtains between every process and its participants in the sense that, as a matter of necessity, this process could not have existed unless these or those participants existed also. A process may have a succession of participants at different phases of its unfolding. Thus there may be different players on the field at different times during the course of a football game; but the process which is the entire game s-depends_on all of these players nonetheless. Some temporal parts of this process will s-depend_on on only some of the players."@en ,
-                                "Occurrent doesn't have a closure axiom because the subclasses don't necessarily exhaust all possibilites. An example would be the sum of a process and the process boundary of another process."@en ,
-                                "Simons uses different terminology for relations of occurrents to regions: Denote the spatio-temporal location of a given occurrent e by 'spn[e]' and call this region its span. We may say an occurrent is at its span, in any larger region, and covers any smaller region. Now suppose we have fixed a frame of reference so that we can speak not merely of spatio-temporal but also of spatial regions (places) and temporal regions (times). The spread of an occurrent, (relative to a frame of reference) is the space it exactly occupies, and its spell is likewise the time it exactly occupies. We write 'spr[e]' and `spl[e]' respectively for the spread and spell of e, omitting mention of the frame." ;
-                obo:IAO_0000412 "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
-                obo:IAO_0000600 "An occurrent is an entity that unfolds itself in time or it is the instantaneous boundary of such an entity (for example a beginning or an ending) or it is a temporal or spatiotemporal region which such an entity occupies_temporal_region or occupies_spatiotemporal_region. (axiom label in BFO2 Reference: [077-002])"@en ;
-                rdfs:comment "per discussion with Barry Smith" ;
-                rdfs:isDefinedBy obo:bfo.owl ;
-                rdfs:label "occurrent"@en .
+<http://purl.obolibrary.org/obo/BFO_0000003> rdf:type owl:Class ;
+                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/BFO_0000001> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000116> "BFO 2 Reference: every occurrent that is not a temporal or spatiotemporal region is s-dependent on some independent continuant that is not a spatial region"@en ,
+                                                                                          "BFO 2 Reference: s-dependence obtains between every process and its participants in the sense that, as a matter of necessity, this process could not have existed unless these or those participants existed also. A process may have a succession of participants at different phases of its unfolding. Thus there may be different players on the field at different times during the course of a football game; but the process which is the entire game s-depends_on all of these players nonetheless. Some temporal parts of this process will s-depend_on on only some of the players."@en ,
+                                                                                          "Occurrent doesn't have a closure axiom because the subclasses don't necessarily exhaust all possibilites. An example would be the sum of a process and the process boundary of another process."@en ,
+                                                                                          "Simons uses different terminology for relations of occurrents to regions: Denote the spatio-temporal location of a given occurrent e by 'spn[e]' and call this region its span. We may say an occurrent is at its span, in any larger region, and covers any smaller region. Now suppose we have fixed a frame of reference so that we can speak not merely of spatio-temporal but also of spatial regions (places) and temporal regions (times). The spread of an occurrent, (relative to a frame of reference) is the space it exactly occupies, and its spell is likewise the time it exactly occupies. We write 'spr[e]' and `spl[e]' respectively for the spread and spell of e, omitting mention of the frame." ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000600> "An occurrent is an entity that unfolds itself in time or it is the instantaneous boundary of such an entity (for example a beginning or an ending) or it is a temporal or spatiotemporal region which such an entity occupies_temporal_region or occupies_spatiotemporal_region. (axiom label in BFO2 Reference: [077-002])"@en ;
+                                             rdfs:comment "per discussion with Barry Smith" ;
+                                             rdfs:isDefinedBy <http://purl.obolibrary.org/obo/bfo.owl> ;
+                                             rdfs:label "occurrent"@en .
 
 
 ###  http://purl.obolibrary.org/obo/BFO_0000004
-obo:BFO_0000004 rdf:type owl:Class ;
-                rdfs:subClassOf obo:BFO_0000002 ;
-                obo:IAO_0000112 "a chair"@en ,
-                                "a heart"@en ,
-                                "a leg"@en ,
-                                "a molecule"@en ,
-                                "a spatial region"@en ,
-                                "an atom"@en ,
-                                "an orchestra."@en ,
-                                "an organism"@en ,
-                                "the bottom right portion of a human torso"@en ,
-                                "the interior of your mouth"@en ;
-                obo:IAO_0000115 "b is an independent continuant = Def. b is a continuant which is such that there is no c and no t such that b s-depends_on c at t. (axiom label in BFO2 Reference: [017-002])"@en ;
-                obo:IAO_0000412 "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
-                rdfs:isDefinedBy obo:bfo.owl ;
-                rdfs:label "independent continuant"@en .
+<http://purl.obolibrary.org/obo/BFO_0000004> rdf:type owl:Class ;
+                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/BFO_0000002> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000112> "a chair"@en ,
+                                                                                          "a heart"@en ,
+                                                                                          "a leg"@en ,
+                                                                                          "a molecule"@en ,
+                                                                                          "a spatial region"@en ,
+                                                                                          "an atom"@en ,
+                                                                                          "an orchestra."@en ,
+                                                                                          "an organism"@en ,
+                                                                                          "the bottom right portion of a human torso"@en ,
+                                                                                          "the interior of your mouth"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000115> "b is an independent continuant = Def. b is a continuant which is such that there is no c and no t such that b s-depends_on c at t. (axiom label in BFO2 Reference: [017-002])"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
+                                             rdfs:isDefinedBy <http://purl.obolibrary.org/obo/bfo.owl> ;
+                                             rdfs:label "independent continuant"@en .
 
 
 ###  http://purl.obolibrary.org/obo/BFO_0000006
-obo:BFO_0000006 rdf:type owl:Class ;
-                rdfs:subClassOf obo:BFO_0000141 ;
-                obo:IAO_0000116 "BFO 2 Reference: Spatial regions do not participate in processes."@en ,
-                                "Spatial region doesn't have a closure axiom because the subclasses don't exhaust all possibilites. An example would be the union of a spatial point and a spatial line that doesn't overlap the point, or two spatial lines that intersect at a single point. In both cases the resultant spatial region is neither 0-dimensional, 1-dimensional, 2-dimensional, or 3-dimensional."@en ;
-                obo:IAO_0000412 "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
-                obo:IAO_0000600 "A spatial region is a continuant entity that is a continuant_part_of spaceR as defined relative to some frame R. (axiom label in BFO2 Reference: [035-001])"@en ;
-                rdfs:comment "per discussion with Barry Smith" ;
-                rdfs:isDefinedBy obo:bfo.owl ;
-                rdfs:label "spatial region"@en .
+<http://purl.obolibrary.org/obo/BFO_0000006> rdf:type owl:Class ;
+                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/BFO_0000141> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000116> "BFO 2 Reference: Spatial regions do not participate in processes."@en ,
+                                                                                          "Spatial region doesn't have a closure axiom because the subclasses don't exhaust all possibilites. An example would be the union of a spatial point and a spatial line that doesn't overlap the point, or two spatial lines that intersect at a single point. In both cases the resultant spatial region is neither 0-dimensional, 1-dimensional, 2-dimensional, or 3-dimensional."@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000600> "A spatial region is a continuant entity that is a continuant_part_of spaceR as defined relative to some frame R. (axiom label in BFO2 Reference: [035-001])"@en ;
+                                             rdfs:comment "per discussion with Barry Smith" ;
+                                             rdfs:isDefinedBy <http://purl.obolibrary.org/obo/bfo.owl> ;
+                                             rdfs:label "spatial region"@en .
 
 
 ###  http://purl.obolibrary.org/obo/BFO_0000008
-obo:BFO_0000008 rdf:type owl:Class ;
-                rdfs:subClassOf obo:BFO_0000003 ;
-                obo:IAO_0000116 "Temporal region doesn't have a closure axiom because the subclasses don't exhaust all possibilites. An example would be the mereological sum of a temporal instant and a temporal interval that doesn't overlap the instant. In this case the resultant temporal region is neither 0-dimensional nor 1-dimensional"@en ;
-                obo:IAO_0000412 "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
-                obo:IAO_0000600 "A temporal region is an occurrent entity that is part of time as defined relative to some reference frame. (axiom label in BFO2 Reference: [100-001])"@en ;
-                rdfs:comment "per discussion with Barry Smith" ;
-                rdfs:isDefinedBy obo:bfo.owl ;
-                rdfs:label "temporal region"@en .
+<http://purl.obolibrary.org/obo/BFO_0000008> rdf:type owl:Class ;
+                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/BFO_0000003> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000116> "Temporal region doesn't have a closure axiom because the subclasses don't exhaust all possibilites. An example would be the mereological sum of a temporal instant and a temporal interval that doesn't overlap the instant. In this case the resultant temporal region is neither 0-dimensional nor 1-dimensional"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000600> "A temporal region is an occurrent entity that is part of time as defined relative to some reference frame. (axiom label in BFO2 Reference: [100-001])"@en ;
+                                             rdfs:comment "per discussion with Barry Smith" ;
+                                             rdfs:isDefinedBy <http://purl.obolibrary.org/obo/bfo.owl> ;
+                                             rdfs:label "temporal region"@en .
 
 
 ###  http://purl.obolibrary.org/obo/BFO_0000011
-obo:BFO_0000011 rdf:type owl:Class ;
-                rdfs:subClassOf obo:BFO_0000003 ;
-                obo:IAO_0000112 "the spatiotemporal region occupied by a human life"@en ,
-                                "the spatiotemporal region occupied by a process of cellular meiosis."@en ,
-                                "the spatiotemporal region occupied by the development of a cancer tumor"@en ;
-                obo:IAO_0000412 "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
-                obo:IAO_0000600 "A spatiotemporal region is an occurrent entity that is part of spacetime. (axiom label in BFO2 Reference: [095-001])"@en ;
-                rdfs:isDefinedBy obo:bfo.owl ;
-                rdfs:label "spatiotemporal region"@en .
+<http://purl.obolibrary.org/obo/BFO_0000011> rdf:type owl:Class ;
+                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/BFO_0000003> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000112> "the spatiotemporal region occupied by a human life"@en ,
+                                                                                          "the spatiotemporal region occupied by a process of cellular meiosis."@en ,
+                                                                                          "the spatiotemporal region occupied by the development of a cancer tumor"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000600> "A spatiotemporal region is an occurrent entity that is part of spacetime. (axiom label in BFO2 Reference: [095-001])"@en ;
+                                             rdfs:isDefinedBy <http://purl.obolibrary.org/obo/bfo.owl> ;
+                                             rdfs:label "spatiotemporal region"@en .
 
 
 ###  http://purl.obolibrary.org/obo/BFO_0000015
-obo:BFO_0000015 rdf:type owl:Class ;
-                rdfs:subClassOf obo:BFO_0000003 ,
-                                [ rdf:type owl:Restriction ;
-                                  owl:onProperty obo:RO_0002012 ;
-                                  owl:allValuesFrom obo:BFO_0000015
-                                ] ;
-                obo:IAO_0000112 "a process of cell-division, \\ a beating of the heart"@en ,
-                                "a process of meiosis"@en ,
-                                "a process of sleeping"@en ,
-                                "the course of a disease"@en ,
-                                "the flight of a bird"@en ,
-                                "the life of an organism"@en ,
-                                "your process of aging."@en ;
-                obo:IAO_0000115 "p is a process = Def. p is an occurrent that has temporal proper parts and for some time t, p s-depends_on some material entity at t. (axiom label in BFO2 Reference: [083-003])"@en ;
-                obo:IAO_0000116 "BFO 2 Reference: The realm of occurrents is less pervasively marked by the presence of natural units than is the case in the realm of independent continuants. Thus there is here no counterpart of ‘object’. In BFO 1.0 ‘process’ served as such a counterpart. In BFO 2.0 ‘process’ is, rather, the occurrent counterpart of ‘material entity’. Those natural – as contrasted with engineered, which here means: deliberately executed – units which do exist in the realm of occurrents are typically either parasitic on the existence of natural units on the continuant side, or they are fiat in nature. Thus we can count lives; we can count football games; we can count chemical reactions performed in experiments or in chemical manufacturing. We cannot count the processes taking place, for instance, in an episode of insect mating behavior.Even where natural units are identifiable, for example cycles in a cyclical process such as the beating of a heart or an organism’s sleep/wake cycle, the processes in question form a sequence with no discontinuities (temporal gaps) of the sort that we find for instance where billiard balls or zebrafish or planets are separated by clear spatial gaps. Lives of organisms are process units, but they too unfold in a continuous series from other, prior processes such as fertilization, and they unfold in turn in continuous series of post-life processes such as post-mortem decay. Clear examples of boundaries of processes are almost always of the fiat sort (midnight, a time of death as declared in an operating theater or on a death certificate, the initiation of a state of war)"@en ;
-                obo:IAO_0000412 "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
-                rdfs:isDefinedBy obo:bfo.owl ;
-                rdfs:label "process"@en .
+<http://purl.obolibrary.org/obo/BFO_0000015> rdf:type owl:Class ;
+                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/BFO_0000003> ,
+                                                             [ rdf:type owl:Restriction ;
+                                                               owl:onProperty <http://purl.obolibrary.org/obo/RO_0002012> ;
+                                                               owl:allValuesFrom <http://purl.obolibrary.org/obo/BFO_0000015>
+                                                             ] ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000112> "a process of cell-division, \\ a beating of the heart"@en ,
+                                                                                          "a process of meiosis"@en ,
+                                                                                          "a process of sleeping"@en ,
+                                                                                          "the course of a disease"@en ,
+                                                                                          "the flight of a bird"@en ,
+                                                                                          "the life of an organism"@en ,
+                                                                                          "your process of aging."@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000115> "p is a process = Def. p is an occurrent that has temporal proper parts and for some time t, p s-depends_on some material entity at t. (axiom label in BFO2 Reference: [083-003])"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000116> "BFO 2 Reference: The realm of occurrents is less pervasively marked by the presence of natural units than is the case in the realm of independent continuants. Thus there is here no counterpart of ‘object’. In BFO 1.0 ‘process’ served as such a counterpart. In BFO 2.0 ‘process’ is, rather, the occurrent counterpart of ‘material entity’. Those natural – as contrasted with engineered, which here means: deliberately executed – units which do exist in the realm of occurrents are typically either parasitic on the existence of natural units on the continuant side, or they are fiat in nature. Thus we can count lives; we can count football games; we can count chemical reactions performed in experiments or in chemical manufacturing. We cannot count the processes taking place, for instance, in an episode of insect mating behavior.Even where natural units are identifiable, for example cycles in a cyclical process such as the beating of a heart or an organism’s sleep/wake cycle, the processes in question form a sequence with no discontinuities (temporal gaps) of the sort that we find for instance where billiard balls or zebrafish or planets are separated by clear spatial gaps. Lives of organisms are process units, but they too unfold in a continuous series from other, prior processes such as fertilization, and they unfold in turn in continuous series of post-life processes such as post-mortem decay. Clear examples of boundaries of processes are almost always of the fiat sort (midnight, a time of death as declared in an operating theater or on a death certificate, the initiation of a state of war)"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
+                                             rdfs:isDefinedBy <http://purl.obolibrary.org/obo/bfo.owl> ;
+                                             rdfs:label "process"@en .
 
 
 ###  http://purl.obolibrary.org/obo/BFO_0000016
-obo:BFO_0000016 rdf:type owl:Class ;
-                rdfs:subClassOf obo:BFO_0000017 ;
-                obo:IAO_0000112 "an atom of element X has the disposition to decay to an atom of element Y"@en ,
-                                "certain people have a predisposition to colon cancer"@en ,
-                                "children are innately disposed to categorize objects in certain ways."@en ,
-                                "the cell wall is disposed to filter chemicals in endocytosis and exocytosis"@en ;
-                obo:IAO_0000116 "BFO 2 Reference: Dispositions exist along a strength continuum. Weaker forms of disposition are realized in only a fraction of triggering cases. These forms occur in a significant number of cases of a similar type."@en ;
-                obo:IAO_0000412 "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
-                obo:IAO_0000600 "b is a disposition means: b is a realizable entity & b’s bearer is some material entity & b is such that if it ceases to exist, then its bearer is physically changed, & b’s realization occurs when and because this bearer is in some special physical circumstances, & this realization occurs in virtue of the bearer’s physical make-up. (axiom label in BFO2 Reference: [062-002])"@en ;
-                rdfs:isDefinedBy obo:bfo.owl ;
-                rdfs:label "disposition"@en .
+<http://purl.obolibrary.org/obo/BFO_0000016> rdf:type owl:Class ;
+                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/BFO_0000017> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000112> "an atom of element X has the disposition to decay to an atom of element Y"@en ,
+                                                                                          "certain people have a predisposition to colon cancer"@en ,
+                                                                                          "children are innately disposed to categorize objects in certain ways."@en ,
+                                                                                          "the cell wall is disposed to filter chemicals in endocytosis and exocytosis"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000116> "BFO 2 Reference: Dispositions exist along a strength continuum. Weaker forms of disposition are realized in only a fraction of triggering cases. These forms occur in a significant number of cases of a similar type."@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000600> "b is a disposition means: b is a realizable entity & b’s bearer is some material entity & b is such that if it ceases to exist, then its bearer is physically changed, & b’s realization occurs when and because this bearer is in some special physical circumstances, & this realization occurs in virtue of the bearer’s physical make-up. (axiom label in BFO2 Reference: [062-002])"@en ;
+                                             rdfs:isDefinedBy <http://purl.obolibrary.org/obo/bfo.owl> ;
+                                             rdfs:label "disposition"@en .
 
 
 ###  http://purl.obolibrary.org/obo/BFO_0000017
-obo:BFO_0000017 rdf:type owl:Class ;
-                rdfs:subClassOf obo:BFO_0000020 ;
-                obo:IAO_0000112 "the disposition of this piece of metal to conduct electricity."@en ,
-                                "the disposition of your blood to coagulate"@en ,
-                                "the function of your reproductive organs"@en ,
-                                "the role of being a doctor"@en ,
-                                "the role of this boundary to delineate where Utah and Colorado meet"@en ;
-                obo:IAO_0000412 "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
-                obo:IAO_0000600 "To say that b is a realizable entity is to say that b is a specifically dependent continuant that inheres in some independent continuant which is not a spatial region and is of a type instances of which are realized in processes of a correlated type. (axiom label in BFO2 Reference: [058-002])"@en ;
-                rdfs:isDefinedBy obo:bfo.owl ;
-                rdfs:label "realizable entity"@en .
+<http://purl.obolibrary.org/obo/BFO_0000017> rdf:type owl:Class ;
+                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/BFO_0000020> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000112> "the disposition of this piece of metal to conduct electricity."@en ,
+                                                                                          "the disposition of your blood to coagulate"@en ,
+                                                                                          "the function of your reproductive organs"@en ,
+                                                                                          "the role of being a doctor"@en ,
+                                                                                          "the role of this boundary to delineate where Utah and Colorado meet"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000600> "To say that b is a realizable entity is to say that b is a specifically dependent continuant that inheres in some independent continuant which is not a spatial region and is of a type instances of which are realized in processes of a correlated type. (axiom label in BFO2 Reference: [058-002])"@en ;
+                                             rdfs:isDefinedBy <http://purl.obolibrary.org/obo/bfo.owl> ;
+                                             rdfs:label "realizable entity"@en .
 
 
 ###  http://purl.obolibrary.org/obo/BFO_0000020
-obo:BFO_0000020 rdf:type owl:Class ;
-                rdfs:subClassOf obo:BFO_0000002 ;
-                obo:IAO_0000112 "Reciprocal specifically dependent continuants: the function of this key to open this lock and the mutually dependent disposition of this lock: to be opened by this key"@en ,
-                                "of one-sided specifically dependent continuants: the mass of this tomato"@en ,
-                                "of relational dependent continuants (multiple bearers): John’s love for Mary, the ownership relation between John and this statue, the relation of authority between John and his subordinates."@en ,
-                                "the disposition of this fish to decay"@en ,
-                                "the function of this heart: to pump blood"@en ,
-                                "the mutual dependence of proton donors and acceptors in chemical reactions [79"@en ,
-                                "the mutual dependence of the role predator and the role prey as played by two organisms in a given interaction"@en ,
-                                "the pink color of a medium rare piece of grilled filet mignon at its center"@en ,
-                                "the role of being a doctor"@en ,
-                                "the shape of this hole."@en ,
-                                "the smell of this portion of mozzarella"@en ;
-                obo:IAO_0000115 "b is a specifically dependent continuant = Def. b is a continuant & there is some independent continuant c which is not a spatial region and which is such that b s-depends_on c at every time t during the course of b’s existence. (axiom label in BFO2 Reference: [050-003])"@en ;
-                obo:IAO_0000116 "Specifically dependent continuant doesn't have a closure axiom because the subclasses don't necessarily exhaust all possibilites. We're not sure what else will develop here, but for example there are questions such as what are promises, obligation, etc."@en ;
-                obo:IAO_0000412 "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
-                rdfs:comment "per discussion with Barry Smith" ;
-                rdfs:isDefinedBy obo:bfo.owl ;
-                rdfs:label "specifically dependent continuant"@en .
+<http://purl.obolibrary.org/obo/BFO_0000020> rdf:type owl:Class ;
+                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/BFO_0000002> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000112> "Reciprocal specifically dependent continuants: the function of this key to open this lock and the mutually dependent disposition of this lock: to be opened by this key"@en ,
+                                                                                          "of one-sided specifically dependent continuants: the mass of this tomato"@en ,
+                                                                                          "of relational dependent continuants (multiple bearers): John’s love for Mary, the ownership relation between John and this statue, the relation of authority between John and his subordinates."@en ,
+                                                                                          "the disposition of this fish to decay"@en ,
+                                                                                          "the function of this heart: to pump blood"@en ,
+                                                                                          "the mutual dependence of proton donors and acceptors in chemical reactions [79"@en ,
+                                                                                          "the mutual dependence of the role predator and the role prey as played by two organisms in a given interaction"@en ,
+                                                                                          "the pink color of a medium rare piece of grilled filet mignon at its center"@en ,
+                                                                                          "the role of being a doctor"@en ,
+                                                                                          "the shape of this hole."@en ,
+                                                                                          "the smell of this portion of mozzarella"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000115> "b is a specifically dependent continuant = Def. b is a continuant & there is some independent continuant c which is not a spatial region and which is such that b s-depends_on c at every time t during the course of b’s existence. (axiom label in BFO2 Reference: [050-003])"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000116> "Specifically dependent continuant doesn't have a closure axiom because the subclasses don't necessarily exhaust all possibilites. We're not sure what else will develop here, but for example there are questions such as what are promises, obligation, etc."@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
+                                             rdfs:comment "per discussion with Barry Smith" ;
+                                             rdfs:isDefinedBy <http://purl.obolibrary.org/obo/bfo.owl> ;
+                                             rdfs:label "specifically dependent continuant"@en .
 
 
 ###  http://purl.obolibrary.org/obo/BFO_0000023
-obo:BFO_0000023 rdf:type owl:Class ;
-                rdfs:subClassOf obo:BFO_0000017 ;
-                obo:IAO_0000112 "John’s role of husband to Mary is dependent on Mary’s role of wife to John, and both are dependent on the object aggregate comprising John and Mary as member parts joined together through the relational quality of being married."@en ,
-                                "the priest role"@en ,
-                                "the role of a boundary to demarcate two neighboring administrative territories"@en ,
-                                "the role of a building in serving as a military target"@en ,
-                                "the role of a stone in marking a property boundary"@en ,
-                                "the role of subject in a clinical trial"@en ,
-                                "the student role"@en ;
-                obo:IAO_0000116 "BFO 2 Reference: One major family of examples of non-rigid universals involves roles, and ontologies developed for corresponding administrative purposes may consist entirely of representatives of entities of this sort. Thus ‘professor’, defined as follows,b instance_of professor at t =Def. there is some c, c instance_of professor role & c inheres_in b at t.denotes a non-rigid universal and so also do ‘nurse’, ‘student’, ‘colonel’, ‘taxpayer’, and so forth. (These terms are all, in the jargon of philosophy, phase sortals.) By using role terms in definitions, we can create a BFO conformant treatment of such entities drawing on the fact that, while an instance of professor may be simultaneously an instance of trade union member, no instance of the type professor role is also (at any time) an instance of the type trade union member role (any more than any instance of the type color is at any time an instance of the type length).If an ontology of employment positions should be defined in terms of roles following the above pattern, this enables the ontology to do justice to the fact that individuals instantiate the corresponding universals –  professor, sergeant, nurse – only during certain phases in their lives."@en ;
-                obo:IAO_0000412 "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
-                obo:IAO_0000600 "b is a role means: b is a realizable entity & b exists because there is some single bearer that is in some special physical, social, or institutional set of circumstances in which this bearer does not have to be& b is not such that, if it ceases to exist, then the physical make-up of the bearer is thereby changed. (axiom label in BFO2 Reference: [061-001])"@en ;
-                rdfs:isDefinedBy obo:bfo.owl ;
-                rdfs:label "role"@en .
+<http://purl.obolibrary.org/obo/BFO_0000023> rdf:type owl:Class ;
+                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/BFO_0000017> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000112> "John’s role of husband to Mary is dependent on Mary’s role of wife to John, and both are dependent on the object aggregate comprising John and Mary as member parts joined together through the relational quality of being married."@en ,
+                                                                                          "the priest role"@en ,
+                                                                                          "the role of a boundary to demarcate two neighboring administrative territories"@en ,
+                                                                                          "the role of a building in serving as a military target"@en ,
+                                                                                          "the role of a stone in marking a property boundary"@en ,
+                                                                                          "the role of subject in a clinical trial"@en ,
+                                                                                          "the student role"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000116> "BFO 2 Reference: One major family of examples of non-rigid universals involves roles, and ontologies developed for corresponding administrative purposes may consist entirely of representatives of entities of this sort. Thus ‘professor’, defined as follows,b instance_of professor at t =Def. there is some c, c instance_of professor role & c inheres_in b at t.denotes a non-rigid universal and so also do ‘nurse’, ‘student’, ‘colonel’, ‘taxpayer’, and so forth. (These terms are all, in the jargon of philosophy, phase sortals.) By using role terms in definitions, we can create a BFO conformant treatment of such entities drawing on the fact that, while an instance of professor may be simultaneously an instance of trade union member, no instance of the type professor role is also (at any time) an instance of the type trade union member role (any more than any instance of the type color is at any time an instance of the type length).If an ontology of employment positions should be defined in terms of roles following the above pattern, this enables the ontology to do justice to the fact that individuals instantiate the corresponding universals –  professor, sergeant, nurse – only during certain phases in their lives."@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000600> "b is a role means: b is a realizable entity & b exists because there is some single bearer that is in some special physical, social, or institutional set of circumstances in which this bearer does not have to be& b is not such that, if it ceases to exist, then the physical make-up of the bearer is thereby changed. (axiom label in BFO2 Reference: [061-001])"@en ;
+                                             rdfs:isDefinedBy <http://purl.obolibrary.org/obo/bfo.owl> ;
+                                             rdfs:label "role"@en .
 
 
 ###  http://purl.obolibrary.org/obo/BFO_0000027
-obo:BFO_0000027 rdf:type owl:Class ;
-                rdfs:subClassOf obo:BFO_0000040 ;
-                obo:IAO_0000112 "a collection of cells in a blood biobank."@en ,
-                                "a swarm of bees is an aggregate of members who are linked together through natural bonds"@en ,
-                                "a symphony orchestra"@en ,
-                                "an organization is an aggregate whose member parts have roles of specific types (for example in a jazz band, a chess club, a football team)"@en ,
-                                "defined by fiat: the aggregate of members of an organization"@en ,
-                                "defined through physical attachment: the aggregate of atoms in a lump of granite"@en ,
-                                "defined through physical containment: the aggregate of molecules of carbon dioxide in a sealed container"@en ,
-                                "defined via attributive delimitations such as: the patients in this hospital"@en ,
-                                "the aggregate of bearings in a constant velocity axle joint"@en ,
-                                "the aggregate of blood cells in your body"@en ,
-                                "the nitrogen atoms in the atmosphere"@en ,
-                                "the restaurants in Palo Alto"@en ,
-                                "your collection of Meissen ceramic plates."@en ;
-                obo:IAO_0000116 "An entity a is an object aggregate if and only if there is a mutually exhaustive and pairwise disjoint partition of a into objects " ,
-                                "BFO 2 Reference: object aggregates may gain and lose parts while remaining numerically identical (one and the same individual) over time. This holds both for aggregates whose membership is determined naturally (the aggregate of cells in your body) and aggregates determined by fiat (a baseball team, a congressional committee)."@en ;
-                obo:IAO_0000119 "ISBN:978-3-938793-98-5pp124-158#Thomas Bittner and Barry Smith, 'A Theory of Granular Partitions', in K. Munn and B. Smith (eds.), Applied Ontology: An Introduction, Frankfurt/Lancaster: ontos, 2008, 125-158." ;
-                obo:IAO_0000412 "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
-                obo:IAO_0000600 "b is an object aggregate means: b is a material entity consisting exactly of a plurality of objects as member_parts at all times at which b exists. (axiom label in BFO2 Reference: [025-004])"@en ;
-                rdfs:isDefinedBy obo:bfo.owl ;
-                rdfs:label "object aggregate"@en .
+<http://purl.obolibrary.org/obo/BFO_0000027> rdf:type owl:Class ;
+                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/BFO_0000040> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000112> "a collection of cells in a blood biobank."@en ,
+                                                                                          "a swarm of bees is an aggregate of members who are linked together through natural bonds"@en ,
+                                                                                          "a symphony orchestra"@en ,
+                                                                                          "an organization is an aggregate whose member parts have roles of specific types (for example in a jazz band, a chess club, a football team)"@en ,
+                                                                                          "defined by fiat: the aggregate of members of an organization"@en ,
+                                                                                          "defined through physical attachment: the aggregate of atoms in a lump of granite"@en ,
+                                                                                          "defined through physical containment: the aggregate of molecules of carbon dioxide in a sealed container"@en ,
+                                                                                          "defined via attributive delimitations such as: the patients in this hospital"@en ,
+                                                                                          "the aggregate of bearings in a constant velocity axle joint"@en ,
+                                                                                          "the aggregate of blood cells in your body"@en ,
+                                                                                          "the nitrogen atoms in the atmosphere"@en ,
+                                                                                          "the restaurants in Palo Alto"@en ,
+                                                                                          "your collection of Meissen ceramic plates."@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000116> "An entity a is an object aggregate if and only if there is a mutually exhaustive and pairwise disjoint partition of a into objects " ,
+                                                                                          "BFO 2 Reference: object aggregates may gain and lose parts while remaining numerically identical (one and the same individual) over time. This holds both for aggregates whose membership is determined naturally (the aggregate of cells in your body) and aggregates determined by fiat (a baseball team, a congressional committee)."@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000119> "ISBN:978-3-938793-98-5pp124-158#Thomas Bittner and Barry Smith, 'A Theory of Granular Partitions', in K. Munn and B. Smith (eds.), Applied Ontology: An Introduction, Frankfurt/Lancaster: ontos, 2008, 125-158." ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000600> "b is an object aggregate means: b is a material entity consisting exactly of a plurality of objects as member_parts at all times at which b exists. (axiom label in BFO2 Reference: [025-004])"@en ;
+                                             rdfs:isDefinedBy <http://purl.obolibrary.org/obo/bfo.owl> ;
+                                             rdfs:label "object aggregate"@en .
 
 
 ###  http://purl.obolibrary.org/obo/BFO_0000029
-obo:BFO_0000029 rdf:type owl:Class ;
-                rdfs:subClassOf obo:BFO_0000141 ;
-                obo:IAO_0000112 "Manhattan Canyon)"@en ,
-                                "a hole in the interior of a portion of cheese"@en ,
-                                "a rabbit hole"@en ,
-                                "an air traffic control region defined in the airspace above an airport"@en ,
-                                "the Grand Canyon"@en ,
-                                "the Piazza San Marco"@en ,
-                                "the cockpit of an aircraft"@en ,
-                                "the hold of a ship"@en ,
-                                "the interior of a kangaroo pouch"@en ,
-                                "the interior of the trunk of your car"@en ,
-                                "the interior of your bedroom"@en ,
-                                "the interior of your office"@en ,
-                                "the interior of your refrigerator"@en ,
-                                "the lumen of your gut"@en ,
-                                "your left nostril (a fiat part – the opening – of your left nasal cavity)"@en ;
-                obo:IAO_0000412 "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
-                obo:IAO_0000600 "b is a site means: b is a three-dimensional immaterial entity that is (partially or wholly) bounded by a material entity or it is a three-dimensional immaterial part thereof. (axiom label in BFO2 Reference: [034-002])"@en ;
-                rdfs:isDefinedBy obo:bfo.owl ;
-                rdfs:label "site"@en .
+<http://purl.obolibrary.org/obo/BFO_0000029> rdf:type owl:Class ;
+                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/BFO_0000141> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000112> "Manhattan Canyon)"@en ,
+                                                                                          "a hole in the interior of a portion of cheese"@en ,
+                                                                                          "a rabbit hole"@en ,
+                                                                                          "an air traffic control region defined in the airspace above an airport"@en ,
+                                                                                          "the Grand Canyon"@en ,
+                                                                                          "the Piazza San Marco"@en ,
+                                                                                          "the cockpit of an aircraft"@en ,
+                                                                                          "the hold of a ship"@en ,
+                                                                                          "the interior of a kangaroo pouch"@en ,
+                                                                                          "the interior of the trunk of your car"@en ,
+                                                                                          "the interior of your bedroom"@en ,
+                                                                                          "the interior of your office"@en ,
+                                                                                          "the interior of your refrigerator"@en ,
+                                                                                          "the lumen of your gut"@en ,
+                                                                                          "your left nostril (a fiat part – the opening – of your left nasal cavity)"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000600> "b is a site means: b is a three-dimensional immaterial entity that is (partially or wholly) bounded by a material entity or it is a three-dimensional immaterial part thereof. (axiom label in BFO2 Reference: [034-002])"@en ;
+                                             rdfs:isDefinedBy <http://purl.obolibrary.org/obo/bfo.owl> ;
+                                             rdfs:label "site"@en .
 
 
 ###  http://purl.obolibrary.org/obo/BFO_0000030
-obo:BFO_0000030 rdf:type owl:Class ;
-                rdfs:subClassOf obo:BFO_0000040 ;
-                obo:IAO_0000112 "atom"@en ,
-                                "cell"@en ,
-                                "cells and organisms"@en ,
-                                "engineered artifacts"@en ,
-                                "grain of sand"@en ,
-                                "molecule"@en ,
-                                "organelle"@en ,
-                                "organism"@en ,
-                                "planet"@en ,
-                                "solid portions of matter"@en ,
-                                "star"@en ;
-                obo:IAO_0000116 "BFO 2 Reference: BFO rests on the presupposition that at multiple micro-, meso- and macroscopic scales reality exhibits certain stable, spatially separated or separable material units, combined or combinable into aggregates of various sorts (for example organisms into what are called ‘populations’). Such units play a central role in almost all domains of natural science from particle physics to cosmology. Many scientific laws govern the units in question, employing general terms (such as ‘molecule’ or ‘planet’) referring to the types and subtypes of units, and also to the types and subtypes of the processes through which such units develop and interact. The division of reality into such natural units is at the heart of biological science, as also is the fact that these units may form higher-level units (as cells form multicellular organisms) and that they may also form aggregates of units, for example as cells form portions of tissue and organs form families, herds, breeds, species, and so on. At the same time, the division of certain portions of reality into engineered units (manufactured artifacts) is the basis of modern industrial technology, which rests on the distributed mass production of engineered parts through division of labor and on their assembly into larger, compound units such as cars and laptops. The division of portions of reality into units is one starting point for the phenomenon of counting."@en ,
-                                "BFO 2 Reference: Each object is such that there are entities of which we can assert unproblematically that they lie in its interior, and other entities of which we can assert unproblematically that they lie in its exterior. This may not be so for entities lying at or near the boundary between the interior and exterior. This means that two objects – for example the two cells depicted in Figure 3 – may be such that there are material entities crossing their boundaries which belong determinately to neither cell. Something similar obtains in certain cases of conjoined twins (see below)."@en ,
-                                "BFO 2 Reference: To say that b is causally unified means: b is a material entity which is such that its material parts are tied together in such a way that, in environments typical for entities of the type in question,if c, a continuant part of b that is in the interior of b at t, is larger than a certain threshold size (which will be determined differently from case to case, depending on factors such as porosity of external cover) and is moved in space to be at t at a location on the exterior of the spatial region that had been occupied by b at t, then either b’s other parts will be moved in coordinated fashion or b will be damaged (be affected, for example, by breakage or tearing) in the interval between t and t.causal changes in one part of b can have consequences for other parts of b without the mediation of any entity that lies on the exterior of b. Material entities with no proper material parts would satisfy these conditions trivially. Candidate examples of types of causal unity for material entities of more complex sorts are as follows (this is not intended to be an exhaustive list):CU1: Causal unity via physical coveringHere the parts in the interior of the unified entity are combined together causally through a common membrane or other physical covering\\. The latter points outwards toward and may serve a protective function in relation to what lies on the exterior of the entity [13, 47"@en ,
-                                "BFO 2 Reference: an object is a maximal causally unified material entity"@en ,
-                                "BFO 2 Reference: ‘objects’ are sometimes referred to as ‘grains’ [74"@en ;
-                obo:IAO_0000412 "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
-                obo:IAO_0000600 "b is an object means: b is a material entity which manifests causal unity of one or other of the types CUn listed above & is of a type (a material universal) instances of which are maximal relative to this criterion of causal unity. (axiom label in BFO2 Reference: [024-001])"@en ;
-                rdfs:isDefinedBy obo:bfo.owl ;
-                rdfs:label "object"@en .
+<http://purl.obolibrary.org/obo/BFO_0000030> rdf:type owl:Class ;
+                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/BFO_0000040> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000112> "atom"@en ,
+                                                                                          "cell"@en ,
+                                                                                          "cells and organisms"@en ,
+                                                                                          "engineered artifacts"@en ,
+                                                                                          "grain of sand"@en ,
+                                                                                          "molecule"@en ,
+                                                                                          "organelle"@en ,
+                                                                                          "organism"@en ,
+                                                                                          "planet"@en ,
+                                                                                          "solid portions of matter"@en ,
+                                                                                          "star"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000116> "BFO 2 Reference: BFO rests on the presupposition that at multiple micro-, meso- and macroscopic scales reality exhibits certain stable, spatially separated or separable material units, combined or combinable into aggregates of various sorts (for example organisms into what are called ‘populations’). Such units play a central role in almost all domains of natural science from particle physics to cosmology. Many scientific laws govern the units in question, employing general terms (such as ‘molecule’ or ‘planet’) referring to the types and subtypes of units, and also to the types and subtypes of the processes through which such units develop and interact. The division of reality into such natural units is at the heart of biological science, as also is the fact that these units may form higher-level units (as cells form multicellular organisms) and that they may also form aggregates of units, for example as cells form portions of tissue and organs form families, herds, breeds, species, and so on. At the same time, the division of certain portions of reality into engineered units (manufactured artifacts) is the basis of modern industrial technology, which rests on the distributed mass production of engineered parts through division of labor and on their assembly into larger, compound units such as cars and laptops. The division of portions of reality into units is one starting point for the phenomenon of counting."@en ,
+                                                                                          "BFO 2 Reference: Each object is such that there are entities of which we can assert unproblematically that they lie in its interior, and other entities of which we can assert unproblematically that they lie in its exterior. This may not be so for entities lying at or near the boundary between the interior and exterior. This means that two objects – for example the two cells depicted in Figure 3 – may be such that there are material entities crossing their boundaries which belong determinately to neither cell. Something similar obtains in certain cases of conjoined twins (see below)."@en ,
+                                                                                          "BFO 2 Reference: To say that b is causally unified means: b is a material entity which is such that its material parts are tied together in such a way that, in environments typical for entities of the type in question,if c, a continuant part of b that is in the interior of b at t, is larger than a certain threshold size (which will be determined differently from case to case, depending on factors such as porosity of external cover) and is moved in space to be at t at a location on the exterior of the spatial region that had been occupied by b at t, then either b’s other parts will be moved in coordinated fashion or b will be damaged (be affected, for example, by breakage or tearing) in the interval between t and t.causal changes in one part of b can have consequences for other parts of b without the mediation of any entity that lies on the exterior of b. Material entities with no proper material parts would satisfy these conditions trivially. Candidate examples of types of causal unity for material entities of more complex sorts are as follows (this is not intended to be an exhaustive list):CU1: Causal unity via physical coveringHere the parts in the interior of the unified entity are combined together causally through a common membrane or other physical covering\\. The latter points outwards toward and may serve a protective function in relation to what lies on the exterior of the entity [13, 47"@en ,
+                                                                                          "BFO 2 Reference: an object is a maximal causally unified material entity"@en ,
+                                                                                          "BFO 2 Reference: ‘objects’ are sometimes referred to as ‘grains’ [74"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000600> "b is an object means: b is a material entity which manifests causal unity of one or other of the types CUn listed above & is of a type (a material universal) instances of which are maximal relative to this criterion of causal unity. (axiom label in BFO2 Reference: [024-001])"@en ;
+                                             rdfs:isDefinedBy <http://purl.obolibrary.org/obo/bfo.owl> ;
+                                             rdfs:label "object"@en .
 
 
 ###  http://purl.obolibrary.org/obo/BFO_0000031
-obo:BFO_0000031 rdf:type owl:Class ;
-                rdfs:subClassOf obo:BFO_0000002 ;
-                obo:IAO_0000112 "The entries in your database are patterns instantiated as quality instances in your hard drive. The database itself is an aggregate of such patterns. When you create the database you create a particular instance of the generically dependent continuant type database. Each entry in the database is an instance of the generically dependent continuant type IAO: information content entity."@en ,
-                                "the pdf file on your laptop, the pdf file that is a copy thereof on my laptop"@en ,
-                                "the sequence of this protein molecule; the sequence that is a copy thereof in that protein molecule."@en ;
-                obo:IAO_0000115 "b is a generically dependent continuant = Def. b is a continuant that g-depends_on one or more other entities. (axiom label in BFO2 Reference: [074-001])"@en ;
-                obo:IAO_0000412 "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
-                rdfs:isDefinedBy obo:bfo.owl ;
-                rdfs:label "generically dependent continuant"@en .
+<http://purl.obolibrary.org/obo/BFO_0000031> rdf:type owl:Class ;
+                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/BFO_0000002> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000112> "The entries in your database are patterns instantiated as quality instances in your hard drive. The database itself is an aggregate of such patterns. When you create the database you create a particular instance of the generically dependent continuant type database. Each entry in the database is an instance of the generically dependent continuant type IAO: information content entity."@en ,
+                                                                                          "the pdf file on your laptop, the pdf file that is a copy thereof on my laptop"@en ,
+                                                                                          "the sequence of this protein molecule; the sequence that is a copy thereof in that protein molecule."@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000115> "b is a generically dependent continuant = Def. b is a continuant that g-depends_on one or more other entities. (axiom label in BFO2 Reference: [074-001])"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
+                                             rdfs:isDefinedBy <http://purl.obolibrary.org/obo/bfo.owl> ;
+                                             rdfs:label "generically dependent continuant"@en .
 
 
 ###  http://purl.obolibrary.org/obo/BFO_0000034
-obo:BFO_0000034 rdf:type owl:Class ;
-                rdfs:subClassOf obo:BFO_0000016 ;
-                obo:IAO_0000112 "the function of a hammer to drive in nails"@en ,
-                                "the function of a heart pacemaker to regulate the beating of a heart through electricity"@en ,
-                                "the function of amylase in saliva to break down starch into sugar"@en ;
-                obo:IAO_0000116 "BFO 2 Reference: In the past, we have distinguished two varieties of function, artifactual function and biological function. These are not asserted subtypes of BFO:function however, since the same function – for example: to pump, to transport – can exist both in artifacts and in biological entities. The asserted subtypes of function that would be needed in order to yield a separate monoheirarchy are not artifactual function, biological function, etc., but rather transporting function, pumping function, etc."@en ;
-                obo:IAO_0000412 "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
-                obo:IAO_0000600 "A function is a disposition that exists in virtue of the bearer’s physical make-up and this physical make-up is something the bearer possesses because it came into being, either through evolution (in the case of natural biological entities) or through intentional design (in the case of artifacts), in order to realize processes of a certain sort. (axiom label in BFO2 Reference: [064-001])"@en ;
-                rdfs:isDefinedBy obo:bfo.owl ;
-                rdfs:label "function"@en .
+<http://purl.obolibrary.org/obo/BFO_0000034> rdf:type owl:Class ;
+                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/BFO_0000016> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000112> "the function of a hammer to drive in nails"@en ,
+                                                                                          "the function of a heart pacemaker to regulate the beating of a heart through electricity"@en ,
+                                                                                          "the function of amylase in saliva to break down starch into sugar"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000116> "BFO 2 Reference: In the past, we have distinguished two varieties of function, artifactual function and biological function. These are not asserted subtypes of BFO:function however, since the same function – for example: to pump, to transport – can exist both in artifacts and in biological entities. The asserted subtypes of function that would be needed in order to yield a separate monoheirarchy are not artifactual function, biological function, etc., but rather transporting function, pumping function, etc."@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000600> "A function is a disposition that exists in virtue of the bearer’s physical make-up and this physical make-up is something the bearer possesses because it came into being, either through evolution (in the case of natural biological entities) or through intentional design (in the case of artifacts), in order to realize processes of a certain sort. (axiom label in BFO2 Reference: [064-001])"@en ;
+                                             rdfs:isDefinedBy <http://purl.obolibrary.org/obo/bfo.owl> ;
+                                             rdfs:label "function"@en .
 
 
 ###  http://purl.obolibrary.org/obo/BFO_0000035
-obo:BFO_0000035 rdf:type owl:Class ;
-                rdfs:subClassOf obo:BFO_0000003 ,
-                                [ rdf:type owl:Restriction ;
-                                  owl:onProperty obo:RO_0002012 ;
-                                  owl:allValuesFrom [ rdf:type owl:Class ;
-                                                      owl:unionOf ( obo:BFO_0000015
-                                                                    obo:BFO_0000035
-                                                                  )
-                                                    ]
-                                ] ;
-                obo:IAO_0000112 "the boundary between the 2nd and 3rd year of your life."@en ;
-                obo:IAO_0000115 "p is a process boundary =Def. p is a temporal part of a process & p has no proper temporal parts. (axiom label in BFO2 Reference: [084-001])"@en ;
-                obo:IAO_0000412 "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
-                rdfs:isDefinedBy obo:bfo.owl ;
-                rdfs:label "process boundary"@en .
+<http://purl.obolibrary.org/obo/BFO_0000035> rdf:type owl:Class ;
+                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/BFO_0000003> ,
+                                                             [ rdf:type owl:Restriction ;
+                                                               owl:onProperty <http://purl.obolibrary.org/obo/RO_0002012> ;
+                                                               owl:allValuesFrom [ rdf:type owl:Class ;
+                                                                                   owl:unionOf ( <http://purl.obolibrary.org/obo/BFO_0000015>
+                                                                                                 <http://purl.obolibrary.org/obo/BFO_0000035>
+                                                                                               )
+                                                                                 ]
+                                                             ] ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000112> "the boundary between the 2nd and 3rd year of your life."@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000115> "p is a process boundary =Def. p is a temporal part of a process & p has no proper temporal parts. (axiom label in BFO2 Reference: [084-001])"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
+                                             rdfs:isDefinedBy <http://purl.obolibrary.org/obo/bfo.owl> ;
+                                             rdfs:label "process boundary"@en .
 
 
 ###  http://purl.obolibrary.org/obo/BFO_0000038
-obo:BFO_0000038 rdf:type owl:Class ;
-                rdfs:subClassOf obo:BFO_0000008 ;
-                obo:IAO_0000112 "the temporal region during which a process occurs."@en ;
-                obo:IAO_0000116 "BFO 2 Reference: A temporal interval is a special kind of one-dimensional temporal region, namely one that is self-connected (is without gaps or breaks)."@en ;
-                obo:IAO_0000412 "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
-                obo:IAO_0000600 "A one-dimensional temporal region is a temporal region that is extended. (axiom label in BFO2 Reference: [103-001])"@en ;
-                rdfs:isDefinedBy obo:bfo.owl ;
-                rdfs:label "one-dimensional temporal region"@en .
+<http://purl.obolibrary.org/obo/BFO_0000038> rdf:type owl:Class ;
+                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/BFO_0000008> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000112> "the temporal region during which a process occurs."@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000116> "BFO 2 Reference: A temporal interval is a special kind of one-dimensional temporal region, namely one that is self-connected (is without gaps or breaks)."@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000600> "A one-dimensional temporal region is a temporal region that is extended. (axiom label in BFO2 Reference: [103-001])"@en ;
+                                             rdfs:isDefinedBy <http://purl.obolibrary.org/obo/bfo.owl> ;
+                                             rdfs:label "one-dimensional temporal region"@en .
 
 
 ###  http://purl.obolibrary.org/obo/BFO_0000040
-obo:BFO_0000040 rdf:type owl:Class ;
-                rdfs:subClassOf obo:BFO_0000004 ;
-                obo:IAO_0000112 "a flame"@en ,
-                                "a forest fire"@en ,
-                                "a human being"@en ,
-                                "a hurricane"@en ,
-                                "a photon"@en ,
-                                "a puff of smoke"@en ,
-                                "a sea wave"@en ,
-                                "a tornado"@en ,
-                                "an aggregate of human beings."@en ,
-                                "an energy wave"@en ,
-                                "an epidemic"@en ,
-                                "the undetached arm of a human being"@en ;
-                obo:IAO_0000116 "BFO 2 Reference: Material entities (continuants) can preserve their identity even while gaining and losing material parts. Continuants are contrasted with occurrents, which unfold themselves in successive temporal parts or phases [60"@en ,
-                                "BFO 2 Reference: Object, Fiat Object Part and Object Aggregate are not intended to be exhaustive of Material Entity. Users are invited to propose new subcategories of Material Entity."@en ,
-                                "BFO 2 Reference: ‘Matter’ is intended to encompass both mass and energy (we will address the ontological treatment of portions of energy in a later version of BFO). A portion of matter is anything that includes elementary particles among its proper or improper parts: quarks and leptons, including electrons, as the smallest particles thus far discovered; baryons (including protons and neutrons) at a higher level of granularity; atoms and molecules at still higher levels, forming the cells, organs, organisms and other material entities studied by biologists, the portions of rock studied by geologists, the fossils studied by paleontologists, and so on.Material entities are three-dimensional entities (entities extended in three spatial dimensions), as contrasted with the processes in which they participate, which are four-dimensional entities (entities extended also along the dimension of time).According to the FMA, material entities may have immaterial entities as parts – including the entities identified below as sites; for example the interior (or ‘lumen’) of your small intestine is a part of your body. BFO 2.0 embodies a decision to follow the FMA here."@en ;
-                obo:IAO_0000412 "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
-                obo:IAO_0000600 "A material entity is an independent continuant that has some portion of matter as proper or improper continuant part. (axiom label in BFO2 Reference: [019-002])"@en ;
-                rdfs:isDefinedBy obo:bfo.owl ;
-                rdfs:label "material entity"@en .
+<http://purl.obolibrary.org/obo/BFO_0000040> rdf:type owl:Class ;
+                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/BFO_0000004> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000112> "a flame"@en ,
+                                                                                          "a forest fire"@en ,
+                                                                                          "a human being"@en ,
+                                                                                          "a hurricane"@en ,
+                                                                                          "a photon"@en ,
+                                                                                          "a puff of smoke"@en ,
+                                                                                          "a sea wave"@en ,
+                                                                                          "a tornado"@en ,
+                                                                                          "an aggregate of human beings."@en ,
+                                                                                          "an energy wave"@en ,
+                                                                                          "an epidemic"@en ,
+                                                                                          "the undetached arm of a human being"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000116> "BFO 2 Reference: Material entities (continuants) can preserve their identity even while gaining and losing material parts. Continuants are contrasted with occurrents, which unfold themselves in successive temporal parts or phases [60"@en ,
+                                                                                          "BFO 2 Reference: Object, Fiat Object Part and Object Aggregate are not intended to be exhaustive of Material Entity. Users are invited to propose new subcategories of Material Entity."@en ,
+                                                                                          "BFO 2 Reference: ‘Matter’ is intended to encompass both mass and energy (we will address the ontological treatment of portions of energy in a later version of BFO). A portion of matter is anything that includes elementary particles among its proper or improper parts: quarks and leptons, including electrons, as the smallest particles thus far discovered; baryons (including protons and neutrons) at a higher level of granularity; atoms and molecules at still higher levels, forming the cells, organs, organisms and other material entities studied by biologists, the portions of rock studied by geologists, the fossils studied by paleontologists, and so on.Material entities are three-dimensional entities (entities extended in three spatial dimensions), as contrasted with the processes in which they participate, which are four-dimensional entities (entities extended also along the dimension of time).According to the FMA, material entities may have immaterial entities as parts – including the entities identified below as sites; for example the interior (or ‘lumen’) of your small intestine is a part of your body. BFO 2.0 embodies a decision to follow the FMA here."@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000600> "A material entity is an independent continuant that has some portion of matter as proper or improper continuant part. (axiom label in BFO2 Reference: [019-002])"@en ;
+                                             rdfs:isDefinedBy <http://purl.obolibrary.org/obo/bfo.owl> ;
+                                             rdfs:label "material entity"@en .
 
 
 ###  http://purl.obolibrary.org/obo/BFO_0000141
-obo:BFO_0000141 rdf:type owl:Class ;
-                rdfs:subClassOf obo:BFO_0000004 ;
-                obo:IAO_0000116 "BFO 2 Reference: Immaterial entities are divided into two subgroups:boundaries and sites, which bound, or are demarcated in relation, to material entities, and which can thus change location, shape and size and as their material hosts move or change shape or size (for example: your nasal passage; the hold of a ship; the boundary of Wales (which moves with the rotation of the Earth) [38, 7, 10"@en ;
-                obo:IAO_0000412 "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
-                rdfs:isDefinedBy obo:bfo.owl ;
-                rdfs:label "immaterial entity"@en .
+<http://purl.obolibrary.org/obo/BFO_0000141> rdf:type owl:Class ;
+                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/BFO_0000004> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000116> "BFO 2 Reference: Immaterial entities are divided into two subgroups:boundaries and sites, which bound, or are demarcated in relation, to material entities, and which can thus change location, shape and size and as their material hosts move or change shape or size (for example: your nasal passage; the hold of a ship; the boundary of Wales (which moves with the rotation of the Earth) [38, 7, 10"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
+                                             rdfs:isDefinedBy <http://purl.obolibrary.org/obo/bfo.owl> ;
+                                             rdfs:label "immaterial entity"@en .
 
 
 ###  http://purl.obolibrary.org/obo/BFO_0000148
-obo:BFO_0000148 rdf:type owl:Class ;
-                rdfs:subClassOf obo:BFO_0000008 ;
-                obo:IAO_0000112 "a temporal region that is occupied by a process boundary"@en ,
-                                "right now"@en ,
-                                "the moment at which a child is born"@en ,
-                                "the moment at which a finger is detached in an industrial accident"@en ,
-                                "the moment of death."@en ;
-                obo:IAO_0000118 "temporal instant."@en ;
-                obo:IAO_0000412 "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
-                obo:IAO_0000600 "A zero-dimensional temporal region is a temporal region that is without extent. (axiom label in BFO2 Reference: [102-001])"@en ;
-                rdfs:isDefinedBy obo:bfo.owl ;
-                rdfs:label "zero-dimensional temporal region"@en .
+<http://purl.obolibrary.org/obo/BFO_0000148> rdf:type owl:Class ;
+                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/BFO_0000008> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000112> "a temporal region that is occupied by a process boundary"@en ,
+                                                                                          "right now"@en ,
+                                                                                          "the moment at which a child is born"@en ,
+                                                                                          "the moment at which a finger is detached in an industrial accident"@en ,
+                                                                                          "the moment of death."@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000118> "temporal instant."@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000600> "A zero-dimensional temporal region is a temporal region that is without extent. (axiom label in BFO2 Reference: [102-001])"@en ;
+                                             rdfs:isDefinedBy <http://purl.obolibrary.org/obo/bfo.owl> ;
+                                             rdfs:label "zero-dimensional temporal region"@en .
 
 
 ###  http://purl.obolibrary.org/obo/GAZ_00000448
-obo:GAZ_00000448 rdf:type owl:Class ;
-                 rdfs:subClassOf obo:BFO_0000029 ;
-                 rdfs:label "geographic location"@en ;
-                 aeon:SMW_datatype "Category" ;
-                 aeon:SMW_import_info "[[Category:GAZ]] [[Category:Imported vocabulary]]" .
+<http://purl.obolibrary.org/obo/GAZ_00000448> rdf:type owl:Class ;
+                                              rdfs:subClassOf <http://purl.obolibrary.org/obo/BFO_0000029> ;
+                                              rdfs:label "geographic location"@en ;
+                                              :SMW_datatype "Category" ;
+                                              :SMW_import_info "[[Category:GAZ]] [[Category:Imported vocabulary]]" .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000027
-obo:IAO_0000027 rdf:type owl:Class ;
-                rdfs:subClassOf obo:IAO_0000030 ;
-                obo:IAO_0000111 "data item"@en ;
-                obo:IAO_0000112 "Data items include counts of things, analyte concentrations, and statistical summaries."@en ;
-                obo:IAO_0000114 obo:IAO_0000125 ;
-                obo:IAO_0000115 "An information content entity that is intended to be a truthful statement about something (modulo, e.g., measurement precision or other systematic errors) and is constructed/acquired by a method which reliably tends to produce (approximately) truthful statements."@en ;
-                obo:IAO_0000116 "2/2/2009 Alan and Bjoern discussing FACS run output data. This is a data item because it is about the cell population. Each element records an event and is typically further composed a set of measurment data items that record the fluorescent intensity stimulated by one of the lasers."@en ,
-                                "2009-03-16: data item deliberatly ambiguous: we merged data set and datum to be one entity, not knowing how to define singular versus plural. So data item is more general than datum."@en ,
-                                "2009-03-16: removed datum as alternative term as datum specifically refers to singular form, and is thus not an exact synonym."@en ,
-                                "2014-03-31: See discussion at http://odontomachus.wordpress.com/2014/03/30/aboutness-objects-propositions/" ,
-                                """JAR: datum     -- well, this will be very tricky to define, but maybe some 
+<http://purl.obolibrary.org/obo/IAO_0000027> rdf:type owl:Class ;
+                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/IAO_0000030> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000111> "data item"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000112> "Data items include counts of things, analyte concentrations, and statistical summaries."@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000125> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000115> "An information content entity that is intended to be a truthful statement about something (modulo, e.g., measurement precision or other systematic errors) and is constructed/acquired by a method which reliably tends to produce (approximately) truthful statements."@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000116> "2/2/2009 Alan and Bjoern discussing FACS run output data. This is a data item because it is about the cell population. Each element records an event and is typically further composed a set of measurment data items that record the fluorescent intensity stimulated by one of the lasers."@en ,
+                                                                                          "2009-03-16: data item deliberatly ambiguous: we merged data set and datum to be one entity, not knowing how to define singular versus plural. So data item is more general than datum."@en ,
+                                                                                          "2009-03-16: removed datum as alternative term as datum specifically refers to singular form, and is thus not an exact synonym."@en ,
+                                                                                          "2014-03-31: See discussion at http://odontomachus.wordpress.com/2014/03/30/aboutness-objects-propositions/" ,
+                                                                                          """JAR: datum     -- well, this will be very tricky to define, but maybe some 
 information-like stuff that might be put into a computer and that is 
 meant, by someone, to denote and/or to be interpreted by some 
 process... I would include lists, tables, sentences... I think I might 
 defer to Barry, or to Brian Cantwell Smith
 
 JAR: A data item is an approximately justified approximately true approximate belief"""@en ;
-                obo:IAO_0000117 "PERSON: Alan Ruttenberg"@en ,
-                                "PERSON: Chris Stoeckert"@en ,
-                                "PERSON: Jonathan Rees"@en ;
-                obo:IAO_0000118 "data"@en ;
-                obo:IAO_0000412 "http://purl.obolibrary.org/obo/iao/2020-12-09/iao.owl"^^xsd:string ;
-                rdfs:label "data item"@en .
+                                             <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Alan Ruttenberg"@en ,
+                                                                                          "PERSON: Chris Stoeckert"@en ,
+                                                                                          "PERSON: Jonathan Rees"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000118> "data"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/iao/2020-12-09/iao.owl"^^xsd:string ;
+                                             rdfs:label "data item"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000028
-obo:IAO_0000028 rdf:type owl:Class ;
-                rdfs:subClassOf obo:IAO_0000030 ;
-                obo:IAO_0000111 "symbol"@en ;
-                obo:IAO_0000112 "a serial number such as \"12324X\""@en ,
-                                "a stop sign"@en ,
-                                "a written proper name such as \"OBI\""@en ;
-                obo:IAO_0000114 obo:IAO_0000125 ;
-                obo:IAO_0000115 "An information content entity that is a mark(s) or character(s) used as a conventional representation of another entity."@en ;
-                obo:IAO_0000116 "20091104, MC: this needs work and will most probably change"@en ,
-                                "2014-03-31: We would like to have a deeper analysis of 'mark' and 'sign' in the future (see https://github.com/information-artifact-ontology/IAO/issues/154)."@en ;
-                obo:IAO_0000117 "PERSON: James A. Overton"@en ,
-                                "PERSON: Jonathan Rees"@en ;
-                obo:IAO_0000119 "based on Oxford English Dictionary"@en ;
-                obo:IAO_0000412 "http://purl.obolibrary.org/obo/iao/2020-12-09/iao.owl"^^xsd:string ;
-                rdfs:label "symbol"@en .
+<http://purl.obolibrary.org/obo/IAO_0000028> rdf:type owl:Class ;
+                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/IAO_0000030> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000111> "symbol"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000112> "a serial number such as \"12324X\""@en ,
+                                                                                          "a stop sign"@en ,
+                                                                                          "a written proper name such as \"OBI\""@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000125> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000115> "An information content entity that is a mark(s) or character(s) used as a conventional representation of another entity."@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000116> "20091104, MC: this needs work and will most probably change"@en ,
+                                                                                          "2014-03-31: We would like to have a deeper analysis of 'mark' and 'sign' in the future (see https://github.com/information-artifact-ontology/IAO/issues/154)."@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: James A. Overton"@en ,
+                                                                                          "PERSON: Jonathan Rees"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000119> "based on Oxford English Dictionary"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/iao/2020-12-09/iao.owl"^^xsd:string ;
+                                             rdfs:label "symbol"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000030
-obo:IAO_0000030 rdf:type owl:Class ;
-                rdfs:subClassOf obo:BFO_0000031 ,
-                                [ rdf:type owl:Restriction ;
-                                  owl:onProperty obo:IAO_0000136 ;
-                                  owl:someValuesFrom obo:BFO_0000001
-                                ] ;
-                obo:IAO_0000111 "information content entity"@en ;
-                obo:IAO_0000112 "Examples of information content entites include journal articles, data, graphical layouts, and graphs."@en ;
-                obo:IAO_0000114 obo:IAO_0000122 ;
-                obo:IAO_0000115 "A generically dependent continuant that is about some thing."@en ;
-                obo:IAO_0000116 "2014-03-10: The use of \"thing\" is intended to be general enough to include universals and configurations (see https://groups.google.com/d/msg/information-ontology/GBxvYZCk1oc/-L6B5fSBBTQJ)."@en ,
-                                """information_content_entity 'is_encoded_in' some digital_entity in obi before split (040907). information_content_entity 'is_encoded_in' some physical_document in obi before split (040907).
+<http://purl.obolibrary.org/obo/IAO_0000030> rdf:type owl:Class ;
+                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/BFO_0000031> ,
+                                                             [ rdf:type owl:Restriction ;
+                                                               owl:onProperty <http://purl.obolibrary.org/obo/IAO_0000136> ;
+                                                               owl:someValuesFrom <http://purl.obolibrary.org/obo/BFO_0000001>
+                                                             ] ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000111> "information content entity"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000112> "Examples of information content entites include journal articles, data, graphical layouts, and graphs."@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000122> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000115> "A generically dependent continuant that is about some thing."@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000116> "2014-03-10: The use of \"thing\" is intended to be general enough to include universals and configurations (see https://groups.google.com/d/msg/information-ontology/GBxvYZCk1oc/-L6B5fSBBTQJ)."@en ,
+                                                                                          """information_content_entity 'is_encoded_in' some digital_entity in obi before split (040907). information_content_entity 'is_encoded_in' some physical_document in obi before split (040907).
 
 Previous. An information content entity is a non-realizable information entity that 'is encoded in' some digital or physical entity."""@en ;
-                obo:IAO_0000117 "PERSON: Chris Stoeckert"@en ;
-                obo:IAO_0000119 "OBI_0000142"@en ;
-                obo:IAO_0000412 "http://purl.obolibrary.org/obo/iao/2020-12-09/iao.owl"^^xsd:string ;
-                rdfs:label "information content entity"@en .
+                                             <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Chris Stoeckert"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000119> "OBI_0000142"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/iao/2020-12-09/iao.owl"^^xsd:string ;
+                                             rdfs:label "information content entity"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000078
-obo:IAO_0000078 rdf:type owl:Class ;
-                rdfs:subClassOf obo:IAO_0000102 ;
-                obo:IAO_0000111 "curation status specification"@en ;
-                obo:IAO_0000114 obo:IAO_0000125 ;
-                obo:IAO_0000115 "The curation status of the term. The allowed values come from an enumerated list of predefined terms. See the specification of these instances for more detailed definitions of each enumerated value."@en ;
-                obo:IAO_0000116 "Better to represent curation as a process with parts and then relate labels to that process (in IAO meeting)"@en ;
-                obo:IAO_0000117 "PERSON:Bill Bug"@en ;
-                obo:IAO_0000119 "GROUP:OBI:<http://purl.obolibrary.org/obo/obi>"@en ,
-                                "OBI_0000266"@en ;
-                obo:IAO_0000412 "http://purl.obolibrary.org/obo/iao/2020-12-09/iao.owl"^^xsd:string ;
-                rdfs:label "curation status specification"@en .
+<http://purl.obolibrary.org/obo/IAO_0000078> rdf:type owl:Class ;
+                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/IAO_0000102> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000111> "curation status specification"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000125> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000115> "The curation status of the term. The allowed values come from an enumerated list of predefined terms. See the specification of these instances for more detailed definitions of each enumerated value."@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000116> "Better to represent curation as a process with parts and then relate labels to that process (in IAO meeting)"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON:Bill Bug"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000119> "GROUP:OBI:<http://purl.obolibrary.org/obo/obi>"@en ,
+                                                                                          "OBI_0000266"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/iao/2020-12-09/iao.owl"^^xsd:string ;
+                                             rdfs:label "curation status specification"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000100
-obo:IAO_0000100 rdf:type owl:Class ;
-                rdfs:subClassOf obo:IAO_0000027 ;
-                obo:IAO_0000111 "data set"@en ;
-                obo:IAO_0000112 "Intensity values in a CEL file or from multiple CEL files comprise a data set (as opposed to the CEL files themselves)."@en ;
-                obo:IAO_0000114 obo:IAO_0000125 ;
-                obo:IAO_0000115 "A data item that is an aggregate of other data items of the same type that have something in common. Averages and distributions can be determined for data sets."@en ;
-                obo:IAO_0000116 "2009/10/23 Alan Ruttenberg. The intention is that this term represent collections of like data. So this isn't for, e.g. the whole contents of a cel file, which includes parameters, metadata etc. This is more like java arrays of a certain rather specific type"@en ,
-                                "2014-05-05: Data sets are aggregates and thus must include two or more data items. We have chosen not to add logical axioms to make this restriction." ;
-                obo:IAO_0000117 "person:Allyson Lister"@en ,
-                                "person:Chris Stoeckert"@en ;
-                obo:IAO_0000119 "OBI_0000042"@en ,
-                                "group:OBI"@en ;
-                obo:IAO_0000412 "http://purl.obolibrary.org/obo/iao/2020-12-09/iao.owl"^^xsd:string ;
-                rdfs:label "data set"@en .
+<http://purl.obolibrary.org/obo/IAO_0000100> rdf:type owl:Class ;
+                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/IAO_0000027> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000111> "data set"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000112> "Intensity values in a CEL file or from multiple CEL files comprise a data set (as opposed to the CEL files themselves)."@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000125> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000115> "A data item that is an aggregate of other data items of the same type that have something in common. Averages and distributions can be determined for data sets."@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000116> "2009/10/23 Alan Ruttenberg. The intention is that this term represent collections of like data. So this isn't for, e.g. the whole contents of a cel file, which includes parameters, metadata etc. This is more like java arrays of a certain rather specific type"@en ,
+                                                                                          "2014-05-05: Data sets are aggregates and thus must include two or more data items. We have chosen not to add logical axioms to make this restriction." ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000117> "person:Allyson Lister"@en ,
+                                                                                          "person:Chris Stoeckert"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000119> "OBI_0000042"@en ,
+                                                                                          "group:OBI"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/iao/2020-12-09/iao.owl"^^xsd:string ;
+                                             rdfs:label "data set"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000102
-obo:IAO_0000102 rdf:type owl:Class ;
-                rdfs:subClassOf obo:IAO_0000027 ;
-                obo:IAO_0000111 "data about an ontology part"@en ;
-                obo:IAO_0000115 "Data about an ontology part is a data item about a part of an ontology, for example a term"@en ;
-                obo:IAO_0000117 "Person:Alan Ruttenberg"@en ;
-                obo:IAO_0000412 "http://purl.obolibrary.org/obo/iao/2020-12-09/iao.owl"^^xsd:string ;
-                rdfs:label "data about an ontology part"@en .
+<http://purl.obolibrary.org/obo/IAO_0000102> rdf:type owl:Class ;
+                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/IAO_0000027> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000111> "data about an ontology part"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000115> "Data about an ontology part is a data item about a part of an ontology, for example a term"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000117> "Person:Alan Ruttenberg"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/iao/2020-12-09/iao.owl"^^xsd:string ;
+                                             rdfs:label "data about an ontology part"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000225
-obo:IAO_0000225 rdf:type owl:Class ;
-                rdfs:subClassOf obo:IAO_0000102 ;
-                obo:IAO_0000111 "obsolescence reason specification"@en ;
-                obo:IAO_0000114 obo:IAO_0000125 ;
-                obo:IAO_0000115 "The reason for which a term has been deprecated. The allowed values come from an enumerated list of predefined terms. See the specification of these instances for more detailed definitions of each enumerated value."@en ;
-                obo:IAO_0000116 "The creation of this class has been inspired in part by Werner Ceusters' paper, Applying evolutionary terminology auditing to the Gene Ontology."@en ;
-                obo:IAO_0000117 "PERSON: Alan Ruttenberg"@en ,
-                                "PERSON: Melanie Courtot"@en ;
-                obo:IAO_0000412 "http://purl.obolibrary.org/obo/iao/2020-12-09/iao.owl"^^xsd:string ;
-                rdfs:label "obsolescence reason specification"@en .
+<http://purl.obolibrary.org/obo/IAO_0000225> rdf:type owl:Class ;
+                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/IAO_0000102> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000111> "obsolescence reason specification"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000125> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000115> "The reason for which a term has been deprecated. The allowed values come from an enumerated list of predefined terms. See the specification of these instances for more detailed definitions of each enumerated value."@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000116> "The creation of this class has been inspired in part by Werner Ceusters' paper, Applying evolutionary terminology auditing to the Gene Ontology."@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Alan Ruttenberg"@en ,
+                                                                                          "PERSON: Melanie Courtot"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/iao/2020-12-09/iao.owl"^^xsd:string ;
+                                             rdfs:label "obsolescence reason specification"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000310
-obo:IAO_0000310 rdf:type owl:Class ;
-                rdfs:subClassOf obo:IAO_0000030 ;
-                obo:IAO_0000111 "document"@en ;
-                obo:IAO_0000112 "A journal article, patent application, laboratory notebook, or a book"@en ;
-                obo:IAO_0000114 obo:IAO_0000120 ;
-                obo:IAO_0000115 "A collection of information content entities intended to be understood together as a whole"@en ;
-                obo:IAO_0000117 "PERSON: Lawrence Hunter"@en ;
-                obo:IAO_0000412 "http://purl.obolibrary.org/obo/iao/2020-12-09/iao.owl"^^xsd:string ;
-                rdfs:label "document"@en .
+<http://purl.obolibrary.org/obo/IAO_0000310> rdf:type owl:Class ;
+                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/IAO_0000030> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000111> "document"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000112> "A journal article, patent application, laboratory notebook, or a book"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000120> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000115> "A collection of information content entities intended to be understood together as a whole"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Lawrence Hunter"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/iao/2020-12-09/iao.owl"^^xsd:string ;
+                                             rdfs:label "document"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000577
-obo:IAO_0000577 rdf:type owl:Class ;
-                rdfs:subClassOf obo:IAO_0000028 ;
-                obo:IAO_0000112 "The sentence \"The article has Pubmed ID 12345.\" contains a CRID that has two parts: one part is the CRID symbol, which is '12345'; the other part denotes the CRID registry, which is Pubmed."@en ;
-                obo:IAO_0000114 obo:IAO_0000120 ;
-                obo:IAO_0000115 "A symbol that is part of a CRID and that is sufficient to look up a record from the CRID's registry."@en ;
-                obo:IAO_0000117 "PERSON: Alan Ruttenberg"@en ,
-                                "PERSON: Bill Hogan"@en ,
-                                "PERSON: Bjoern Peters"@en ,
-                                "PERSON: Melanie Courtot"@en ;
-                obo:IAO_0000118 "CRID symbol" ;
-                obo:IAO_0000119 "Original proposal from Bjoern, discussions at IAO calls"@en ;
-                obo:IAO_0000412 "http://purl.obolibrary.org/obo/iao/2020-12-09/iao.owl"^^xsd:string ;
-                rdfs:label "centrally registered identifier symbol"@en .
+<http://purl.obolibrary.org/obo/IAO_0000577> rdf:type owl:Class ;
+                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/IAO_0000028> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000112> "The sentence \"The article has Pubmed ID 12345.\" contains a CRID that has two parts: one part is the CRID symbol, which is '12345'; the other part denotes the CRID registry, which is Pubmed."@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000120> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000115> "A symbol that is part of a CRID and that is sufficient to look up a record from the CRID's registry."@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Alan Ruttenberg"@en ,
+                                                                                          "PERSON: Bill Hogan"@en ,
+                                                                                          "PERSON: Bjoern Peters"@en ,
+                                                                                          "PERSON: Melanie Courtot"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000118> "CRID symbol" ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000119> "Original proposal from Bjoern, discussions at IAO calls"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/iao/2020-12-09/iao.owl"^^xsd:string ;
+                                             rdfs:label "centrally registered identifier symbol"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000578
-obo:IAO_0000578 rdf:type owl:Class ;
-                rdfs:subClassOf obo:IAO_0020000 ,
-                                [ rdf:type owl:Restriction ;
-                                  owl:onProperty obo:BFO_0000051 ;
-                                  owl:someValuesFrom obo:IAO_0000577
-                                ] ,
-                                [ rdf:type owl:Restriction ;
-                                  owl:onProperty obo:BFO_0000051 ;
-                                  owl:someValuesFrom [ rdf:type owl:Restriction ;
-                                                       owl:onProperty obo:IAO_0000219 ;
-                                                       owl:someValuesFrom obo:IAO_0000579
-                                                     ]
-                                ] ;
-                obo:IAO_0000112 "The sentence \"The article has Pubmed ID 12345.\" contains a CRID that has two parts: one part is the CRID symbol, which is '12345'; the other part denotes the CRID registry, which is Pubmed."@en ;
-                obo:IAO_0000114 obo:IAO_0000120 ;
-                obo:IAO_0000115 "An information content entity that consists of a CRID symbol and additional information about the CRID registry to which it belongs."@en ;
-                obo:IAO_0000116 "2014-05-05: In defining this term we take no position on what the CRID denotes. In particular do not assume it denotes a *record* in the CRID registry (since the registry might not have 'records')."@en ,
-                                "Alan, IAO call 20101124: potentially the CRID denotes the instance it was associated with during creation."@en ,
-                                "Note, IAO call 20101124: URIs are not always CRID, as not centrally registered. We acknowledge that CRID is a subset of a larger identifier class, but this subset fulfills our current needs. OBI PURLs are CRID as they are registered with OCLC. UPCs (Universal Product Codes from AC Nielsen)are not CRID as they are not centrally registered."@en ;
-                obo:IAO_0000117 "PERSON: Alan Ruttenberg"@en ,
-                                "PERSON: Bill Hogan"@en ,
-                                "PERSON: Bjoern Peters"@en ,
-                                "PERSON: Melanie Courtot"@en ;
-                obo:IAO_0000118 "CRID" ;
-                obo:IAO_0000119 "Original proposal from Bjoern, discussions at IAO calls"@en ;
-                obo:IAO_0000412 "http://purl.obolibrary.org/obo/iao/2020-12-09/iao.owl"^^xsd:string ;
-                rdfs:label "centrally registered identifier"@en .
+<http://purl.obolibrary.org/obo/IAO_0000578> rdf:type owl:Class ;
+                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/IAO_0020000> ,
+                                                             [ rdf:type owl:Restriction ;
+                                                               owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000051> ;
+                                                               owl:someValuesFrom <http://purl.obolibrary.org/obo/IAO_0000577>
+                                                             ] ,
+                                                             [ rdf:type owl:Restriction ;
+                                                               owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000051> ;
+                                                               owl:someValuesFrom [ rdf:type owl:Restriction ;
+                                                                                    owl:onProperty <http://purl.obolibrary.org/obo/IAO_0000219> ;
+                                                                                    owl:someValuesFrom <http://purl.obolibrary.org/obo/IAO_0000579>
+                                                                                  ]
+                                                             ] ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000112> "The sentence \"The article has Pubmed ID 12345.\" contains a CRID that has two parts: one part is the CRID symbol, which is '12345'; the other part denotes the CRID registry, which is Pubmed."@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000120> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000115> "An information content entity that consists of a CRID symbol and additional information about the CRID registry to which it belongs."@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000116> "2014-05-05: In defining this term we take no position on what the CRID denotes. In particular do not assume it denotes a *record* in the CRID registry (since the registry might not have 'records')."@en ,
+                                                                                          "Alan, IAO call 20101124: potentially the CRID denotes the instance it was associated with during creation."@en ,
+                                                                                          "Note, IAO call 20101124: URIs are not always CRID, as not centrally registered. We acknowledge that CRID is a subset of a larger identifier class, but this subset fulfills our current needs. OBI PURLs are CRID as they are registered with OCLC. UPCs (Universal Product Codes from AC Nielsen)are not CRID as they are not centrally registered."@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Alan Ruttenberg"@en ,
+                                                                                          "PERSON: Bill Hogan"@en ,
+                                                                                          "PERSON: Bjoern Peters"@en ,
+                                                                                          "PERSON: Melanie Courtot"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000118> "CRID" ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000119> "Original proposal from Bjoern, discussions at IAO calls"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/iao/2020-12-09/iao.owl"^^xsd:string ;
+                                             rdfs:label "centrally registered identifier"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000579
-obo:IAO_0000579 rdf:type owl:Class ;
-                rdfs:subClassOf obo:IAO_0000100 ;
-                obo:IAO_0000112 "PubMed is a CRID registry. It has a dataset of PubMed identifiers associated with journal articles. "@en ;
-                obo:IAO_0000114 obo:IAO_0000120 ;
-                obo:IAO_0000115 "A CRID registry is a dataset of CRID records, each consisting of a CRID symbol and additional information which was recorded in the dataset through a assigning a centrally registered identifier process."@en ;
-                obo:IAO_0000117 "PERSON: Alan Ruttenberg"@en ,
-                                "PERSON: Bill Hogan"@en ,
-                                "PERSON: Bjoern Peters"@en ,
-                                "PERSON: Melanie Courtot"@en ;
-                obo:IAO_0000118 "CRID registry" ;
-                obo:IAO_0000119 "Original proposal from Bjoern, discussions at IAO calls"@en ;
-                obo:IAO_0000412 "http://purl.obolibrary.org/obo/iao/2020-12-09/iao.owl"^^xsd:string ;
-                rdfs:label "centrally registered identifier registry"@en .
+<http://purl.obolibrary.org/obo/IAO_0000579> rdf:type owl:Class ;
+                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/IAO_0000100> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000112> "PubMed is a CRID registry. It has a dataset of PubMed identifiers associated with journal articles. "@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000120> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000115> "A CRID registry is a dataset of CRID records, each consisting of a CRID symbol and additional information which was recorded in the dataset through a assigning a centrally registered identifier process."@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Alan Ruttenberg"@en ,
+                                                                                          "PERSON: Bill Hogan"@en ,
+                                                                                          "PERSON: Bjoern Peters"@en ,
+                                                                                          "PERSON: Melanie Courtot"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000118> "CRID registry" ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000119> "Original proposal from Bjoern, discussions at IAO calls"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/iao/2020-12-09/iao.owl"^^xsd:string ;
+                                             rdfs:label "centrally registered identifier registry"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0020000
-obo:IAO_0020000 rdf:type owl:Class ;
-                rdfs:subClassOf obo:IAO_0000030 ;
-                obo:IAO_0000111 "identifier"@en ;
-                obo:IAO_0000115 "An identifier is an information content entity that is the outcome of a dubbing process and is used to refer to one instance of entity shared by a group of people to refer to that individual entity."@en ;
-                obo:IAO_0000412 "http://purl.obolibrary.org/obo/iao/2020-12-09/iao.owl"^^xsd:string ;
-                rdfs:label "identifier"@en .
+<http://purl.obolibrary.org/obo/IAO_0020000> rdf:type owl:Class ;
+                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/IAO_0000030> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000111> "identifier"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000115> "An identifier is an information content entity that is the outcome of a dubbing process and is used to refer to one instance of entity shared by a group of people to refer to that individual entity."@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/iao/2020-12-09/iao.owl"^^xsd:string ;
+                                             rdfs:label "identifier"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0020015
-obo:IAO_0020015 rdf:type owl:Class ;
-                owl:equivalentClass [ owl:intersectionOf ( obo:IAO_0020000
-                                                           [ rdf:type owl:Restriction ;
-                                                             owl:onProperty obo:IAO_0000219 ;
-                                                             owl:allValuesFrom obo:NCBITaxon_9606
-                                                           ]
-                                                         ) ;
-                                      rdf:type owl:Class
-                                    ] ;
-                rdfs:subClassOf obo:IAO_0020000 ;
-                obo:IAO_0000115 "A personal name is a proper name identifying an individual person."@en ;
-                obo:IAO_0000117 "Mathias Brochhausen" ;
-                obo:IAO_0000119 "http://en.wikipedia.org/wiki/Personal_name" ;
-                obo:IAO_0000412 "http://purl.obolibrary.org/obo/iao/pno/release/2020-04-18/pno.owl"^^xsd:string ;
-                rdfs:comment "Personal names \"today usually comprises a given name bestowed at birth or at a young age plus a surname. It is nearly universal for a human to have a name; except in rare cases, for example feral children growing up in isolation, or infants orphaned by natural disaster for whom no written record survives.[citation needed] The Convention on the Rights of the Child specifies that a child has the right from birth to a name. Certain isolated tribes, such as the Machiguenga of the Amazon, also lack personal names.\" (http://en.wikipedia.org/wiki/Personal_name)"@en ,
-                             "Sep 29, 2016: The comment that including the wikipedia definition of personal name is not to be interpreted in a way that restricts this class to only contain strings of letters. A numerical or alphanumerical identifier that denotes a human is being is a personal name, too. (MB)"@en ;
-                rdfs:label "personal name"@en .
+<http://purl.obolibrary.org/obo/IAO_0020015> rdf:type owl:Class ;
+                                             owl:equivalentClass [ owl:intersectionOf ( <http://purl.obolibrary.org/obo/IAO_0020000>
+                                                                                        [ rdf:type owl:Restriction ;
+                                                                                          owl:onProperty <http://purl.obolibrary.org/obo/IAO_0000219> ;
+                                                                                          owl:allValuesFrom <http://purl.obolibrary.org/obo/NCBITaxon_9606>
+                                                                                        ]
+                                                                                      ) ;
+                                                                   rdf:type owl:Class
+                                                                 ] ;
+                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/IAO_0020000> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000115> "A personal name is a proper name identifying an individual person."@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000117> "Mathias Brochhausen" ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000119> "http://en.wikipedia.org/wiki/Personal_name" ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/iao/pno/release/2020-04-18/pno.owl"^^xsd:string ;
+                                             rdfs:comment "Personal names \"today usually comprises a given name bestowed at birth or at a young age plus a surname. It is nearly universal for a human to have a name; except in rare cases, for example feral children growing up in isolation, or infants orphaned by natural disaster for whom no written record survives.[citation needed] The Convention on the Rights of the Child specifies that a child has the right from birth to a name. Certain isolated tribes, such as the Machiguenga of the Amazon, also lack personal names.\" (http://en.wikipedia.org/wiki/Personal_name)"@en ,
+                                                          "Sep 29, 2016: The comment that including the wikipedia definition of personal name is not to be interpreted in a way that restricts this class to only contain strings of letters. A numerical or alphanumerical identifier that denotes a human is being is a personal name, too. (MB)"@en ;
+                                             rdfs:label "personal name"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0022000
-obo:IAO_0022000 rdf:type owl:Class ;
-                owl:equivalentClass aeon:AEON_0000034 ;
-                rdfs:subClassOf obo:IAO_0020000 ;
-                obo:IAO_0000111 "http://purl.obolibrary.org/obo/IAO_0000122"@en ;
-                obo:IAO_0000112 "postal codes are assigned by each country"@en ;
-                obo:IAO_0000115 "An identifier issued by more than one authority"@en ;
-                obo:IAO_0000117 "PERSON: Michael Conlon"@en ;
-                obo:IAO_0000412 "http://purl.obolibrary.org/obo/iao/ido/release/2021-02-19/ido.owl"^^xsd:string ;
-                rdfs:label "distributed identifier"@en .
+<http://purl.obolibrary.org/obo/IAO_0022000> rdf:type owl:Class ;
+                                             owl:equivalentClass :AEON_0000034 ;
+                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/IAO_0020000> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000111> "http://purl.obolibrary.org/obo/IAO_0000122"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000112> "postal codes are assigned by each country"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000115> "An identifier issued by more than one authority"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Michael Conlon"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/iao/ido/release/2021-02-19/ido.owl"^^xsd:string ;
+                                             rdfs:label "distributed identifier"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0022014
-obo:IAO_0022014 rdf:type owl:Class ;
-                owl:equivalentClass aeon:AEON_0000018 ;
-                rdfs:subClassOf obo:IAO_0000578 ;
-                obo:IAO_0000111 "ISNI"@en ,
-                                "http://purl.obolibrary.org/obo/IAO_0000123"@en ;
-                obo:IAO_0000115 "An identifier for persons and organizations which may be assigned by matching algorithms based on records provided by publishers"@en ;
-                obo:IAO_0000116 "spell out"@en ;
-                obo:IAO_0000117 "PERSON: Michael Conlon"@en ;
-                obo:IAO_0000119 "https://isni.org/page/what-is-isni/"@en ;
-                obo:IAO_0000412 "http://purl.obolibrary.org/obo/iao/ido/release/2021-02-19/ido.owl"^^xsd:string ;
-                rdfs:label "international standard name identifier"@en .
+<http://purl.obolibrary.org/obo/IAO_0022014> rdf:type owl:Class ;
+                                             owl:equivalentClass :AEON_0000018 ;
+                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/IAO_0000578> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000111> "ISNI"@en ,
+                                                                                          "http://purl.obolibrary.org/obo/IAO_0000123"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000115> "An identifier for persons and organizations which may be assigned by matching algorithms based on records provided by publishers"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000116> "spell out"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Michael Conlon"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000119> "https://isni.org/page/what-is-isni/"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/iao/ido/release/2021-02-19/ido.owl"^^xsd:string ;
+                                             rdfs:label "international standard name identifier"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0022019
-obo:IAO_0022019 rdf:type owl:Class ;
-                owl:equivalentClass aeon:AEON_0000019 ;
-                rdfs:subClassOf obo:IAO_0000578 ;
-                obo:IAO_0000111 "ORCID ID"@en ,
-                                "http://purl.obolibrary.org/obo/IAO_0000123"@en ;
-                obo:IAO_0000115 "Open Researcher and Contributor ID is an alphanumeric code (ORCID iD) to uniquely identify authors and contributors of scholarly communication"@en ;
-                obo:IAO_0000117 "PERSON: Michael Conlon"@en ;
-                obo:IAO_0000119 "https://en.wikipedia.org/wiki/ORCID"@en ;
-                obo:IAO_0000412 "http://purl.obolibrary.org/obo/iao/ido/release/2021-02-19/ido.owl"^^xsd:string ;
-                rdfs:label "open researcher and contributor identifier"@en .
+<http://purl.obolibrary.org/obo/IAO_0022019> rdf:type owl:Class ;
+                                             owl:equivalentClass :AEON_0000019 ;
+                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/IAO_0000578> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000111> "ORCID ID"@en ,
+                                                                                          "http://purl.obolibrary.org/obo/IAO_0000123"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000115> "Open Researcher and Contributor ID is an alphanumeric code (ORCID iD) to uniquely identify authors and contributors of scholarly communication"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Michael Conlon"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/wiki/ORCID"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/iao/ido/release/2021-02-19/ido.owl"^^xsd:string ;
+                                             rdfs:label "open researcher and contributor identifier"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0022022
-obo:IAO_0022022 rdf:type owl:Class ;
-                owl:equivalentClass aeon:AEON_0000020 ;
-                rdfs:subClassOf obo:IAO_0000578 ;
-                obo:IAO_0000111 "ROR ID"@en ,
-                                "http://purl.obolibrary.org/obo/IAO_0000123"@en ;
-                obo:IAO_0000115 "An identifier assigned by ROR to research organizations in the world"@en ;
-                obo:IAO_0000117 "PERSON: Michael Conlon"@en ;
-                obo:IAO_0000119 "http://ror.org"@en ;
-                obo:IAO_0000412 "http://purl.obolibrary.org/obo/iao/ido/release/2021-02-19/ido.owl"^^xsd:string ;
-                rdfs:label "research organization registry identifier"@en .
+<http://purl.obolibrary.org/obo/IAO_0022022> rdf:type owl:Class ;
+                                             owl:equivalentClass :AEON_0000020 ;
+                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/IAO_0000578> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000111> "ROR ID"@en ,
+                                                                                          "http://purl.obolibrary.org/obo/IAO_0000123"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000115> "An identifier assigned by ROR to research organizations in the world"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Michael Conlon"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000119> "http://ror.org"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/iao/ido/release/2021-02-19/ido.owl"^^xsd:string ;
+                                             rdfs:label "research organization registry identifier"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0022027
-obo:IAO_0022027 rdf:type owl:Class ;
-                owl:equivalentClass aeon:AEON_0000021 ;
-                rdfs:subClassOf obo:IAO_0000578 ;
-                obo:IAO_0000111 "QID"@en ,
-                                "http://purl.obolibrary.org/obo/IAO_0000123"@en ;
-                obo:IAO_0000115 "QID (or Q number) is the unique identifier of a data item on Wikidata, comprising the letter \"Q\" followed by one or more digits."@en ;
-                obo:IAO_0000117 "PERSON: Michael Conlon"@en ;
-                obo:IAO_0000119 "https://www.wikidata.org/wiki/Q43649390"@en ;
-                obo:IAO_0000412 "http://purl.obolibrary.org/obo/iao/ido/release/2021-02-19/ido.owl"^^xsd:string ;
-                rdfs:label "wikidata q number"@en .
+<http://purl.obolibrary.org/obo/IAO_0022027> rdf:type owl:Class ;
+                                             owl:equivalentClass :AEON_0000021 ;
+                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/IAO_0000578> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000111> "QID"@en ,
+                                                                                          "http://purl.obolibrary.org/obo/IAO_0000123"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000115> "QID (or Q number) is the unique identifier of a data item on Wikidata, comprising the letter \"Q\" followed by one or more digits."@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Michael Conlon"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000119> "https://www.wikidata.org/wiki/Q43649390"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/iao/ido/release/2021-02-19/ido.owl"^^xsd:string ;
+                                             rdfs:label "wikidata q number"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0022034
-obo:IAO_0022034 rdf:type owl:Class ;
-                owl:equivalentClass aeon:AEON_0000003 ;
-                rdfs:subClassOf obo:IAO_0020000 ;
-                obo:IAO_0000111 "http://purl.obolibrary.org/obo/IAO_0000123"@en ;
-                obo:IAO_0000115 "An identifier assigned to an ice by a repository in which it is held"@en ;
-                obo:IAO_0000117 "PERSON: Michael Conlon"@en ;
-                obo:IAO_0000412 "http://purl.obolibrary.org/obo/iao/ido/release/2021-02-19/ido.owl"^^xsd:string ;
-                rdfs:label "local information content entity identifier"@en .
+<http://purl.obolibrary.org/obo/IAO_0022034> rdf:type owl:Class ;
+                                             owl:equivalentClass :AEON_0000003 ;
+                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/IAO_0020000> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000111> "http://purl.obolibrary.org/obo/IAO_0000123"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000115> "An identifier assigned to an ice by a repository in which it is held"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Michael Conlon"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/iao/ido/release/2021-02-19/ido.owl"^^xsd:string ;
+                                             rdfs:label "local information content entity identifier"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0022041
-obo:IAO_0022041 rdf:type owl:Class ;
-                owl:equivalentClass aeon:AEON_0000016 ;
-                rdfs:subClassOf obo:IAO_0020000 ;
-                obo:IAO_0000111 "DOI"@en ,
-                                "http://purl.obolibrary.org/obo/IAO_0000123"@en ;
-                obo:IAO_0000115 "A digital object identifier (DOI) is a persistent identifier or handle used to identify objects uniquely, standardized by the International Organization for Standardization (ISO)."@en ;
-                obo:IAO_0000117 "PERSON: Michael Conlon"@en ;
-                obo:IAO_0000119 "https://en.wikipedia.org/wiki/Digital_object_identifier"@en ;
-                obo:IAO_0000412 "http://purl.obolibrary.org/obo/iao/ido/release/2021-02-19/ido.owl"^^xsd:string ;
-                rdfs:label "digital object identifier"@en .
+<http://purl.obolibrary.org/obo/IAO_0022041> rdf:type owl:Class ;
+                                             owl:equivalentClass :AEON_0000016 ;
+                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/IAO_0020000> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000111> "DOI"@en ,
+                                                                                          "http://purl.obolibrary.org/obo/IAO_0000123"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000115> "A digital object identifier (DOI) is a persistent identifier or handle used to identify objects uniquely, standardized by the International Organization for Standardization (ISO)."@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Michael Conlon"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/wiki/Digital_object_identifier"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/iao/ido/release/2021-02-19/ido.owl"^^xsd:string ;
+                                             rdfs:label "digital object identifier"@en .
 
 
 ###  http://purl.obolibrary.org/obo/ICO_0000048
-obo:ICO_0000048 rdf:type owl:Class ;
-                rdfs:subClassOf obo:OBI_0000245 ;
-                owl:disjointWith obo:ICO_0000049 ;
-                obo:IAO_0000115 "An organization that is operated without the principal goal of making a financial profit."@en ;
-                obo:IAO_0000117 "Yongqun He"@en ;
-                obo:IAO_0000412 "http://purl.obolibrary.org/obo/2020-08-27/ico.owl"^^xsd:string ;
-                rdfs:label "nonprofit organization"@en ;
-                aeon:SMW_datatype "Category" ;
-                aeon:SMW_import_info "[[Category:ICO]] [[Category:Imported vocabulary]]" .
+<http://purl.obolibrary.org/obo/ICO_0000048> rdf:type owl:Class ;
+                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/OBI_0000245> ;
+                                             owl:disjointWith <http://purl.obolibrary.org/obo/ICO_0000049> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000115> "An organization that is operated without the principal goal of making a financial profit."@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000117> "Yongqun He"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/2020-08-27/ico.owl"^^xsd:string ;
+                                             rdfs:label "nonprofit organization"@en ;
+                                             :SMW_datatype "Category" ;
+                                             :SMW_import_info "[[Category:ICO]] [[Category:Imported vocabulary]]" .
 
 
 ###  http://purl.obolibrary.org/obo/ICO_0000049
-obo:ICO_0000049 rdf:type owl:Class ;
-                rdfs:subClassOf obo:OBI_0000245 ;
-                obo:IAO_0000115 "An organization which has the principle goal of earning financial profit."@en ;
-                obo:IAO_0000117 "Yongqun He"@en ;
-                obo:IAO_0000412 "http://purl.obolibrary.org/obo/2020-08-27/ico.owl"^^xsd:string ;
-                rdfs:label "profit organization"@en ;
-                aeon:SMW_datatype "Category" ;
-                aeon:SMW_import_info "[[Category:ICO]] [[Category:Imported vocabulary]]" .
+<http://purl.obolibrary.org/obo/ICO_0000049> rdf:type owl:Class ;
+                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/OBI_0000245> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000115> "An organization which has the principle goal of earning financial profit."@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000117> "Yongqun He"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/2020-08-27/ico.owl"^^xsd:string ;
+                                             rdfs:label "profit organization"@en ;
+                                             :SMW_datatype "Category" ;
+                                             :SMW_import_info "[[Category:ICO]] [[Category:Imported vocabulary]]" .
 
 
 ###  http://purl.obolibrary.org/obo/NCBITaxon_9606
-obo:NCBITaxon_9606 rdf:type owl:Class ;
-                   rdfs:subClassOf obo:OBI_0100026 ,
-                                   [ rdf:type owl:Restriction ;
-                                     owl:onProperty obo:IAO_0000235 ;
-                                     owl:someValuesFrom obo:IAO_0020015
-                                   ] ,
-                                   [ rdf:type owl:Restriction ;
-                                     owl:onProperty obo:IAO_0000235 ;
-                                     owl:someValuesFrom aeon:AEON_0000019
-                                   ] ;
-                   obo:IAO_0000111 "Homo sapiens"^^xsd:string ;
-                   obo:IAO_0000118 "human"^^xsd:string ,
-                                   "human being"^^xsd:string ,
-                                   "man"^^xsd:string ;
-                   obo:IAO_0000412 "http://purl.obolibrary.org/obo/obi/2020-12-16/obi.owl"^^xsd:string ;
-                   rdfs:label "Homo sapiens"^^xsd:string ;
-                   aeon:SMW_datatype "Category" ;
-                   aeon:SMW_import_info "[[Category:NCBITaxon]] [[Category:Imported vocabulary]]" .
+<http://purl.obolibrary.org/obo/NCBITaxon_9606> rdf:type owl:Class ;
+                                                rdfs:subClassOf <http://purl.obolibrary.org/obo/OBI_0100026> ,
+                                                                [ rdf:type owl:Restriction ;
+                                                                  owl:onProperty <http://purl.obolibrary.org/obo/IAO_0000235> ;
+                                                                  owl:someValuesFrom <http://purl.obolibrary.org/obo/IAO_0020015>
+                                                                ] ,
+                                                                [ rdf:type owl:Restriction ;
+                                                                  owl:onProperty <http://purl.obolibrary.org/obo/IAO_0000235> ;
+                                                                  owl:someValuesFrom :AEON_0000019
+                                                                ] ;
+                                                <http://purl.obolibrary.org/obo/IAO_0000111> "Homo sapiens"^^xsd:string ;
+                                                <http://purl.obolibrary.org/obo/IAO_0000118> "human"^^xsd:string ,
+                                                                                             "human being"^^xsd:string ,
+                                                                                             "man"^^xsd:string ;
+                                                <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/obi/2020-12-16/obi.owl"^^xsd:string ;
+                                                rdfs:label "Homo sapiens"^^xsd:string ;
+                                                :SMW_datatype "Category" ;
+                                                :SMW_import_info "[[Category:NCBITaxon]] [[Category:Imported vocabulary]]" .
 
 
 ###  http://purl.obolibrary.org/obo/OBI_0000011
-obo:OBI_0000011 rdf:type owl:Class ;
-                rdfs:subClassOf obo:BFO_0000015 ;
-                rdfs:label "planned process"@en .
+<http://purl.obolibrary.org/obo/OBI_0000011> rdf:type owl:Class ;
+                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/BFO_0000015> ;
+                                             rdfs:label "planned process"@en .
 
 
 ###  http://purl.obolibrary.org/obo/OBI_0000245
-obo:OBI_0000245 rdf:type owl:Class ;
-                rdfs:subClassOf obo:BFO_0000027 ;
-                obo:IAO_0000111 "organization"@en ;
-                obo:IAO_0000112 "PMID: 16353909.AAPS J. 2005 Sep 22;7(2):E274-80. Review. The joint food and agriculture organization of the United Nations/World Health Organization Expert Committee on Food Additives and its role in the evaluation of the safety of veterinary drug residues in foods."@en ;
-                obo:IAO_0000114 obo:IAO_0000122 ;
-                obo:IAO_0000115 "An entity that can bear roles, has members, and has a set of organization rules. Members of organizations are either organizations themselves or individual people. Members can bear specific organization member roles that are determined in the organization rules. The organization rules also determine how decisions are made on behalf of the organization by the organization members."@en ;
-                obo:IAO_0000116 """BP: The definition summarizes long email discussions on the OBI developer, roles, biomaterial and denrie branches. It leaves open if an organization is a material entity or a dependent continuant, as no consensus was reached on that.  The current placement as material is therefore temporary, in order to move forward with development. Here is the entire email summary, on which the definition is based:
+<http://purl.obolibrary.org/obo/OBI_0000245> rdf:type owl:Class ;
+                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/BFO_0000027> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000111> "organization"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000112> "PMID: 16353909.AAPS J. 2005 Sep 22;7(2):E274-80. Review. The joint food and agriculture organization of the United Nations/World Health Organization Expert Committee on Food Additives and its role in the evaluation of the safety of veterinary drug residues in foods."@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000122> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000115> "An entity that can bear roles, has members, and has a set of organization rules. Members of organizations are either organizations themselves or individual people. Members can bear specific organization member roles that are determined in the organization rules. The organization rules also determine how decisions are made on behalf of the organization by the organization members."@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000116> """BP: The definition summarizes long email discussions on the OBI developer, roles, biomaterial and denrie branches. It leaves open if an organization is a material entity or a dependent continuant, as no consensus was reached on that.  The current placement as material is therefore temporary, in order to move forward with development. Here is the entire email summary, on which the definition is based:
 
 1) there are organization_member_roles (president, treasurer, branch
 editor), with individual persons as bearers
@@ -2762,338 +2756,338 @@ This leads to my proposal: We define organization through the statements 1 -
 current place in the is_a hierarchy (material entity) or move it up to
 'continuant'. We leave further clarifications to BFO, and close this issue
 for now."""@en ;
-                obo:IAO_0000117 "PERSON: Alan Ruttenberg"^^xsd:string ,
-                                "PERSON: Bjoern Peters"^^xsd:string ,
-                                "PERSON: Philippe Rocca-Serra"^^xsd:string ,
-                                "PERSON: Susanna Sansone"^^xsd:string ;
-                obo:IAO_0000119 "GROUP: OBI"^^xsd:string ;
-                obo:IAO_0000412 "http://purl.obolibrary.org/obo/obi/2020-12-16/obi.owl"^^xsd:string ;
-                rdfs:label "organization"@en ;
-                aeon:SMW_datatype "Category" ;
-                aeon:SMW_import_info "[[Category:OBI]] [[Category:Imported vocabulary]]" .
+                                             <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Alan Ruttenberg"^^xsd:string ,
+                                                                                          "PERSON: Bjoern Peters"^^xsd:string ,
+                                                                                          "PERSON: Philippe Rocca-Serra"^^xsd:string ,
+                                                                                          "PERSON: Susanna Sansone"^^xsd:string ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000119> "GROUP: OBI"^^xsd:string ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/obi/2020-12-16/obi.owl"^^xsd:string ;
+                                             rdfs:label "organization"@en ;
+                                             :SMW_datatype "Category" ;
+                                             :SMW_import_info "[[Category:OBI]] [[Category:Imported vocabulary]]" .
 
 
 ###  http://purl.obolibrary.org/obo/OBI_0100026
-obo:OBI_0100026 rdf:type owl:Class ;
-                rdfs:subClassOf obo:BFO_0000030 ;
-                obo:IAO_0000111 "organizational term"@en ;
-                obo:IAO_0000112 "fungus; plant; virus; animal"@en ;
-                obo:IAO_0000114 "organizational term"@en ;
-                obo:IAO_0000116 "10/21/09: This is a placeholder term, that should ideally be imported from the NCBI taxonomy, but the high level hierarchy there does not suit our needs (includes plasmids and 'other organisms')"@en ,
-                                "13-02-2009: OBI doesn't take position as to when an organism starts or ends being an organism - e.g. sperm, foetus. This issue is outside the scope of OBI."@en ;
-                obo:IAO_0000119 "WEB: http://en.wikipedia.org/wiki/Organism"@en ;
-                rdfs:label "organism"@en .
+<http://purl.obolibrary.org/obo/OBI_0100026> rdf:type owl:Class ;
+                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/BFO_0000030> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000111> "organizational term"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000112> "fungus; plant; virus; animal"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000114> "organizational term"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000116> "10/21/09: This is a placeholder term, that should ideally be imported from the NCBI taxonomy, but the high level hierarchy there does not suit our needs (includes plasmids and 'other organisms')"@en ,
+                                                                                          "13-02-2009: OBI doesn't take position as to when an organism starts or ends being an organism - e.g. sperm, foetus. This issue is outside the scope of OBI."@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000119> "WEB: http://en.wikipedia.org/wiki/Organism"@en ;
+                                             rdfs:label "organism"@en .
 
 
 ###  http://www.w3.org/2004/02/skos/core#Concept
-skos:Concept rdf:type owl:Class ;
-             obo:IAO_0000115 """A SKOS concept can be viewed as an idea or notion; a unit of thought. However, what constitutes a unit of thought is subjective, and this definition is meant to be suggestive, rather than restrictive.
+<http://www.w3.org/2004/02/skos/core#Concept> rdf:type owl:Class ;
+                                              <http://purl.obolibrary.org/obo/IAO_0000115> """A SKOS concept can be viewed as an idea or notion; a unit of thought. However, what constitutes a unit of thought is subjective, and this definition is meant to be suggestive, rather than restrictive.
 
 The notion of a SKOS concept is useful when describing the conceptual or intellectual structure of a knowledge organization system, and when referring to specific ideas or meanings established within a KOS.
 
 Note that, because SKOS is designed to be a vehicle for representing semi-formal KOS, such as thesauri and classification schemes, a certain amount of flexibility has been built in to the formal definition of this class.
 
 See the [SKOS-PRIMER] for more examples of identifying and describing SKOS concepts."""@en ;
-             obo:IAO_0000412 "https://www.w3.org/2009/08/skos-reference/skos.html#Concept" ;
-             rdfs:label "Concept" ;
-             aeon:SMW_datatype "Category" ;
-             aeon:SMW_import_info "[[Category:SKOS]] [[Category:Imported vocabulary]]" .
+                                              <http://purl.obolibrary.org/obo/IAO_0000412> "https://www.w3.org/2009/08/skos-reference/skos.html#Concept" ;
+                                              rdfs:label "Concept" ;
+                                              :SMW_datatype "Category" ;
+                                              :SMW_import_info "[[Category:SKOS]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000001
-aeon:AEON_0000001 rdf:type owl:Class ;
-                  rdfs:subClassOf obo:OBI_0000011 ,
-                                  [ rdf:type owl:Restriction ;
-                                    owl:onProperty obo:BFO_0000055 ;
-                                    owl:someValuesFrom aeon:AEON_0000005
-                                  ] ,
-                                  [ rdf:type owl:Restriction ;
-                                    owl:onProperty aeon:AEON_0000084 ;
-                                    owl:someValuesFrom aeon:AEON_0000002
-                                  ] ;
-                  owl:disjointWith aeon:AEON_0000002 ;
-                  obo:IAO_0000112 "The 19th International Semantic Web Conference (ISWC2020) is an academic  event."@en ;
-                  obo:IAO_0000115 "An academic event is an organized gathering for researchers (not necessarily academics) to present and discuss their work."@en ;
-                  rdfs:comment """TODO:
+:AEON_0000001 rdf:type owl:Class ;
+              rdfs:subClassOf <http://purl.obolibrary.org/obo/OBI_0000011> ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000055> ;
+                                owl:someValuesFrom :AEON_0000005
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty :AEON_0000084 ;
+                                owl:someValuesFrom :AEON_0000002
+                              ] ;
+              owl:disjointWith :AEON_0000002 ;
+              <http://purl.obolibrary.org/obo/IAO_0000112> "The 19th International Semantic Web Conference (ISWC2020) is an academic  event."@en ;
+              <http://purl.obolibrary.org/obo/IAO_0000115> "An academic event is an organized gathering for researchers (not necessarily academics) to present and discuss their work."@en ;
+              rdfs:comment """TODO:
 * It needs to be discussed, if we need the \"process boundary\" class to describe the start and end of an academic event or event series.
 * It needs to be discussed, if we need the \"temporal region\" and \"spatiotemporal region\"  classes to describe the duration and manifestation in spacetime of an academic event or event series."""@en ;
-                  rdfs:label "academic event"@en ;
-                  aeon:AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Q1656682\", \"label\": \"eventLabel\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Category:Event\", \"label\": \"Event\"}, \"gnd\": {\"uri\": \"https://d-nb.info/standards/elementset/gnd#ConferenceOrEvent\", \"label\": \"Conference or Event\"}}"^^xsd:string ;
-                  aeon:SMW_datatype "Category" ;
-                  aeon:SMW_import_info """
+              rdfs:label "academic event"@en ;
+              :AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Q1656682\", \"label\": \"eventLabel\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Category:Event\", \"label\": \"Event\"}, \"gnd\": {\"uri\": \"https://d-nb.info/standards/elementset/gnd#ConferenceOrEvent\", \"label\": \"Conference or Event\"}}"^^xsd:string ;
+              :SMW_datatype "Category" ;
+              :SMW_import_info """
            [[Category:AEON]] [[Category:Imported vocabulary]]""" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000002
-aeon:AEON_0000002 rdf:type owl:Class ;
-                  rdfs:subClassOf obo:OBI_0000011 ,
-                                  [ rdf:type owl:Restriction ;
-                                    owl:onProperty obo:BFO_0000055 ;
-                                    owl:someValuesFrom aeon:AEON_0000005
-                                  ] ;
-                  obo:IAO_0000112 "International Semantic Web Conference (ISWC) series" ;
-                  rdfs:label "academic event series" ;
-                  aeon:AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Q15900647\", \"label\": \"conference_seriesLabel\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Category:Event_series\", \"label\": \"Event_series\"}, \"gnd\": {\"uri\": \"https://d-nb.info/standards/elementset/gnd#SeriesOfConferenceOrEvent\", \"label\": \"Series of conference or event\"}}"^^xsd:string ;
-                  aeon:SMW_datatype "Category" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:AEON_0000002 rdf:type owl:Class ;
+              rdfs:subClassOf <http://purl.obolibrary.org/obo/OBI_0000011> ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000055> ;
+                                owl:someValuesFrom :AEON_0000005
+                              ] ;
+              <http://purl.obolibrary.org/obo/IAO_0000112> "International Semantic Web Conference (ISWC) series" ;
+              rdfs:label "academic event series" ;
+              :AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Q15900647\", \"label\": \"conference_seriesLabel\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Category:Event_series\", \"label\": \"Event_series\"}, \"gnd\": {\"uri\": \"https://d-nb.info/standards/elementset/gnd#SeriesOfConferenceOrEvent\", \"label\": \"Series of conference or event\"}}"^^xsd:string ;
+              :SMW_datatype "Category" ;
+              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000003
-aeon:AEON_0000003 rdf:type owl:Class ;
-                  rdfs:subClassOf obo:IAO_0020000 ;
-                  obo:IAO_0000116 "The alternative term \"ConfIDent_ID\" is used here, as the ontology is being developed by the ConfIDent project (https://projects.tib.eu/en/confident/) to be used in its service. Thus the internal identifier is called \"ConfIDent ID\". You will probably want to change that in your implementation."@en ;
-                  obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
-                  obo:IAO_0000118 "ConfIDent ID"@en ;
-                  rdfs:label "internal identifier"@en ;
-                  ns:term_status obo:IAO_0000423 ;
-                  aeon:SMW_datatype "Category" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:AEON_0000003 rdf:type owl:Class ;
+              rdfs:subClassOf <http://purl.obolibrary.org/obo/IAO_0020000> ;
+              <http://purl.obolibrary.org/obo/IAO_0000116> "The alternative term \"ConfIDent_ID\" is used here, as the ontology is being developed by the ConfIDent project (https://projects.tib.eu/en/confident/) to be used in its service. Thus the internal identifier is called \"ConfIDent ID\". You will probably want to change that in your implementation."@en ;
+              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"@en ;
+              <http://purl.obolibrary.org/obo/IAO_0000118> "ConfIDent ID"@en ;
+              rdfs:label "internal identifier"@en ;
+              <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> <http://purl.obolibrary.org/obo/IAO_0000423> ;
+              :SMW_datatype "Category" ;
+              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000004
-aeon:AEON_0000004 rdf:type owl:Class ;
-                  rdfs:subClassOf skos:Concept ;
-                  obo:IAO_0000115 "An event type is a skos:Concept that is being used to distinguish between the different academic event formats."@en ;
-                  obo:IAO_0000116 "As the used definitions of the various academic event types can vary strongly between different communities and societies, we chose to model the type of an event as a SKOS concept instead of adding subclasses to the \"academic event\" class. The most commonly used event types are provided in AEON as named instances of this class."@en ;
-                  obo:IAO_0000117 "PERSON: Philip Strömert" ;
-                  rdfs:label "event type"@en ;
-                  aeon:SMW_datatype "Category" ;
-                  aeon:SMW_import_info "The individuals/instances of this class make up the allowed value list in [[MediaWiki:Smw_allows_list_has_event_type]]. [[Category:AEON]] [[Category:Imported vocabulary]]" .
+:AEON_0000004 rdf:type owl:Class ;
+              rdfs:subClassOf <http://www.w3.org/2004/02/skos/core#Concept> ;
+              <http://purl.obolibrary.org/obo/IAO_0000115> "An event type is a skos:Concept that is being used to distinguish between the different academic event formats."@en ;
+              <http://purl.obolibrary.org/obo/IAO_0000116> "As the used definitions of the various academic event types can vary strongly between different communities and societies, we chose to model the type of an event as a SKOS concept instead of adding subclasses to the \"academic event\" class. The most commonly used event types are provided in AEON as named instances of this class."@en ;
+              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert" ;
+              rdfs:label "event type"@en ;
+              :SMW_datatype "Category" ;
+              :SMW_import_info "The individuals/instances of this class make up the allowed value list in [[MediaWiki:Smw_allows_list_has_event_type]]. [[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000005
-aeon:AEON_0000005 rdf:type owl:Class ;
-                  owl:equivalentClass [ rdf:type owl:Restriction ;
-                                        owl:onProperty obo:RO_0000081 ;
-                                        owl:someValuesFrom [ rdf:type owl:Restriction ;
-                                                             owl:onProperty aeon:contibutes_to ;
-                                                             owl:someValuesFrom obo:OBI_0000011
-                                                           ]
-                                      ] ;
-                  rdfs:subClassOf obo:BFO_0000023 ,
-                                  [ rdf:type owl:Restriction ;
-                                    owl:onProperty obo:BFO_0000054 ;
-                                    owl:someValuesFrom obo:OBI_0000011
-                                  ] ,
-                                  [ rdf:type owl:Restriction ;
-                                    owl:onProperty obo:BFO_0000054 ;
-                                    owl:someValuesFrom aeon:AEON_0000001
-                                  ] ,
-                                  [ rdf:type owl:Restriction ;
-                                    owl:onProperty obo:BFO_0000054 ;
-                                    owl:someValuesFrom aeon:AEON_0000002
-                                  ] ,
-                                  [ rdf:type owl:Restriction ;
-                                    owl:onProperty obo:RO_0000081 ;
-                                    owl:someValuesFrom aeon:contributor
+:AEON_0000005 rdf:type owl:Class ;
+              owl:equivalentClass [ rdf:type owl:Restriction ;
+                                    owl:onProperty <http://purl.obolibrary.org/obo/RO_0000081> ;
+                                    owl:someValuesFrom [ rdf:type owl:Restriction ;
+                                                         owl:onProperty :contibutes_to ;
+                                                         owl:someValuesFrom <http://purl.obolibrary.org/obo/OBI_0000011>
+                                                       ]
                                   ] ;
-                  obo:IAO_0000115 "The contributor role inheres in a person or organization that participates in a planned process by somehow contributing to it."@en ;
-                  obo:IAO_0000117 "PERSON: Philip Strömert" ;
-                  <http://purl.org/dc/elements/1.1/date> "2020-09-28T12:51:02Z"^^xsd:dateTime ;
-                  rdfs:label "contributor role"@en ;
-                  aeon:SMW_datatype "Category" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+              rdfs:subClassOf <http://purl.obolibrary.org/obo/BFO_0000023> ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000054> ;
+                                owl:someValuesFrom <http://purl.obolibrary.org/obo/OBI_0000011>
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000054> ;
+                                owl:someValuesFrom :AEON_0000001
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000054> ;
+                                owl:someValuesFrom :AEON_0000002
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty <http://purl.obolibrary.org/obo/RO_0000081> ;
+                                owl:someValuesFrom :contributor
+                              ] ;
+              <http://purl.obolibrary.org/obo/IAO_0000115> "The contributor role inheres in a person or organization that participates in a planned process by somehow contributing to it."@en ;
+              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert" ;
+              <http://purl.org/dc/elements/1.1/date> "2020-09-28T12:51:02Z"^^xsd:dateTime ;
+              rdfs:label "contributor role"@en ;
+              :SMW_datatype "Category" ;
+              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000006
-aeon:AEON_0000006 rdf:type owl:Class ;
-                  owl:equivalentClass [ rdf:type owl:Restriction ;
-                                        owl:onProperty obo:RO_0000081 ;
-                                        owl:someValuesFrom [ rdf:type owl:Restriction ;
-                                                             owl:onProperty aeon:organizes ;
-                                                             owl:someValuesFrom obo:OBI_0000011
-                                                           ]
-                                      ] ;
-                  rdfs:subClassOf aeon:AEON_0000005 ;
-                  obo:IAO_0000115 "The organizer role inheres in a person or organization that contributes to a planned process by planning and managing its realization."@en ;
-                  obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
-                  rdfs:label "organizer role"@en ;
-                  aeon:SMW_datatype "Category" ;
-                  aeon:SMW_import_info """[[partOfSubobject::Template:Subobject Organizer]]
+:AEON_0000006 rdf:type owl:Class ;
+              owl:equivalentClass [ rdf:type owl:Restriction ;
+                                    owl:onProperty <http://purl.obolibrary.org/obo/RO_0000081> ;
+                                    owl:someValuesFrom [ rdf:type owl:Restriction ;
+                                                         owl:onProperty :organizes ;
+                                                         owl:someValuesFrom <http://purl.obolibrary.org/obo/OBI_0000011>
+                                                       ]
+                                  ] ;
+              rdfs:subClassOf :AEON_0000005 ;
+              <http://purl.obolibrary.org/obo/IAO_0000115> "The organizer role inheres in a person or organization that contributes to a planned process by planning and managing its realization."@en ;
+              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"@en ;
+              rdfs:label "organizer role"@en ;
+              :SMW_datatype "Category" ;
+              :SMW_import_info """[[partOfSubobject::Template:Subobject Organizer]]
 
 [[Category:AEON]] [[Category:Imported vocabulary]]""" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000007
-aeon:AEON_0000007 rdf:type owl:Class ;
-                  owl:equivalentClass [ rdf:type owl:Restriction ;
-                                        owl:onProperty obo:RO_0000081 ;
-                                        owl:someValuesFrom [ rdf:type owl:Restriction ;
-                                                             owl:onProperty aeon:committee_member_in ;
-                                                             owl:someValuesFrom obo:OBI_0000011
-                                                           ]
-                                      ] ;
-                  rdfs:subClassOf aeon:AEON_0000006 ;
-                  owl:disjointWith aeon:AEON_0000009 ;
-                  obo:IAO_0000115 "The 'committee member role' inheres in a person who contributes to a planned process by somehow realizing the function of the committe he is a member of."@en ;
-                  obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
-                  rdfs:label "event committee member role"@en ;
-                  aeon:SMW_datatype "Category" ;
-                  aeon:SMW_import_info """[[partOfSubobject::Template:Subobject Committee]]
+:AEON_0000007 rdf:type owl:Class ;
+              owl:equivalentClass [ rdf:type owl:Restriction ;
+                                    owl:onProperty <http://purl.obolibrary.org/obo/RO_0000081> ;
+                                    owl:someValuesFrom [ rdf:type owl:Restriction ;
+                                                         owl:onProperty :committee_member_in ;
+                                                         owl:someValuesFrom <http://purl.obolibrary.org/obo/OBI_0000011>
+                                                       ]
+                                  ] ;
+              rdfs:subClassOf :AEON_0000006 ;
+              owl:disjointWith :AEON_0000009 ;
+              <http://purl.obolibrary.org/obo/IAO_0000115> "The 'committee member role' inheres in a person who contributes to a planned process by somehow realizing the function of the committe he is a member of."@en ;
+              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"@en ;
+              rdfs:label "event committee member role"@en ;
+              :SMW_datatype "Category" ;
+              :SMW_import_info """[[partOfSubobject::Template:Subobject Committee]]
 
 [[Category:AEON]] [[Category:Imported vocabulary]]""" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000008
-aeon:AEON_0000008 rdf:type owl:Class ;
-                  owl:equivalentClass [ rdf:type owl:Restriction ;
-                                        owl:onProperty obo:RO_0000081 ;
-                                        owl:someValuesFrom [ rdf:type owl:Restriction ;
-                                                             owl:onProperty aeon:committee_chair_in ;
-                                                             owl:someValuesFrom obo:OBI_0000011
-                                                           ]
-                                      ] ;
-                  rdfs:subClassOf aeon:AEON_0000007 ;
-                  obo:IAO_0000115 "The 'committee chair role' inheres in a person who contributes to a planned process by somehow realizing the function of the committee he is a chair of."@en ;
-                  obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
-                  rdfs:label "event committee chair role"@en ;
-                  aeon:SMW_datatype "Category" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:AEON_0000008 rdf:type owl:Class ;
+              owl:equivalentClass [ rdf:type owl:Restriction ;
+                                    owl:onProperty <http://purl.obolibrary.org/obo/RO_0000081> ;
+                                    owl:someValuesFrom [ rdf:type owl:Restriction ;
+                                                         owl:onProperty :committee_chair_in ;
+                                                         owl:someValuesFrom <http://purl.obolibrary.org/obo/OBI_0000011>
+                                                       ]
+                                  ] ;
+              rdfs:subClassOf :AEON_0000007 ;
+              <http://purl.obolibrary.org/obo/IAO_0000115> "The 'committee chair role' inheres in a person who contributes to a planned process by somehow realizing the function of the committee he is a chair of."@en ;
+              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"@en ;
+              rdfs:label "event committee chair role"@en ;
+              :SMW_datatype "Category" ;
+              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000009
-aeon:AEON_0000009 rdf:type owl:Class ;
-                  owl:equivalentClass [ rdf:type owl:Restriction ;
-                                        owl:onProperty obo:RO_0000081 ;
-                                        owl:someValuesFrom [ rdf:type owl:Restriction ;
-                                                             owl:onProperty aeon:contact_person_of ;
-                                                             owl:someValuesFrom obo:OBI_0000011
-                                                           ]
-                                      ] ;
-                  rdfs:subClassOf aeon:AEON_0000006 ;
-                  obo:IAO_0000115 "The contact person role inheres in a person that contributes to a planned process by functioning as the addressee of the planned process who answers general inquiries and redirects more complex inqueries to a more appropriate addressee."@en ;
-                  obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
-                  rdfs:label "contact person role"@en ;
-                  aeon:SMW_datatype "Category" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:AEON_0000009 rdf:type owl:Class ;
+              owl:equivalentClass [ rdf:type owl:Restriction ;
+                                    owl:onProperty <http://purl.obolibrary.org/obo/RO_0000081> ;
+                                    owl:someValuesFrom [ rdf:type owl:Restriction ;
+                                                         owl:onProperty :contact_person_of ;
+                                                         owl:someValuesFrom <http://purl.obolibrary.org/obo/OBI_0000011>
+                                                       ]
+                                  ] ;
+              rdfs:subClassOf :AEON_0000006 ;
+              <http://purl.obolibrary.org/obo/IAO_0000115> "The contact person role inheres in a person that contributes to a planned process by functioning as the addressee of the planned process who answers general inquiries and redirects more complex inqueries to a more appropriate addressee."@en ;
+              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"@en ;
+              rdfs:label "contact person role"@en ;
+              :SMW_datatype "Category" ;
+              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000010
-aeon:AEON_0000010 rdf:type owl:Class ;
-                  owl:equivalentClass [ rdf:type owl:Restriction ;
-                                        owl:onProperty obo:RO_0000081 ;
-                                        owl:someValuesFrom [ rdf:type owl:Restriction ;
-                                                             owl:onProperty aeon:attends_at ;
-                                                             owl:someValuesFrom obo:OBI_0000011
-                                                           ]
-                                      ] ;
-                  rdfs:subClassOf aeon:AEON_0000005 ;
-                  obo:IAO_0000115 "The attendee role inheres in a person that contributes to a planned process by attending it."@en ;
-                  obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
-                  rdfs:label "attendee role"@en ;
-                  aeon:SMW_datatype "Category" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:AEON_0000010 rdf:type owl:Class ;
+              owl:equivalentClass [ rdf:type owl:Restriction ;
+                                    owl:onProperty <http://purl.obolibrary.org/obo/RO_0000081> ;
+                                    owl:someValuesFrom [ rdf:type owl:Restriction ;
+                                                         owl:onProperty :attends_at ;
+                                                         owl:someValuesFrom <http://purl.obolibrary.org/obo/OBI_0000011>
+                                                       ]
+                                  ] ;
+              rdfs:subClassOf :AEON_0000005 ;
+              <http://purl.obolibrary.org/obo/IAO_0000115> "The attendee role inheres in a person that contributes to a planned process by attending it."@en ;
+              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"@en ;
+              rdfs:label "attendee role"@en ;
+              :SMW_datatype "Category" ;
+              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000011
-aeon:AEON_0000011 rdf:type owl:Class ;
-                  owl:equivalentClass [ rdf:type owl:Restriction ;
-                                        owl:onProperty obo:RO_0000081 ;
-                                        owl:someValuesFrom [ rdf:type owl:Restriction ;
-                                                             owl:onProperty aeon:moderates_at ;
-                                                             owl:someValuesFrom obo:OBI_0000011
-                                                           ]
-                                      ] ;
-                  rdfs:subClassOf aeon:AEON_0000005 ;
-                  obo:IAO_0000115 "The moderating role inheres in a person that contributes to a planned process by facilitating the communication."@en ;
-                  obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
-                  rdfs:label "moderator role"@en ;
-                  aeon:SMW_datatype "Category" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:AEON_0000011 rdf:type owl:Class ;
+              owl:equivalentClass [ rdf:type owl:Restriction ;
+                                    owl:onProperty <http://purl.obolibrary.org/obo/RO_0000081> ;
+                                    owl:someValuesFrom [ rdf:type owl:Restriction ;
+                                                         owl:onProperty :moderates_at ;
+                                                         owl:someValuesFrom <http://purl.obolibrary.org/obo/OBI_0000011>
+                                                       ]
+                                  ] ;
+              rdfs:subClassOf :AEON_0000005 ;
+              <http://purl.obolibrary.org/obo/IAO_0000115> "The moderating role inheres in a person that contributes to a planned process by facilitating the communication."@en ;
+              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"@en ;
+              rdfs:label "moderator role"@en ;
+              :SMW_datatype "Category" ;
+              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000012
-aeon:AEON_0000012 rdf:type owl:Class ;
-                  owl:equivalentClass [ rdf:type owl:Restriction ;
-                                        owl:onProperty obo:RO_0000081 ;
-                                        owl:someValuesFrom [ rdf:type owl:Restriction ;
-                                                             owl:onProperty aeon:reviews_at ;
-                                                             owl:someValuesFrom obo:OBI_0000011
-                                                           ]
-                                      ] ;
-                  rdfs:subClassOf aeon:AEON_0000005 ;
-                  obo:IAO_0000115 "Evaluation of scientific, academic, or professional work, such as manuscripts or grants by others working in the same field."@en ,
-                                  "The reviewer role inheres in a person that contributes to a planned process by reviewing something of interest in a planned process."@en ;
-                  obo:IAO_0000116 "ToDo: use CRO IRI http://purl.obolibrary.org/obo/CRO_0000101"@en ;
-                  obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
-                  obo:IAO_0000118 "manuscript review role"@en ;
-                  rdfs:label "reviewer role"@en ;
-                  aeon:SMW_datatype "Category" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:AEON_0000012 rdf:type owl:Class ;
+              owl:equivalentClass [ rdf:type owl:Restriction ;
+                                    owl:onProperty <http://purl.obolibrary.org/obo/RO_0000081> ;
+                                    owl:someValuesFrom [ rdf:type owl:Restriction ;
+                                                         owl:onProperty :reviews_at ;
+                                                         owl:someValuesFrom <http://purl.obolibrary.org/obo/OBI_0000011>
+                                                       ]
+                                  ] ;
+              rdfs:subClassOf :AEON_0000005 ;
+              <http://purl.obolibrary.org/obo/IAO_0000115> "Evaluation of scientific, academic, or professional work, such as manuscripts or grants by others working in the same field."@en ,
+                                                           "The reviewer role inheres in a person that contributes to a planned process by reviewing something of interest in a planned process."@en ;
+              <http://purl.obolibrary.org/obo/IAO_0000116> "ToDo: use CRO IRI http://purl.obolibrary.org/obo/CRO_0000101"@en ;
+              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"@en ;
+              <http://purl.obolibrary.org/obo/IAO_0000118> "manuscript review role"@en ;
+              rdfs:label "reviewer role"@en ;
+              :SMW_datatype "Category" ;
+              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000013
-aeon:AEON_0000013 rdf:type owl:Class ;
-                  owl:equivalentClass [ rdf:type owl:Restriction ;
-                                        owl:onProperty obo:RO_0000081 ;
-                                        owl:someValuesFrom [ rdf:type owl:Restriction ;
-                                                             owl:onProperty aeon:speaks_at ;
-                                                             owl:someValuesFrom obo:OBI_0000011
-                                                           ]
-                                      ] ;
-                  rdfs:subClassOf aeon:AEON_0000005 ;
-                  obo:IAO_0000115 "The presenter role inheres in a person that contributes to a planned process by presenting something of interest at a planned process."@en ;
-                  obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
-                  obo:IAO_0000118 "invited speaker role"@en ;
-                  obo:IAO_0006011 "http://purl.obolibrary.org/obo/CRO_0000100"^^xsd:anyURI ;
-                  rdfs:label "presenter role"@en ;
-                  aeon:SMW_datatype "Category" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:AEON_0000013 rdf:type owl:Class ;
+              owl:equivalentClass [ rdf:type owl:Restriction ;
+                                    owl:onProperty <http://purl.obolibrary.org/obo/RO_0000081> ;
+                                    owl:someValuesFrom [ rdf:type owl:Restriction ;
+                                                         owl:onProperty :speaks_at ;
+                                                         owl:someValuesFrom <http://purl.obolibrary.org/obo/OBI_0000011>
+                                                       ]
+                                  ] ;
+              rdfs:subClassOf :AEON_0000005 ;
+              <http://purl.obolibrary.org/obo/IAO_0000115> "The presenter role inheres in a person that contributes to a planned process by presenting something of interest at a planned process."@en ;
+              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"@en ;
+              <http://purl.obolibrary.org/obo/IAO_0000118> "invited speaker role"@en ;
+              <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/CRO_0000100"^^xsd:anyURI ;
+              rdfs:label "presenter role"@en ;
+              :SMW_datatype "Category" ;
+              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000014
-aeon:AEON_0000014 rdf:type owl:Class ;
-                  owl:equivalentClass [ rdf:type owl:Restriction ;
-                                        owl:onProperty obo:RO_0000081 ;
-                                        owl:someValuesFrom [ rdf:type owl:Restriction ;
-                                                             owl:onProperty aeon:holds_keynote_at ;
-                                                             owl:someValuesFrom obo:OBI_0000011
-                                                           ]
-                                      ] ;
-                  rdfs:subClassOf aeon:AEON_0000013 ;
-                  obo:IAO_0000115 "The keynote speaker role inheres in a person that contributes to a planned process by holding a keynote speech at a planned process."@en ;
-                  obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
-                  rdfs:label "keynote speaker role"@en ;
-                  aeon:SMW_datatype "Category" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:AEON_0000014 rdf:type owl:Class ;
+              owl:equivalentClass [ rdf:type owl:Restriction ;
+                                    owl:onProperty <http://purl.obolibrary.org/obo/RO_0000081> ;
+                                    owl:someValuesFrom [ rdf:type owl:Restriction ;
+                                                         owl:onProperty :holds_keynote_at ;
+                                                         owl:someValuesFrom <http://purl.obolibrary.org/obo/OBI_0000011>
+                                                       ]
+                                  ] ;
+              rdfs:subClassOf :AEON_0000013 ;
+              <http://purl.obolibrary.org/obo/IAO_0000115> "The keynote speaker role inheres in a person that contributes to a planned process by holding a keynote speech at a planned process."@en ;
+              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"@en ;
+              rdfs:label "keynote speaker role"@en ;
+              :SMW_datatype "Category" ;
+              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000015
-aeon:AEON_0000015 rdf:type owl:Class ;
-                  owl:equivalentClass [ rdf:type owl:Restriction ;
-                                        owl:onProperty obo:RO_0000081 ;
-                                        owl:someValuesFrom [ rdf:type owl:Restriction ;
-                                                             owl:onProperty aeon:sponsors ;
-                                                             owl:someValuesFrom obo:OBI_0000011
-                                                           ]
-                                      ] ;
-                  rdfs:subClassOf aeon:AEON_0000005 ;
-                  obo:IAO_0000115 "The sponsor role inheres in a person or organization that contributes to a planned process by providing the financial or material ressources needed to realize a planned process."@en ;
-                  obo:IAO_0000116 "PS 2-9-2020: For me there is still the open question on how to best model the different sponsor types (e.g. gold, silver, bronze...). As the possible sponsor types can have various schemes, it seems best to have named individuals of the aeon:Sponsor class at the moment." ;
-                  obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
-                  rdfs:label "sponsor role"@en ;
-                  aeon:SMW_datatype "Category" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:AEON_0000015 rdf:type owl:Class ;
+              owl:equivalentClass [ rdf:type owl:Restriction ;
+                                    owl:onProperty <http://purl.obolibrary.org/obo/RO_0000081> ;
+                                    owl:someValuesFrom [ rdf:type owl:Restriction ;
+                                                         owl:onProperty :sponsors ;
+                                                         owl:someValuesFrom <http://purl.obolibrary.org/obo/OBI_0000011>
+                                                       ]
+                                  ] ;
+              rdfs:subClassOf :AEON_0000005 ;
+              <http://purl.obolibrary.org/obo/IAO_0000115> "The sponsor role inheres in a person or organization that contributes to a planned process by providing the financial or material ressources needed to realize a planned process."@en ;
+              <http://purl.obolibrary.org/obo/IAO_0000116> "PS 2-9-2020: For me there is still the open question on how to best model the different sponsor types (e.g. gold, silver, bronze...). As the possible sponsor types can have various schemes, it seems best to have named individuals of the aeon:Sponsor class at the moment." ;
+              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"@en ;
+              rdfs:label "sponsor role"@en ;
+              :SMW_datatype "Category" ;
+              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000016
-aeon:AEON_0000016 rdf:type owl:Class ;
-                  rdfs:subClassOf obo:IAO_0020000 ;
-                  obo:IAO_0000114 obo:IAO_0000423 ;
-                  obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
-                  rdfs:label "digital object identifier"@en ;
-                  aeon:SMW_datatype "Category" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:AEON_0000016 rdf:type owl:Class ;
+              rdfs:subClassOf <http://purl.obolibrary.org/obo/IAO_0020000> ;
+              <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000423> ;
+              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"@en ;
+              rdfs:label "digital object identifier"@en ;
+              :SMW_datatype "Category" ;
+              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000017
-aeon:AEON_0000017 rdf:type owl:Class ;
-                  rdfs:subClassOf obo:IAO_0000578 ;
-                  obo:IAO_0000114 obo:IAO_0000423 ;
-                  obo:IAO_0000117 "PERSON: Philip Strömert" ;
-                  rdfs:label "GND ID" ;
-                  aeon:SMW_datatype "Category" ;
-                  aeon:SMW_import_info """[[partOfSubobject::Template:Subobject External_Process_ID]]
+:AEON_0000017 rdf:type owl:Class ;
+              rdfs:subClassOf <http://purl.obolibrary.org/obo/IAO_0000578> ;
+              <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000423> ;
+              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert" ;
+              rdfs:label "GND ID" ;
+              :SMW_datatype "Category" ;
+              :SMW_import_info """[[partOfSubobject::Template:Subobject External_Process_ID]]
 [[partOfSubobject::Template:Subobject Person_ID]]
 [[partOfSubobject::Template:Subobject Organization_ID]]
 
@@ -3101,51 +3095,51 @@ aeon:AEON_0000017 rdf:type owl:Class ;
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000018
-aeon:AEON_0000018 rdf:type owl:Class ;
-                  rdfs:subClassOf obo:IAO_0000578 ;
-                  obo:IAO_0000114 obo:IAO_0000423 ;
-                  obo:IAO_0000117 "PERSON: Philip Strömert" ;
-                  rdfs:label "ISNI" ;
-                  aeon:SMW_datatype "Category" ;
-                  aeon:SMW_import_info """[[partOfSubobject::Template:Subobject Person_ID]]
+:AEON_0000018 rdf:type owl:Class ;
+              rdfs:subClassOf <http://purl.obolibrary.org/obo/IAO_0000578> ;
+              <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000423> ;
+              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert" ;
+              rdfs:label "ISNI" ;
+              :SMW_datatype "Category" ;
+              :SMW_import_info """[[partOfSubobject::Template:Subobject Person_ID]]
 [[partOfSubobject::Template:Subobject Organization_ID]]
 
 [[Category:AEON]] [[Category:Imported vocabulary]]""" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000019
-aeon:AEON_0000019 rdf:type owl:Class ;
-                  rdfs:subClassOf obo:IAO_0000578 ;
-                  obo:IAO_0000114 obo:IAO_0000423 ;
-                  obo:IAO_0000117 "PERSON: Philip Strömert" ;
-                  rdfs:label "ORCID" ;
-                  aeon:SMW_datatype "Category" ;
-                  aeon:SMW_import_info """[[partOfSubobject::Template:Subobject Person_ID]]
+:AEON_0000019 rdf:type owl:Class ;
+              rdfs:subClassOf <http://purl.obolibrary.org/obo/IAO_0000578> ;
+              <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000423> ;
+              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert" ;
+              rdfs:label "ORCID" ;
+              :SMW_datatype "Category" ;
+              :SMW_import_info """[[partOfSubobject::Template:Subobject Person_ID]]
 
 [[Category:AEON]] [[Category:Imported vocabulary]]""" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000020
-aeon:AEON_0000020 rdf:type owl:Class ;
-                  rdfs:subClassOf obo:IAO_0000578 ;
-                  obo:IAO_0000114 obo:IAO_0000423 ;
-                  obo:IAO_0000117 "PERSON: Philip Strömert" ;
-                  rdfs:label "ROR ID" ;
-                  aeon:SMW_datatype "Category" ;
-                  aeon:SMW_import_info """[[partOfSubobject::Template:Subobject Organization_ID]]
+:AEON_0000020 rdf:type owl:Class ;
+              rdfs:subClassOf <http://purl.obolibrary.org/obo/IAO_0000578> ;
+              <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000423> ;
+              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert" ;
+              rdfs:label "ROR ID" ;
+              :SMW_datatype "Category" ;
+              :SMW_import_info """[[partOfSubobject::Template:Subobject Organization_ID]]
 
 [[Category:AEON]] [[Category:Imported vocabulary]]""" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000021
-aeon:AEON_0000021 rdf:type owl:Class ;
-                  rdfs:subClassOf obo:IAO_0000578 ;
-                  obo:IAO_0000114 obo:IAO_0000423 ;
-                  obo:IAO_0000117 "PERSON: Philip Strömert" ;
-                  obo:IAO_0006011 "\"https://www.wikidata.org/wiki/\"^^ xsd:anyURI"@en ;
-                  rdfs:label "Wikidata QID"@en ;
-                  aeon:SMW_datatype "Category" ;
-                  aeon:SMW_import_info """[[partOfSubobject::Template:Subobject Process_External_ID]]
+:AEON_0000021 rdf:type owl:Class ;
+              rdfs:subClassOf <http://purl.obolibrary.org/obo/IAO_0000578> ;
+              <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000423> ;
+              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert" ;
+              <http://purl.obolibrary.org/obo/IAO_0006011> "\"https://www.wikidata.org/wiki/\"^^ xsd:anyURI"@en ;
+              rdfs:label "Wikidata QID"@en ;
+              :SMW_datatype "Category" ;
+              :SMW_import_info """[[partOfSubobject::Template:Subobject Process_External_ID]]
 [[partOfSubobject::Template:Subobject Person_ID]]
 [[partOfSubobject::Template:Subobject Organization_ID]]
 
@@ -3153,77 +3147,77 @@ aeon:AEON_0000021 rdf:type owl:Class ;
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000022
-aeon:AEON_0000022 rdf:type owl:Class ;
-                  rdfs:subClassOf obo:GAZ_00000448 ;
-                  rdfs:label "city"@en ;
-                  aeon:SMW_datatype "Category" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:AEON_0000022 rdf:type owl:Class ;
+              rdfs:subClassOf <http://purl.obolibrary.org/obo/GAZ_00000448> ;
+              rdfs:label "city"@en ;
+              :SMW_datatype "Category" ;
+              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000023
-aeon:AEON_0000023 rdf:type owl:Class ;
-                  rdfs:subClassOf obo:GAZ_00000448 ;
-                  rdfs:label "country"@en ;
-                  aeon:SMW_datatype "Category" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:AEON_0000023 rdf:type owl:Class ;
+              rdfs:subClassOf <http://purl.obolibrary.org/obo/GAZ_00000448> ;
+              rdfs:label "country"@en ;
+              :SMW_datatype "Category" ;
+              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000024
-aeon:AEON_0000024 rdf:type owl:Class ;
-                  rdfs:subClassOf obo:GAZ_00000448 ;
-                  obo:IAO_0000118 "province"@en ;
-                  rdfs:label "state"@en ;
-                  aeon:SMW_datatype "Category" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:AEON_0000024 rdf:type owl:Class ;
+              rdfs:subClassOf <http://purl.obolibrary.org/obo/GAZ_00000448> ;
+              <http://purl.obolibrary.org/obo/IAO_0000118> "province"@en ;
+              rdfs:label "state"@en ;
+              :SMW_datatype "Category" ;
+              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000025
-aeon:AEON_0000025 rdf:type owl:Class ;
-                  rdfs:subClassOf obo:GAZ_00000448 ;
-                  rdfs:label "event venue"@en ;
-                  aeon:SMW_datatype "Category" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:AEON_0000025 rdf:type owl:Class ;
+              rdfs:subClassOf <http://purl.obolibrary.org/obo/GAZ_00000448> ;
+              rdfs:label "event venue"@en ;
+              :SMW_datatype "Category" ;
+              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000027
-aeon:AEON_0000027 rdf:type owl:Class ;
-                  rdfs:subClassOf skos:Concept ;
-                  obo:IAO_0000112 "DDC 410 Linguistics, OECD 6.02 Languages and literature"@en ;
-                  obo:IAO_0000115 "'academic field' is a skos:Concept that describes the research field of an academic event or event series. As opposed to the class 'topic', the instances of this class must be terms from a controlled vocabulary or thesaurus."@en ;
-                  obo:IAO_0000117 "PERSON: Philip Strömert" ;
-                  rdfs:label "academic field"@en ;
-                  aeon:SMW_datatype "Category" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:AEON_0000027 rdf:type owl:Class ;
+              rdfs:subClassOf <http://www.w3.org/2004/02/skos/core#Concept> ;
+              <http://purl.obolibrary.org/obo/IAO_0000112> "DDC 410 Linguistics, OECD 6.02 Languages and literature"@en ;
+              <http://purl.obolibrary.org/obo/IAO_0000115> "'academic field' is a skos:Concept that describes the research field of an academic event or event series. As opposed to the class 'topic', the instances of this class must be terms from a controlled vocabulary or thesaurus."@en ;
+              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert" ;
+              rdfs:label "academic field"@en ;
+              :SMW_datatype "Category" ;
+              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000028
-aeon:AEON_0000028 rdf:type owl:Class ;
-                  rdfs:subClassOf skos:Concept ;
-                  obo:IAO_0000112 "\"The future of knowlegde graphs in the humanities\" could be a topic of an interdisciplinary oriented computer sciences conference."@en ;
-                  obo:IAO_0000115 "Topic is a skos:Concept that describes the central theme of an academic event or event series. In contrast to 'academic field' the instances of the class topic should not be terms of a controlled vocabulary or thesaurus."@en ;
-                  obo:IAO_0000117 "PERSON: Philip Strömert" ;
-                  rdfs:label "topic"@en .
+:AEON_0000028 rdf:type owl:Class ;
+              rdfs:subClassOf <http://www.w3.org/2004/02/skos/core#Concept> ;
+              <http://purl.obolibrary.org/obo/IAO_0000112> "\"The future of knowlegde graphs in the humanities\" could be a topic of an interdisciplinary oriented computer sciences conference."@en ;
+              <http://purl.obolibrary.org/obo/IAO_0000115> "Topic is a skos:Concept that describes the central theme of an academic event or event series. In contrast to 'academic field' the instances of the class topic should not be terms of a controlled vocabulary or thesaurus."@en ;
+              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert" ;
+              rdfs:label "topic"@en .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000029
-aeon:AEON_0000029 rdf:type owl:Class ;
-                  rdfs:subClassOf obo:BFO_0000029 ;
-                  obo:IAO_0000117 "Philip Strömert"^^xsd:string ;
-                  <http://purl.org/dc/elements/1.1/date> "2020-10-14T15:31:27Z"^^xsd:dateTime ;
-                  rdfs:label "virtual location"@en ;
-                  aeon:SMW_datatype "Category" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:AEON_0000029 rdf:type owl:Class ;
+              rdfs:subClassOf <http://purl.obolibrary.org/obo/BFO_0000029> ;
+              <http://purl.obolibrary.org/obo/IAO_0000117> "Philip Strömert"^^xsd:string ;
+              <http://purl.org/dc/elements/1.1/date> "2020-10-14T15:31:27Z"^^xsd:dateTime ;
+              rdfs:label "virtual location"@en ;
+              :SMW_datatype "Category" ;
+              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000030
-aeon:AEON_0000030 rdf:type owl:Class ;
-                  rdfs:subClassOf obo:IAO_0000030 ;
-                  obo:IAO_0000115 "The financial cost of attendance at a scientific event."@en ;
-                  obo:IAO_0000116 "PS: It needs to be discussed, if having fee as ICE is sufficient/correct."@en ;
-                  obo:IAO_0000117 "Philip Strömert"^^xsd:string ;
-                  rdfs:label "fee"@en ;
-                  aeon:SMW_datatype "Category" ;
-                  aeon:SMW_import_info """The individuals/instances of this class make up the allowed value list in [[MediaWiki:Smw_allows_list_Has_fee]].
+:AEON_0000030 rdf:type owl:Class ;
+              rdfs:subClassOf <http://purl.obolibrary.org/obo/IAO_0000030> ;
+              <http://purl.obolibrary.org/obo/IAO_0000115> "The financial cost of attendance at a scientific event."@en ;
+              <http://purl.obolibrary.org/obo/IAO_0000116> "PS: It needs to be discussed, if having fee as ICE is sufficient/correct."@en ;
+              <http://purl.obolibrary.org/obo/IAO_0000117> "Philip Strömert"^^xsd:string ;
+              rdfs:label "fee"@en ;
+              :SMW_datatype "Category" ;
+              :SMW_import_info """The individuals/instances of this class make up the allowed value list in [[MediaWiki:Smw_allows_list_Has_fee]].
 
 [[partOfSubobject::Template:Subobject Fee]]
 
@@ -3231,364 +3225,364 @@ aeon:AEON_0000030 rdf:type owl:Class ;
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000034
-aeon:AEON_0000034 rdf:type owl:Class ;
-                  rdfs:subClassOf obo:IAO_0020000 ;
-                  obo:IAO_0000114 obo:IAO_0000423 ;
-                  obo:IAO_0000117 "PERSON: Philip Strömert" ;
-                  <http://purl.org/dc/elements/1.1/date> "2020-11-20T17:31:33Z"^^xsd:dateTime ;
-                  rdfs:label "distributed identifier"@en .
+:AEON_0000034 rdf:type owl:Class ;
+              rdfs:subClassOf <http://purl.obolibrary.org/obo/IAO_0020000> ;
+              <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000423> ;
+              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert" ;
+              <http://purl.org/dc/elements/1.1/date> "2020-11-20T17:31:33Z"^^xsd:dateTime ;
+              rdfs:label "distributed identifier"@en .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000042
-aeon:AEON_0000042 rdf:type owl:Class ;
-                  rdfs:subClassOf obo:BFO_0000027 ;
-                  obo:IAO_0000600 "An academic event committee or commission is a body of one or more persons that is responsible for the realization of a certain task or aspect in an academic event."@en ;
-                  rdfs:label "event committee"@en ;
-                  ns:term_status "pending"@en ;
-                  aeon:SMW_datatype "Category" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+:AEON_0000042 rdf:type owl:Class ;
+              rdfs:subClassOf <http://purl.obolibrary.org/obo/BFO_0000027> ;
+              <http://purl.obolibrary.org/obo/IAO_0000600> "An academic event committee or commission is a body of one or more persons that is responsible for the realization of a certain task or aspect in an academic event."@en ;
+              rdfs:label "event committee"@en ;
+              <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "pending"@en ;
+              :SMW_datatype "Category" ;
+              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#attendee
-aeon:attendee rdf:type owl:Class ;
-              owl:equivalentClass [ rdf:type owl:Restriction ;
-                                    owl:onProperty obo:RO_0000087 ;
-                                    owl:someValuesFrom [ owl:intersectionOf ( aeon:AEON_0000010
-                                                                              [ rdf:type owl:Restriction ;
-                                                                                owl:onProperty obo:BFO_0000054 ;
-                                                                                owl:someValuesFrom obo:OBI_0000011
-                                                                              ]
-                                                                            ) ;
-                                                         rdf:type owl:Class
-                                                       ]
-                                  ] ;
-              rdfs:subClassOf aeon:contributor ;
-              obo:IAO_0000112 "Philip Strömert is an attendee of PIDapalooza 2021."@en ;
-              obo:IAO_0000114 obo:IAO_0000423 ;
-              obo:IAO_0000115 "An attendee is a contributer that holds an attendee role which is being realized in a planned process."@en ;
-              obo:IAO_0000116 """The general assumption is that the attendee role is being realized the moment someone shows up to an event which she is expected to participate in as part of an audience. Someone who plans to attend some academic event but never shows up during this event, would not be considered an attendee of the event.
+:attendee rdf:type owl:Class ;
+          owl:equivalentClass [ rdf:type owl:Restriction ;
+                                owl:onProperty <http://purl.obolibrary.org/obo/RO_0000087> ;
+                                owl:someValuesFrom [ owl:intersectionOf ( :AEON_0000010
+                                                                          [ rdf:type owl:Restriction ;
+                                                                            owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000054> ;
+                                                                            owl:someValuesFrom <http://purl.obolibrary.org/obo/OBI_0000011>
+                                                                          ]
+                                                                        ) ;
+                                                     rdf:type owl:Class
+                                                   ]
+                              ] ;
+          rdfs:subClassOf :contributor ;
+          <http://purl.obolibrary.org/obo/IAO_0000112> "Philip Strömert is an attendee of PIDapalooza 2021."@en ;
+          <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000423> ;
+          <http://purl.obolibrary.org/obo/IAO_0000115> "An attendee is a contributer that holds an attendee role which is being realized in a planned process."@en ;
+          <http://purl.obolibrary.org/obo/IAO_0000116> """The general assumption is that the attendee role is being realized the moment someone shows up to an event which she is expected to participate in as part of an audience. Someone who plans to attend some academic event but never shows up during this event, would not be considered an attendee of the event.
 
 Defining 'attendee' is not trivial, as the expectations of what an attendee must do, can differ from community to community and from event type to event type. For some an attendee must have been accredited by some official organizer and might only get a certificate of attendence at the end of it, when a certain amount of participation (e.g. visited sessions, completed workshops) has been achieved. For others it might suffice to simple be present."""@en ,
-                              "We need this concept of an attendee in order to be able to properly quantify the participation in a planned process. For this we would also need to have an action specification that is the conretizaion of the attendee role."@en ;
-              obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string ;
-              obo:IAO_0000600 "A person who participates actively or passively in an event."@en ;
-              rdfs:label "attendee"@en .
+                                                       "We need this concept of an attendee in order to be able to properly quantify the participation in a planned process. For this we would also need to have an action specification that is the conretizaion of the attendee role."@en ;
+          <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string ;
+          <http://purl.obolibrary.org/obo/IAO_0000600> "A person who participates actively or passively in an event."@en ;
+          rdfs:label "attendee"@en .
 
 
 ###  https://github.com/tibonto/aeon#committee_chair
-aeon:committee_chair rdf:type owl:Class ;
-                     owl:equivalentClass [ owl:intersectionOf ( [ rdf:type owl:Restriction ;
-                                                                  owl:onProperty obo:RO_0000087 ;
-                                                                  owl:someValuesFrom [ owl:intersectionOf ( aeon:AEON_0000008
-                                                                                                            [ rdf:type owl:Restriction ;
-                                                                                                              owl:onProperty obo:BFO_0000054 ;
-                                                                                                              owl:someValuesFrom obo:OBI_0000011
-                                                                                                            ]
-                                                                                                          ) ;
-                                                                                       rdf:type owl:Class
-                                                                                     ]
-                                                                ]
-                                                                [ rdf:type owl:Restriction ;
-                                                                  owl:onProperty obo:RO_0002350 ;
-                                                                  owl:someValuesFrom aeon:AEON_0000042
-                                                                ]
-                                                              ) ;
-                                           rdf:type owl:Class
-                                         ] ;
-                     rdfs:subClassOf aeon:committee_member ;
-                     obo:IAO_0000114 obo:IAO_0000423 ;
-                     obo:IAO_0000115 "A committee chair is a committee member that holds a committee chair role which is being realized in a planned process."@en ;
-                     obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string ;
-                     obo:IAO_0000600 "A committee chair is a committe member that is expected to speak on behalf of and to be responsible for the committee."@en ,
-                                     "The person who is in charge of a committee with primary responsibility for carrying out the committee's duties."@en ;
-                     rdfs:label "event committee chair"@en .
-
-
-###  https://github.com/tibonto/aeon#committee_member
-aeon:committee_member rdf:type owl:Class ;
-                      owl:equivalentClass [ owl:intersectionOf ( [ rdf:type owl:Restriction ;
-                                                                   owl:onProperty obo:RO_0000087 ;
-                                                                   owl:someValuesFrom [ owl:intersectionOf ( aeon:AEON_0000007
-                                                                                                             [ rdf:type owl:Restriction ;
-                                                                                                               owl:onProperty obo:BFO_0000054 ;
-                                                                                                               owl:someValuesFrom obo:OBI_0000011
-                                                                                                             ]
-                                                                                                           ) ;
-                                                                                        rdf:type owl:Class
-                                                                                      ]
-                                                                 ]
-                                                                 [ rdf:type owl:Restriction ;
-                                                                   owl:onProperty obo:RO_0002350 ;
-                                                                   owl:someValuesFrom aeon:AEON_0000042
-                                                                 ]
-                                                               ) ;
-                                            rdf:type owl:Class
-                                          ] ;
-                      rdfs:subClassOf aeon:organizer ,
-                                      [ rdf:type owl:Restriction ;
-                                        owl:onProperty obo:RO_0002350 ;
-                                        owl:someValuesFrom aeon:AEON_0000042
-                                      ] ;
-                      obo:IAO_0000114 obo:IAO_0000423 ;
-                      obo:IAO_0000115 "A committee member is an organizer that holds a committee member role which is being realized in a planned process."@en ;
-                      obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string ;
-                      rdfs:label "event committee member"@en .
-
-
-###  https://github.com/tibonto/aeon#contact_person
-aeon:contact_person rdf:type owl:Class ;
-                    owl:equivalentClass [ rdf:type owl:Restriction ;
-                                          owl:onProperty obo:RO_0000087 ;
-                                          owl:someValuesFrom [ owl:intersectionOf ( aeon:AEON_0000009
-                                                                                    [ rdf:type owl:Restriction ;
-                                                                                      owl:onProperty obo:BFO_0000054 ;
-                                                                                      owl:someValuesFrom obo:OBI_0000011
-                                                                                    ]
-                                                                                  ) ;
-                                                               rdf:type owl:Class
-                                                             ]
-                                        ] ;
-                    rdfs:subClassOf aeon:organizer ;
-                    obo:IAO_0000114 obo:IAO_0000423 ;
-                    obo:IAO_0000115 "A contact person is an organizer that holds a contact person role which is being realized in a planned process."@en ;
-                    obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string ;
-                    obo:IAO_0000600 "A contact peron is defined by its role to be the person who answers general questions about a planned process and who forwards any further inquiries to the appropriate recipiant."@en ;
-                    rdfs:label "contact person"@en .
-
-
-###  https://github.com/tibonto/aeon#contributor
-aeon:contributor rdf:type owl:Class ;
-                 owl:equivalentClass [ owl:intersectionOf ( [ rdf:type owl:Class ;
-                                                              owl:unionOf ( obo:NCBITaxon_9606
-                                                                            obo:OBI_0000245
-                                                                          )
-                                                            ]
-                                                            [ rdf:type owl:Restriction ;
-                                                              owl:onProperty obo:RO_0000087 ;
-                                                              owl:someValuesFrom [ owl:intersectionOf ( aeon:AEON_0000005
+:committee_chair rdf:type owl:Class ;
+                 owl:equivalentClass [ owl:intersectionOf ( [ rdf:type owl:Restriction ;
+                                                              owl:onProperty <http://purl.obolibrary.org/obo/RO_0000087> ;
+                                                              owl:someValuesFrom [ owl:intersectionOf ( :AEON_0000008
                                                                                                         [ rdf:type owl:Restriction ;
-                                                                                                          owl:onProperty obo:BFO_0000054 ;
-                                                                                                          owl:someValuesFrom obo:OBI_0000011
+                                                                                                          owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000054> ;
+                                                                                                          owl:someValuesFrom <http://purl.obolibrary.org/obo/OBI_0000011>
                                                                                                         ]
                                                                                                       ) ;
                                                                                    rdf:type owl:Class
                                                                                  ]
                                                             ]
+                                                            [ rdf:type owl:Restriction ;
+                                                              owl:onProperty <http://purl.obolibrary.org/obo/RO_0002350> ;
+                                                              owl:someValuesFrom :AEON_0000042
+                                                            ]
                                                           ) ;
                                        rdf:type owl:Class
                                      ] ;
-                 rdfs:subClassOf obo:BFO_0000040 ;
-                 obo:IAO_0000112 "All organizers and participants of the academic event called PIDapalooza 2020 are contributors of that particular event.."@en ;
-                 obo:IAO_0000114 obo:IAO_0000423 ;
-                 obo:IAO_0000115 "A contributor is a person or organization that holds a contributor role which is being realized in a planned process."@en ;
-                 obo:IAO_0000116 ""@en ,
-                                 "An academic conference is being realized by the contributions of different kinds of people and organizations. The organizers plan the program and manage the needed logistics. The sponsors provide the resources and funds needed for the realization. The speakers contribute by presenting their academic work. The reviewers make sure the submitted work is worth to be presented. The moderators make sure that the mode of communication is caried out as planned by the organizer. The attendees contribute by being there as the audience, providing feedback and by making up the pool of possible future collaborators."@en ,
-                                 """This class and its children should be defined in an ontology that covers the domain of contributorship in the sciences. 
+                 rdfs:subClassOf :committee_member ;
+                 <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000423> ;
+                 <http://purl.obolibrary.org/obo/IAO_0000115> "A committee chair is a committee member that holds a committee chair role which is being realized in a planned process."@en ;
+                 <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string ;
+                 <http://purl.obolibrary.org/obo/IAO_0000600> "A committee chair is a committe member that is expected to speak on behalf of and to be responsible for the committee."@en ,
+                                                              "The person who is in charge of a committee with primary responsibility for carrying out the committee's duties."@en ;
+                 rdfs:label "event committee chair"@en .
+
+
+###  https://github.com/tibonto/aeon#committee_member
+:committee_member rdf:type owl:Class ;
+                  owl:equivalentClass [ owl:intersectionOf ( [ rdf:type owl:Restriction ;
+                                                               owl:onProperty <http://purl.obolibrary.org/obo/RO_0000087> ;
+                                                               owl:someValuesFrom [ owl:intersectionOf ( :AEON_0000007
+                                                                                                         [ rdf:type owl:Restriction ;
+                                                                                                           owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000054> ;
+                                                                                                           owl:someValuesFrom <http://purl.obolibrary.org/obo/OBI_0000011>
+                                                                                                         ]
+                                                                                                       ) ;
+                                                                                    rdf:type owl:Class
+                                                                                  ]
+                                                             ]
+                                                             [ rdf:type owl:Restriction ;
+                                                               owl:onProperty <http://purl.obolibrary.org/obo/RO_0002350> ;
+                                                               owl:someValuesFrom :AEON_0000042
+                                                             ]
+                                                           ) ;
+                                        rdf:type owl:Class
+                                      ] ;
+                  rdfs:subClassOf :organizer ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty <http://purl.obolibrary.org/obo/RO_0002350> ;
+                                    owl:someValuesFrom :AEON_0000042
+                                  ] ;
+                  <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000423> ;
+                  <http://purl.obolibrary.org/obo/IAO_0000115> "A committee member is an organizer that holds a committee member role which is being realized in a planned process."@en ;
+                  <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string ;
+                  rdfs:label "event committee member"@en .
+
+
+###  https://github.com/tibonto/aeon#contact_person
+:contact_person rdf:type owl:Class ;
+                owl:equivalentClass [ rdf:type owl:Restriction ;
+                                      owl:onProperty <http://purl.obolibrary.org/obo/RO_0000087> ;
+                                      owl:someValuesFrom [ owl:intersectionOf ( :AEON_0000009
+                                                                                [ rdf:type owl:Restriction ;
+                                                                                  owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000054> ;
+                                                                                  owl:someValuesFrom <http://purl.obolibrary.org/obo/OBI_0000011>
+                                                                                ]
+                                                                              ) ;
+                                                           rdf:type owl:Class
+                                                         ]
+                                    ] ;
+                rdfs:subClassOf :organizer ;
+                <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000423> ;
+                <http://purl.obolibrary.org/obo/IAO_0000115> "A contact person is an organizer that holds a contact person role which is being realized in a planned process."@en ;
+                <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string ;
+                <http://purl.obolibrary.org/obo/IAO_0000600> "A contact peron is defined by its role to be the person who answers general questions about a planned process and who forwards any further inquiries to the appropriate recipiant."@en ;
+                rdfs:label "contact person"@en .
+
+
+###  https://github.com/tibonto/aeon#contributor
+:contributor rdf:type owl:Class ;
+             owl:equivalentClass [ owl:intersectionOf ( [ rdf:type owl:Class ;
+                                                          owl:unionOf ( <http://purl.obolibrary.org/obo/NCBITaxon_9606>
+                                                                        <http://purl.obolibrary.org/obo/OBI_0000245>
+                                                                      )
+                                                        ]
+                                                        [ rdf:type owl:Restriction ;
+                                                          owl:onProperty <http://purl.obolibrary.org/obo/RO_0000087> ;
+                                                          owl:someValuesFrom [ owl:intersectionOf ( :AEON_0000005
+                                                                                                    [ rdf:type owl:Restriction ;
+                                                                                                      owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000054> ;
+                                                                                                      owl:someValuesFrom <http://purl.obolibrary.org/obo/OBI_0000011>
+                                                                                                    ]
+                                                                                                  ) ;
+                                                                               rdf:type owl:Class
+                                                                             ]
+                                                        ]
+                                                      ) ;
+                                   rdf:type owl:Class
+                                 ] ;
+             rdfs:subClassOf <http://purl.obolibrary.org/obo/BFO_0000040> ;
+             <http://purl.obolibrary.org/obo/IAO_0000112> "All organizers and participants of the academic event called PIDapalooza 2020 are contributors of that particular event.."@en ;
+             <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000423> ;
+             <http://purl.obolibrary.org/obo/IAO_0000115> "A contributor is a person or organization that holds a contributor role which is being realized in a planned process."@en ;
+             <http://purl.obolibrary.org/obo/IAO_0000116> ""@en ,
+                                                          "An academic conference is being realized by the contributions of different kinds of people and organizations. The organizers plan the program and manage the needed logistics. The sponsors provide the resources and funds needed for the realization. The speakers contribute by presenting their academic work. The reviewers make sure the submitted work is worth to be presented. The moderators make sure that the mode of communication is caried out as planned by the organizer. The attendees contribute by being there as the audience, providing feedback and by making up the pool of possible future collaborators."@en ,
+                                                          """This class and its children should be defined in an ontology that covers the domain of contributorship in the sciences. 
 The contributor ontology (CRO - http://purl.obolibrary.org/obo/cro.owl) seems to be the best place. However at the moment CRO only covers \"the diverse roles performed in the work leading to a published research output in the sciences.\" An academic event or event series should ot be understood as a published research output, as they are procceses (occurents) and not ICEs."""@en ;
-                 obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string ;
-                 obo:IAO_0000600 "A person or organization can only be considered a contributor of some planned process, if and only if the act of contributing has been fulfilled. The contributor role is being realized, when the task (objective specification) attached to this role has been achieved somehow. It can thus be possible for a person or organization to hold multiple roles either in the same or in different planned processes."@en ;
-                 rdfs:label "contributor"@en ;
-                 ns:term_status "TODO: There needs to be an ICE branch in AEON covering the action and objective specifications which the various contributors have to concretize when realizing their roles. The concretization of these specification calsses needs to be axiomized here and in the various contributor roles."@en .
+             <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string ;
+             <http://purl.obolibrary.org/obo/IAO_0000600> "A person or organization can only be considered a contributor of some planned process, if and only if the act of contributing has been fulfilled. The contributor role is being realized, when the task (objective specification) attached to this role has been achieved somehow. It can thus be possible for a person or organization to hold multiple roles either in the same or in different planned processes."@en ;
+             rdfs:label "contributor"@en ;
+             <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "TODO: There needs to be an ICE branch in AEON covering the action and objective specifications which the various contributors have to concretize when realizing their roles. The concretization of these specification calsses needs to be axiomized here and in the various contributor roles."@en .
 
 
 ###  https://github.com/tibonto/aeon#finance_committee
-aeon:finance_committee rdf:type owl:Class ;
-                       rdfs:subClassOf aeon:AEON_0000042 ;
-                       obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string ;
-                       obo:IAO_0000600 "The finance committee has the task of monitoring the budget of an academic event."@en ;
-                       rdfs:label "event finance committee"@en .
+:finance_committee rdf:type owl:Class ;
+                   rdfs:subClassOf :AEON_0000042 ;
+                   <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string ;
+                   <http://purl.obolibrary.org/obo/IAO_0000600> "The finance committee has the task of monitoring the budget of an academic event."@en ;
+                   rdfs:label "event finance committee"@en .
 
 
 ###  https://github.com/tibonto/aeon#general_committee
-aeon:general_committee rdf:type owl:Class ;
-                       rdfs:subClassOf aeon:AEON_0000042 ;
-                       obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string ;
-                       obo:IAO_0000118 "steering committee"@en ;
-                       obo:IAO_0000600 "The general or steering committee is responsible for the entire conceptual design of an academic event, from decisions on the content focus, budget, size, choice of venue and time, selection of other responsible persons, etc."@en ;
-                       rdfs:label "general committee"@en .
+:general_committee rdf:type owl:Class ;
+                   rdfs:subClassOf :AEON_0000042 ;
+                   <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string ;
+                   <http://purl.obolibrary.org/obo/IAO_0000118> "steering committee"@en ;
+                   <http://purl.obolibrary.org/obo/IAO_0000600> "The general or steering committee is responsible for the entire conceptual design of an academic event, from decisions on the content focus, budget, size, choice of venue and time, selection of other responsible persons, etc."@en ;
+                   rdfs:label "general committee"@en .
 
 
 ###  https://github.com/tibonto/aeon#keynote_speaker
-aeon:keynote_speaker rdf:type owl:Class ;
-                     owl:equivalentClass [ rdf:type owl:Restriction ;
-                                           owl:onProperty obo:RO_0000087 ;
-                                           owl:someValuesFrom [ owl:intersectionOf ( aeon:AEON_0000014
-                                                                                     [ rdf:type owl:Restriction ;
-                                                                                       owl:onProperty obo:BFO_0000054 ;
-                                                                                       owl:someValuesFrom obo:OBI_0000011
-                                                                                     ]
-                                                                                   ) ;
-                                                                rdf:type owl:Class
-                                                              ]
-                                         ] ;
-                     rdfs:subClassOf aeon:speaker ;
-                     obo:IAO_0000114 obo:IAO_0000423 ;
-                     obo:IAO_0000115 "A 'keynote speaker' is a presenter that holds a keynote speaker role which is being realized in a planned process."@en ;
-                     obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string ;
-                     obo:IAO_0000600 "An invited person - often a multiplier in his or her (research) field - responsible for delivering a keynote speech."@en ;
-                     rdfs:label "keynote speaker"@en .
+:keynote_speaker rdf:type owl:Class ;
+                 owl:equivalentClass [ rdf:type owl:Restriction ;
+                                       owl:onProperty <http://purl.obolibrary.org/obo/RO_0000087> ;
+                                       owl:someValuesFrom [ owl:intersectionOf ( :AEON_0000014
+                                                                                 [ rdf:type owl:Restriction ;
+                                                                                   owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000054> ;
+                                                                                   owl:someValuesFrom <http://purl.obolibrary.org/obo/OBI_0000011>
+                                                                                 ]
+                                                                               ) ;
+                                                            rdf:type owl:Class
+                                                          ]
+                                     ] ;
+                 rdfs:subClassOf :speaker ;
+                 <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000423> ;
+                 <http://purl.obolibrary.org/obo/IAO_0000115> "A 'keynote speaker' is a presenter that holds a keynote speaker role which is being realized in a planned process."@en ;
+                 <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string ;
+                 <http://purl.obolibrary.org/obo/IAO_0000600> "An invited person - often a multiplier in his or her (research) field - responsible for delivering a keynote speech."@en ;
+                 rdfs:label "keynote speaker"@en .
 
 
 ###  https://github.com/tibonto/aeon#local_committee
-aeon:local_committee rdf:type owl:Class ;
-                     rdfs:subClassOf aeon:AEON_0000042 ;
-                     obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string ;
-                     obo:IAO_0000600 "The local committee takes care of planning, organizing and carrying out an academic event on site (venue, registration, supply, accommodations etc.)"@en ;
-                     rdfs:label "local committee"@en .
+:local_committee rdf:type owl:Class ;
+                 rdfs:subClassOf :AEON_0000042 ;
+                 <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string ;
+                 <http://purl.obolibrary.org/obo/IAO_0000600> "The local committee takes care of planning, organizing and carrying out an academic event on site (venue, registration, supply, accommodations etc.)"@en ;
+                 rdfs:label "local committee"@en .
 
 
 ###  https://github.com/tibonto/aeon#moderator
-aeon:moderator rdf:type owl:Class ;
-               owl:equivalentClass [ rdf:type owl:Restriction ;
-                                     owl:onProperty obo:RO_0000087 ;
-                                     owl:someValuesFrom [ owl:intersectionOf ( aeon:AEON_0000011
-                                                                               [ rdf:type owl:Restriction ;
-                                                                                 owl:onProperty obo:BFO_0000054 ;
-                                                                                 owl:someValuesFrom obo:OBI_0000011
-                                                                               ]
-                                                                             ) ;
-                                                          rdf:type owl:Class
-                                                        ]
-                                   ] ;
-               rdfs:subClassOf aeon:contributor ;
-               obo:IAO_0000114 obo:IAO_0000423 ;
-               obo:IAO_0000115 "A moderator is a contributer that holds a moderating role which is being realized in a planned process."@en ;
-               obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string ;
-               obo:IAO_0000600 "A person responsible for facilitating a session at an academic event."@en ;
-               rdfs:label "moderator"@en .
+:moderator rdf:type owl:Class ;
+           owl:equivalentClass [ rdf:type owl:Restriction ;
+                                 owl:onProperty <http://purl.obolibrary.org/obo/RO_0000087> ;
+                                 owl:someValuesFrom [ owl:intersectionOf ( :AEON_0000011
+                                                                           [ rdf:type owl:Restriction ;
+                                                                             owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000054> ;
+                                                                             owl:someValuesFrom <http://purl.obolibrary.org/obo/OBI_0000011>
+                                                                           ]
+                                                                         ) ;
+                                                      rdf:type owl:Class
+                                                    ]
+                               ] ;
+           rdfs:subClassOf :contributor ;
+           <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000423> ;
+           <http://purl.obolibrary.org/obo/IAO_0000115> "A moderator is a contributer that holds a moderating role which is being realized in a planned process."@en ;
+           <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string ;
+           <http://purl.obolibrary.org/obo/IAO_0000600> "A person responsible for facilitating a session at an academic event."@en ;
+           rdfs:label "moderator"@en .
 
 
 ###  https://github.com/tibonto/aeon#organizer
-aeon:organizer rdf:type owl:Class ;
-               owl:equivalentClass [ rdf:type owl:Restriction ;
-                                     owl:onProperty obo:RO_0000087 ;
-                                     owl:someValuesFrom [ owl:intersectionOf ( aeon:AEON_0000006
-                                                                               [ rdf:type owl:Restriction ;
-                                                                                 owl:onProperty obo:BFO_0000054 ;
-                                                                                 owl:someValuesFrom obo:OBI_0000011
-                                                                               ]
-                                                                             ) ;
-                                                          rdf:type owl:Class
-                                                        ]
-                                   ] ;
-               rdfs:subClassOf aeon:contributor ;
-               obo:IAO_0000112 "DataCite is an organizer of PIDapalooza 2020."@en ,
-                               "Organizers of academic events or event series are often organizations that form special taks forces, or event committees, in order to plan and manage all aspects related to the realization of the event or event series." ;
-               obo:IAO_0000114 obo:IAO_0000423 ;
-               obo:IAO_0000115 "An organizer is a contributer that holds an organizing role which is being realized in a planned process."@en ;
-               obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string ;
-               obo:IAO_0000600 "A person or organization that is responsible for the planning and realization of a planned process." .
+:organizer rdf:type owl:Class ;
+           owl:equivalentClass [ rdf:type owl:Restriction ;
+                                 owl:onProperty <http://purl.obolibrary.org/obo/RO_0000087> ;
+                                 owl:someValuesFrom [ owl:intersectionOf ( :AEON_0000006
+                                                                           [ rdf:type owl:Restriction ;
+                                                                             owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000054> ;
+                                                                             owl:someValuesFrom <http://purl.obolibrary.org/obo/OBI_0000011>
+                                                                           ]
+                                                                         ) ;
+                                                      rdf:type owl:Class
+                                                    ]
+                               ] ;
+           rdfs:subClassOf :contributor ;
+           <http://purl.obolibrary.org/obo/IAO_0000112> "DataCite is an organizer of PIDapalooza 2020."@en ,
+                                                        "Organizers of academic events or event series are often organizations that form special taks forces, or event committees, in order to plan and manage all aspects related to the realization of the event or event series." ;
+           <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000423> ;
+           <http://purl.obolibrary.org/obo/IAO_0000115> "An organizer is a contributer that holds an organizing role which is being realized in a planned process."@en ;
+           <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string ;
+           <http://purl.obolibrary.org/obo/IAO_0000600> "A person or organization that is responsible for the planning and realization of a planned process." .
 
 
 ###  https://github.com/tibonto/aeon#program_committee
-aeon:program_committee rdf:type owl:Class ;
-                       rdfs:subClassOf aeon:AEON_0000042 ;
-                       obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string ;
-                       obo:IAO_0000600 "The programme committee is responsible for the selection of submissions (peer review process) and content of an academic event."@en ;
-                       rdfs:label "program committee"@en .
+:program_committee rdf:type owl:Class ;
+                   rdfs:subClassOf :AEON_0000042 ;
+                   <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string ;
+                   <http://purl.obolibrary.org/obo/IAO_0000600> "The programme committee is responsible for the selection of submissions (peer review process) and content of an academic event."@en ;
+                   rdfs:label "program committee"@en .
 
 
 ###  https://github.com/tibonto/aeon#publication_committee
-aeon:publication_committee rdf:type owl:Class ;
-                           rdfs:subClassOf aeon:AEON_0000042 ;
-                           obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string ;
-                           obo:IAO_0000600 "The publication committee deals with the publication of the proceedings of an academic event(editorial and peer review process)."@en ;
-                           rdfs:label "publication committee"@en .
+:publication_committee rdf:type owl:Class ;
+                       rdfs:subClassOf :AEON_0000042 ;
+                       <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string ;
+                       <http://purl.obolibrary.org/obo/IAO_0000600> "The publication committee deals with the publication of the proceedings of an academic event(editorial and peer review process)."@en ;
+                       rdfs:label "publication committee"@en .
 
 
 ###  https://github.com/tibonto/aeon#publicity_committee
-aeon:publicity_committee rdf:type owl:Class ;
-                         rdfs:subClassOf aeon:AEON_0000042 ;
-                         obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string ;
-                         obo:IAO_0000600 "The publicity committee is responsible for the external communication of an academic event: promotion, (social) media relations, web presence, further releases, etc."@en ;
-                         rdfs:label "publicity committee"@en .
+:publicity_committee rdf:type owl:Class ;
+                     rdfs:subClassOf :AEON_0000042 ;
+                     <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string ;
+                     <http://purl.obolibrary.org/obo/IAO_0000600> "The publicity committee is responsible for the external communication of an academic event: promotion, (social) media relations, web presence, further releases, etc."@en ;
+                     rdfs:label "publicity committee"@en .
 
 
 ###  https://github.com/tibonto/aeon#reviewer
-aeon:reviewer rdf:type owl:Class ;
-              owl:equivalentClass [ rdf:type owl:Restriction ;
-                                    owl:onProperty obo:RO_0000087 ;
-                                    owl:someValuesFrom [ owl:intersectionOf ( aeon:AEON_0000012
-                                                                              [ rdf:type owl:Restriction ;
-                                                                                owl:onProperty obo:BFO_0000054 ;
-                                                                                owl:someValuesFrom obo:OBI_0000011
-                                                                              ]
-                                                                            ) ;
-                                                         rdf:type owl:Class
-                                                       ]
-                                  ] ;
-              rdfs:subClassOf aeon:contributor ;
-              obo:IAO_0000112 "The reviewer of a conference who reviews the submitted papers."@en ;
-              obo:IAO_0000114 obo:IAO_0000423 ;
-              obo:IAO_0000115 "A reviewer is a contributer that holds a reviewer role which is being realized in a planned process."@en ;
-              obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string ;
-              rdfs:label "reviewer"@en .
+:reviewer rdf:type owl:Class ;
+          owl:equivalentClass [ rdf:type owl:Restriction ;
+                                owl:onProperty <http://purl.obolibrary.org/obo/RO_0000087> ;
+                                owl:someValuesFrom [ owl:intersectionOf ( :AEON_0000012
+                                                                          [ rdf:type owl:Restriction ;
+                                                                            owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000054> ;
+                                                                            owl:someValuesFrom <http://purl.obolibrary.org/obo/OBI_0000011>
+                                                                          ]
+                                                                        ) ;
+                                                     rdf:type owl:Class
+                                                   ]
+                              ] ;
+          rdfs:subClassOf :contributor ;
+          <http://purl.obolibrary.org/obo/IAO_0000112> "The reviewer of a conference who reviews the submitted papers."@en ;
+          <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000423> ;
+          <http://purl.obolibrary.org/obo/IAO_0000115> "A reviewer is a contributer that holds a reviewer role which is being realized in a planned process."@en ;
+          <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string ;
+          rdfs:label "reviewer"@en .
 
 
 ###  https://github.com/tibonto/aeon#speaker
-aeon:speaker rdf:type owl:Class ;
-             owl:equivalentClass [ rdf:type owl:Restriction ;
-                                   owl:onProperty obo:RO_0000087 ;
-                                   owl:someValuesFrom [ owl:intersectionOf ( aeon:AEON_0000013
-                                                                             [ rdf:type owl:Restriction ;
-                                                                               owl:onProperty obo:BFO_0000054 ;
-                                                                               owl:someValuesFrom obo:OBI_0000011
-                                                                             ]
-                                                                           ) ;
-                                                        rdf:type owl:Class
-                                                      ]
-                                 ] ;
-             rdfs:subClassOf aeon:contributor ;
-             obo:IAO_0000112 "A presenter is a person who's role it is to present some body of work to an audience."@en ,
-                             "Philip Strömert is a presenter at PIDapalooza 2021."@en ;
-             obo:IAO_0000114 obo:IAO_0000423 ;
-             obo:IAO_0000115 "A presenter is a contributer that holds a presenter role which is being realized in a planned process."@en ;
-             obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string ;
-             obo:IAO_0000118 "speaker"@en ;
-             rdfs:label "presenter"@en .
+:speaker rdf:type owl:Class ;
+         owl:equivalentClass [ rdf:type owl:Restriction ;
+                               owl:onProperty <http://purl.obolibrary.org/obo/RO_0000087> ;
+                               owl:someValuesFrom [ owl:intersectionOf ( :AEON_0000013
+                                                                         [ rdf:type owl:Restriction ;
+                                                                           owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000054> ;
+                                                                           owl:someValuesFrom <http://purl.obolibrary.org/obo/OBI_0000011>
+                                                                         ]
+                                                                       ) ;
+                                                    rdf:type owl:Class
+                                                  ]
+                             ] ;
+         rdfs:subClassOf :contributor ;
+         <http://purl.obolibrary.org/obo/IAO_0000112> "A presenter is a person who's role it is to present some body of work to an audience."@en ,
+                                                      "Philip Strömert is a presenter at PIDapalooza 2021."@en ;
+         <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000423> ;
+         <http://purl.obolibrary.org/obo/IAO_0000115> "A presenter is a contributer that holds a presenter role which is being realized in a planned process."@en ;
+         <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string ;
+         <http://purl.obolibrary.org/obo/IAO_0000118> "speaker"@en ;
+         rdfs:label "presenter"@en .
 
 
 ###  https://github.com/tibonto/aeon#sponsor
-aeon:sponsor rdf:type owl:Class ;
-             owl:equivalentClass [ rdf:type owl:Restriction ;
-                                   owl:onProperty obo:RO_0000087 ;
-                                   owl:someValuesFrom [ owl:intersectionOf ( aeon:AEON_0000015
-                                                                             [ rdf:type owl:Restriction ;
-                                                                               owl:onProperty obo:BFO_0000054 ;
-                                                                               owl:someValuesFrom obo:OBI_0000011
-                                                                             ]
-                                                                           ) ;
-                                                        rdf:type owl:Class
-                                                      ]
-                                 ] ;
-             rdfs:subClassOf aeon:contributor ;
-             obo:IAO_0000112 "An organization or person that promises to fund an academic event is a sponsor of that event the moment the promised funds have been recieved by the organizers of the event."@en ;
-             obo:IAO_0000114 obo:IAO_0000423 ;
-             obo:IAO_0000115 "A sponsor is a contributer that holds a sponsor role which is being realized in a planned process."@en ;
-             obo:IAO_0000116 "Philip Strömert 2-9-2020: For me there is still the open question on how to best model the different sponsor types (e.g. gold, silver, bronze...), as there are various schemes. At the moment any sponsor type other than gold, silver or bronze can be further specified by using the data property \"sponsor_type\". We could also reuse the \"event type a SKOS:concept\" pattern here. But it seems best to have a clear definition of each sponsor type, in order to be able to subclass them here and add the corresponding roles and properties."@en ;
-             obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string .
+:sponsor rdf:type owl:Class ;
+         owl:equivalentClass [ rdf:type owl:Restriction ;
+                               owl:onProperty <http://purl.obolibrary.org/obo/RO_0000087> ;
+                               owl:someValuesFrom [ owl:intersectionOf ( :AEON_0000015
+                                                                         [ rdf:type owl:Restriction ;
+                                                                           owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000054> ;
+                                                                           owl:someValuesFrom <http://purl.obolibrary.org/obo/OBI_0000011>
+                                                                         ]
+                                                                       ) ;
+                                                    rdf:type owl:Class
+                                                  ]
+                             ] ;
+         rdfs:subClassOf :contributor ;
+         <http://purl.obolibrary.org/obo/IAO_0000112> "An organization or person that promises to fund an academic event is a sponsor of that event the moment the promised funds have been recieved by the organizers of the event."@en ;
+         <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000423> ;
+         <http://purl.obolibrary.org/obo/IAO_0000115> "A sponsor is a contributer that holds a sponsor role which is being realized in a planned process."@en ;
+         <http://purl.obolibrary.org/obo/IAO_0000116> "Philip Strömert 2-9-2020: For me there is still the open question on how to best model the different sponsor types (e.g. gold, silver, bronze...), as there are various schemes. At the moment any sponsor type other than gold, silver or bronze can be further specified by using the data property \"sponsor_type\". We could also reuse the \"event type a SKOS:concept\" pattern here. But it seems best to have a clear definition of each sponsor type, in order to be able to subclass them here and add the corresponding roles and properties."@en ;
+         <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string .
 
 
 ###  https://github.com/tibonto/aeon#sponsorship_committee
-aeon:sponsorship_committee rdf:type owl:Class ;
-                           rdfs:subClassOf aeon:AEON_0000042 ;
-                           obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string ;
-                           rdfs:label "sponsorship committee"@en .
+:sponsorship_committee rdf:type owl:Class ;
+                       rdfs:subClassOf :AEON_0000042 ;
+                       <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string ;
+                       rdfs:label "sponsorship committee"@en .
 
 
 ###  https://github.com/tibonto/aeon#technical_committee
-aeon:technical_committee rdf:type owl:Class ;
-                         rdfs:subClassOf aeon:AEON_0000042 ;
-                         obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string ;
-                         rdfs:label "technical committee"@en .
+:technical_committee rdf:type owl:Class ;
+                     rdfs:subClassOf :AEON_0000042 ;
+                     <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string ;
+                     rdfs:label "technical committee"@en .
 
 
 ###  https://github.com/tibonto/aeon#wikiCFP_ID
-aeon:wikiCFP_ID rdf:type owl:Class ;
-                rdfs:subClassOf obo:IAO_0000578 ;
-                obo:IAO_0000117 "PERSON: Philip Strömert" ;
-                rdfs:label "wikiCFP ID" ;
-                ns:term_status obo:IAO_0000423 .
+:wikiCFP_ID rdf:type owl:Class ;
+            rdfs:subClassOf <http://purl.obolibrary.org/obo/IAO_0000578> ;
+            <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert" ;
+            rdfs:label "wikiCFP ID" ;
+            <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> <http://purl.obolibrary.org/obo/IAO_0000423> .
 
 
 #################################################################
@@ -3596,238 +3590,238 @@ aeon:wikiCFP_ID rdf:type owl:Class ;
 #################################################################
 
 ###  http://purl.obolibrary.org/obo/IAO_0000002
-obo:IAO_0000002 rdf:type owl:NamedIndividual ,
-                         obo:IAO_0000078 ;
-                obo:IAO_0000111 "example to be eventually removed"@en ;
-                rdfs:label "example to be eventually removed"@en .
+<http://purl.obolibrary.org/obo/IAO_0000002> rdf:type owl:NamedIndividual ,
+                                                      <http://purl.obolibrary.org/obo/IAO_0000078> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000111> "example to be eventually removed"@en ;
+                                             rdfs:label "example to be eventually removed"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000120
-obo:IAO_0000120 rdf:type owl:NamedIndividual ,
-                         obo:IAO_0000078 ;
-                obo:IAO_0000111 "metadata complete"@en ;
-                obo:IAO_0000115 "Class has all its metadata, but is either not guaranteed to be in its final location in the asserted IS_A hierarchy or refers to another class that is not complete."@en ;
-                rdfs:label "metadata complete"@en .
+<http://purl.obolibrary.org/obo/IAO_0000120> rdf:type owl:NamedIndividual ,
+                                                      <http://purl.obolibrary.org/obo/IAO_0000078> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000111> "metadata complete"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000115> "Class has all its metadata, but is either not guaranteed to be in its final location in the asserted IS_A hierarchy or refers to another class that is not complete."@en ;
+                                             rdfs:label "metadata complete"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000122
-obo:IAO_0000122 rdf:type owl:NamedIndividual ,
-                         obo:IAO_0000078 ;
-                obo:IAO_0000111 "ready for release"@en ;
-                obo:IAO_0000115 "Class has undergone final review, is ready for use, and will be included in the next release. Any class lacking \"ready_for_release\" should be considered likely to change place in hierarchy, have its definition refined, or be obsoleted in the next release.  Those classes deemed \"ready_for_release\" will also derived from a chain of ancestor classes that are also \"ready_for_release.\""@en ;
-                rdfs:label "ready for release"@en .
+<http://purl.obolibrary.org/obo/IAO_0000122> rdf:type owl:NamedIndividual ,
+                                                      <http://purl.obolibrary.org/obo/IAO_0000078> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000111> "ready for release"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000115> "Class has undergone final review, is ready for use, and will be included in the next release. Any class lacking \"ready_for_release\" should be considered likely to change place in hierarchy, have its definition refined, or be obsoleted in the next release.  Those classes deemed \"ready_for_release\" will also derived from a chain of ancestor classes that are also \"ready_for_release.\""@en ;
+                                             rdfs:label "ready for release"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000123
-obo:IAO_0000123 rdf:type owl:NamedIndividual ,
-                         obo:IAO_0000078 ;
-                obo:IAO_0000111 "metadata incomplete"@en ;
-                obo:IAO_0000115 "Class is being worked on; however, the metadata (including definition) are not complete or sufficiently clear to the branch editors."@en ;
-                rdfs:label "metadata incomplete"@en .
+<http://purl.obolibrary.org/obo/IAO_0000123> rdf:type owl:NamedIndividual ,
+                                                      <http://purl.obolibrary.org/obo/IAO_0000078> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000111> "metadata incomplete"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000115> "Class is being worked on; however, the metadata (including definition) are not complete or sufficiently clear to the branch editors."@en ;
+                                             rdfs:label "metadata incomplete"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000125
-obo:IAO_0000125 rdf:type owl:NamedIndividual ,
-                         obo:IAO_0000078 ;
-                obo:IAO_0000111 "pending final vetting"@en ;
-                obo:IAO_0000115 "All definitions, placement in the asserted IS_A hierarchy and required minimal metadata are complete. The class is awaiting a final review by someone other than the term editor."@en ;
-                rdfs:label "pending final vetting"@en .
+<http://purl.obolibrary.org/obo/IAO_0000125> rdf:type owl:NamedIndividual ,
+                                                      <http://purl.obolibrary.org/obo/IAO_0000078> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000111> "pending final vetting"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000115> "All definitions, placement in the asserted IS_A hierarchy and required minimal metadata are complete. The class is awaiting a final review by someone other than the term editor."@en ;
+                                             rdfs:label "pending final vetting"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000226
-obo:IAO_0000226 rdf:type owl:NamedIndividual ,
-                         obo:IAO_0000225 ,
-                         owl:Thing ;
-                obo:IAO_0000111 "placeholder removed"@en ;
-                rdfs:label "placeholder removed"@en .
+<http://purl.obolibrary.org/obo/IAO_0000226> rdf:type owl:NamedIndividual ,
+                                                      <http://purl.obolibrary.org/obo/IAO_0000225> ,
+                                                      owl:Thing ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000111> "placeholder removed"@en ;
+                                             rdfs:label "placeholder removed"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000227
-obo:IAO_0000227 rdf:type owl:NamedIndividual ,
-                         obo:IAO_0000225 ;
-                obo:IAO_0000111 "terms merged"@en ;
-                obo:IAO_0000116 "An editor note should explain what were the merged terms and the reason for the merge."@en ;
-                rdfs:label "terms merged"@en .
+<http://purl.obolibrary.org/obo/IAO_0000227> rdf:type owl:NamedIndividual ,
+                                                      <http://purl.obolibrary.org/obo/IAO_0000225> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000111> "terms merged"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000116> "An editor note should explain what were the merged terms and the reason for the merge."@en ;
+                                             rdfs:label "terms merged"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000228
-obo:IAO_0000228 rdf:type owl:NamedIndividual ,
-                         obo:IAO_0000225 ;
-                obo:IAO_0000111 "term imported"@en ;
-                obo:IAO_0000116 "This is to be used when the original term has been replaced by a term imported from an other ontology. An editor note should indicate what is the URI of the new term to use."@en ;
-                rdfs:label "term imported"@en .
+<http://purl.obolibrary.org/obo/IAO_0000228> rdf:type owl:NamedIndividual ,
+                                                      <http://purl.obolibrary.org/obo/IAO_0000225> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000111> "term imported"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000116> "This is to be used when the original term has been replaced by a term imported from an other ontology. An editor note should indicate what is the URI of the new term to use."@en ;
+                                             rdfs:label "term imported"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000229
-obo:IAO_0000229 rdf:type owl:NamedIndividual ,
-                         obo:IAO_0000225 ;
-                obo:IAO_0000111 "term split"@en ;
-                obo:IAO_0000116 "This is to be used when a term has been split in two or more new terms. An editor note should indicate the reason for the split and indicate the URIs of the new terms created."@en ;
-                rdfs:label "term split"@en .
+<http://purl.obolibrary.org/obo/IAO_0000229> rdf:type owl:NamedIndividual ,
+                                                      <http://purl.obolibrary.org/obo/IAO_0000225> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000111> "term split"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000116> "This is to be used when a term has been split in two or more new terms. An editor note should indicate the reason for the split and indicate the URIs of the new terms created."@en ;
+                                             rdfs:label "term split"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000423
-obo:IAO_0000423 rdf:type owl:NamedIndividual ,
-                         obo:IAO_0000078 ;
-                obo:IAO_0000111 "to be replaced with external ontology term"@en ;
-                obo:IAO_0000115 "Terms with this status should eventually replaced with a term from another ontology."@en ;
-                obo:IAO_0000117 "Alan Ruttenberg"@en ;
-                obo:IAO_0000119 "group:OBI"@en ;
-                rdfs:label "to be replaced with external ontology term"@en .
+<http://purl.obolibrary.org/obo/IAO_0000423> rdf:type owl:NamedIndividual ,
+                                                      <http://purl.obolibrary.org/obo/IAO_0000078> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000111> "to be replaced with external ontology term"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000115> "Terms with this status should eventually replaced with a term from another ontology."@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000117> "Alan Ruttenberg"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000119> "group:OBI"@en ;
+                                             rdfs:label "to be replaced with external ontology term"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000428
-obo:IAO_0000428 rdf:type owl:NamedIndividual ,
-                         obo:IAO_0000078 ;
-                obo:IAO_0000111 "requires discussion"@en ;
-                obo:IAO_0000115 "A term that is metadata complete, has been reviewed, and problems have been identified that require discussion before release. Such a term requires editor note(s) to identify the outstanding issues."@en ;
-                obo:IAO_0000117 "Alan Ruttenberg"@en ;
-                obo:IAO_0000119 "group:OBI"@en ;
-                rdfs:label "requires discussion"@en .
+<http://purl.obolibrary.org/obo/IAO_0000428> rdf:type owl:NamedIndividual ,
+                                                      <http://purl.obolibrary.org/obo/IAO_0000078> ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000111> "requires discussion"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000115> "A term that is metadata complete, has been reviewed, and problems have been identified that require discussion before release. Such a term requires editor note(s) to identify the outstanding issues."@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000117> "Alan Ruttenberg"@en ;
+                                             <http://purl.obolibrary.org/obo/IAO_0000119> "group:OBI"@en ;
+                                             rdfs:label "requires discussion"@en .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0010000
-aeon:AEON_0010000 rdf:type owl:NamedIndividual ,
-                           aeon:AEON_0000004 ;
-                  rdfs:label "Colloquium" .
+:AEON_0010000 rdf:type owl:NamedIndividual ,
+                       :AEON_0000004 ;
+              rdfs:label "Colloquium" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0010001
-aeon:AEON_0010001 rdf:type owl:NamedIndividual ,
-                           aeon:AEON_0000004 ;
-                  rdfs:label "Conference" .
+:AEON_0010001 rdf:type owl:NamedIndividual ,
+                       :AEON_0000004 ;
+              rdfs:label "Conference" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0010002
-aeon:AEON_0010002 rdf:type owl:NamedIndividual ,
-                           aeon:AEON_0000004 ;
-                  rdfs:label "Forum" .
+:AEON_0010002 rdf:type owl:NamedIndividual ,
+                       :AEON_0000004 ;
+              rdfs:label "Forum" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0010003
-aeon:AEON_0010003 rdf:type owl:NamedIndividual ,
-                           aeon:AEON_0000004 ;
-                  rdfs:label "Hackathon" .
+:AEON_0010003 rdf:type owl:NamedIndividual ,
+                       :AEON_0000004 ;
+              rdfs:label "Hackathon" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0010004
-aeon:AEON_0010004 rdf:type owl:NamedIndividual ,
-                           aeon:AEON_0000004 ;
-                  rdfs:label "Seminar" .
+:AEON_0010004 rdf:type owl:NamedIndividual ,
+                       :AEON_0000004 ;
+              rdfs:label "Seminar" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0010005
-aeon:AEON_0010005 rdf:type owl:NamedIndividual ,
-                           aeon:AEON_0000004 ;
-                  rdfs:label "Session" .
+:AEON_0010005 rdf:type owl:NamedIndividual ,
+                       :AEON_0000004 ;
+              rdfs:label "Session" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0010006
-aeon:AEON_0010006 rdf:type owl:NamedIndividual ,
-                           aeon:AEON_0000004 ;
-                  rdfs:label "Symposium" .
+:AEON_0010006 rdf:type owl:NamedIndividual ,
+                       :AEON_0000004 ;
+              rdfs:label "Symposium" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0010007
-aeon:AEON_0010007 rdf:type owl:NamedIndividual ,
-                           aeon:AEON_0000004 ;
-                  rdfs:label "Talk" .
+:AEON_0010007 rdf:type owl:NamedIndividual ,
+                       :AEON_0000004 ;
+              rdfs:label "Talk" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0010008
-aeon:AEON_0010008 rdf:type owl:NamedIndividual ,
-                           aeon:AEON_0000004 ;
-                  rdfs:label "Track" .
+:AEON_0010008 rdf:type owl:NamedIndividual ,
+                       :AEON_0000004 ;
+              rdfs:label "Track" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0010009
-aeon:AEON_0010009 rdf:type owl:NamedIndividual ,
-                           aeon:AEON_0000004 ;
-                  rdfs:label "Tutorial" .
+:AEON_0010009 rdf:type owl:NamedIndividual ,
+                       :AEON_0000004 ;
+              rdfs:label "Tutorial" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0010010
-aeon:AEON_0010010 rdf:type owl:NamedIndividual ,
-                           aeon:AEON_0000004 ;
-                  rdfs:label "Workshop" .
+:AEON_0010010 rdf:type owl:NamedIndividual ,
+                       :AEON_0000004 ;
+              rdfs:label "Workshop" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0010011
-aeon:AEON_0010011 rdf:type owl:NamedIndividual ,
-                           aeon:AEON_0000004 ;
-                  rdfs:label "Other event type"@en .
+:AEON_0010011 rdf:type owl:NamedIndividual ,
+                       :AEON_0000004 ;
+              rdfs:label "Other event type"@en .
 
 
 ###  https://github.com/tibonto/aeon#Lisbon
-aeon:Lisbon rdf:type owl:NamedIndividual .
+:Lisbon rdf:type owl:NamedIndividual .
 
 
 ###  https://github.com/tibonto/aeon#Portugal
-aeon:Portugal rdf:type owl:NamedIndividual .
+:Portugal rdf:type owl:NamedIndividual .
 
 
 ###  https://github.com/tibonto/aeon#_PIDapalooza
-aeon:_PIDapalooza rdf:type owl:NamedIndividual ;
-                  rdfs:comment obo:IAO_0000002 ;
-                  rdfs:label "_PIDapalooza"@en .
+:_PIDapalooza rdf:type owl:NamedIndividual ;
+              rdfs:comment <http://purl.obolibrary.org/obo/IAO_0000002> ;
+              rdfs:label "_PIDapalooza"@en .
 
 
 ###  https://github.com/tibonto/aeon#_PIDapalooza2020
-aeon:_PIDapalooza2020 rdf:type owl:NamedIndividual ;
-                      obo:BFO_0000055 aeon:__PIDapalooza_Role_1 ,
-                                      aeon:__PIDapalooza_Role_2 ;
-                      aeon:AEON_0000050 aeon:_Person_1 ;
-                      aeon:AEON_0000055 aeon:_Person_2 ;
-                      aeon:end_date "2020-01-30T17:00:00"^^xsd:dateTime ;
-                      aeon:number_of_attendees 117 ;
-                      aeon:number_of_tracks 13 ;
-                      aeon:start_date "2020-01-29T09:00:00"^^xsd:dateTime ;
-                      rdfs:comment obo:IAO_0000002 ;
-                      rdfs:label "_PIDapalooza2020"@en .
+:_PIDapalooza2020 rdf:type owl:NamedIndividual ;
+                  <http://purl.obolibrary.org/obo/BFO_0000055> :__PIDapalooza_Role_1 ,
+                                                               :__PIDapalooza_Role_2 ;
+                  :AEON_0000050 :_Person_1 ;
+                  :AEON_0000055 :_Person_2 ;
+                  :end_date "2020-01-30T17:00:00"^^xsd:dateTime ;
+                  :number_of_attendees 117 ;
+                  :number_of_tracks 13 ;
+                  :start_date "2020-01-29T09:00:00"^^xsd:dateTime ;
+                  rdfs:comment <http://purl.obolibrary.org/obo/IAO_0000002> ;
+                  rdfs:label "_PIDapalooza2020"@en .
 
 
 ###  https://github.com/tibonto/aeon#_PIDapalooza_general_committee
-aeon:_PIDapalooza_general_committee rdf:type owl:NamedIndividual ,
-                                             aeon:general_committee ;
-                                    obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string .
+:_PIDapalooza_general_committee rdf:type owl:NamedIndividual ,
+                                         :general_committee ;
+                                <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string .
 
 
 ###  https://github.com/tibonto/aeon#_Person_1
-aeon:_Person_1 rdf:type owl:NamedIndividual ;
-               obo:IAO_0000235 <https://orcid.org/0000-0002-1595-3213> ;
-               obo:RO_0000087 aeon:__PIDapalooza_Role_1 ;
-               aeon:first_name "Philip"^^xsd:string ;
-               aeon:last_name "Strömert"^^xsd:string ;
-               ns:term_status obo:IAO_0000002 .
+:_Person_1 rdf:type owl:NamedIndividual ;
+           <http://purl.obolibrary.org/obo/IAO_0000235> <https://orcid.org/0000-0002-1595-3213> ;
+           <http://purl.obolibrary.org/obo/RO_0000087> :__PIDapalooza_Role_1 ;
+           :first_name "Philip"^^xsd:string ;
+           :last_name "Strömert"^^xsd:string ;
+           <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> <http://purl.obolibrary.org/obo/IAO_0000002> .
 
 
 ###  https://github.com/tibonto/aeon#_Person_2
-aeon:_Person_2 rdf:type owl:NamedIndividual ;
-               obo:RO_0000087 aeon:__PIDapalooza_Role_2 ;
-               obo:RO_0002350 aeon:_PIDapalooza_general_committee ;
-               aeon:personal_name "Sam general committee Chair" ;
-               obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string .
+:_Person_2 rdf:type owl:NamedIndividual ;
+           <http://purl.obolibrary.org/obo/RO_0000087> :__PIDapalooza_Role_2 ;
+           <http://purl.obolibrary.org/obo/RO_0002350> :_PIDapalooza_general_committee ;
+           :personal_name "Sam general committee Chair" ;
+           <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string .
 
 
 ###  https://github.com/tibonto/aeon#__PIDapalooza_Role_1
-aeon:__PIDapalooza_Role_1 rdf:type owl:NamedIndividual ;
-                          obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string .
+:__PIDapalooza_Role_1 rdf:type owl:NamedIndividual ;
+                      <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string .
 
 
 ###  https://github.com/tibonto/aeon#__PIDapalooza_Role_2
-aeon:__PIDapalooza_Role_2 rdf:type owl:NamedIndividual ;
-                          obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string .
+:__PIDapalooza_Role_2 rdf:type owl:NamedIndividual ;
+                      <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string .
 
 
 ###  https://orcid.org/0000-0002-1595-3213
 <https://orcid.org/0000-0002-1595-3213> rdf:type owl:NamedIndividual ;
-                                        aeon:ID_base_URL "https://orcid.org/"^^xsd:anyURI .
+                                        :ID_base_URL "https://orcid.org/"^^xsd:anyURI .
 
 
 ###  https://www.wikidata.org/wiki/Q65929359
 <https://www.wikidata.org/wiki/Q65929359> rdf:type owl:NamedIndividual ;
-                                          aeon:ID_base_URL "https://www.wikidata.org/wiki/"^^xsd:anyURI ;
-                                          rdfs:comment obo:IAO_0000002 .
+                                          :ID_base_URL "https://www.wikidata.org/wiki/"^^xsd:anyURI ;
+                                          rdfs:comment <http://purl.obolibrary.org/obo/IAO_0000002> .
 
 
 #################################################################
@@ -3835,56 +3829,56 @@ aeon:__PIDapalooza_Role_2 rdf:type owl:NamedIndividual ;
 #################################################################
 
 [ rdf:type owl:AllDisjointClasses ;
-  owl:members ( obo:BFO_0000004
-                obo:BFO_0000020
-                obo:BFO_0000031
+  owl:members ( <http://purl.obolibrary.org/obo/BFO_0000004>
+                <http://purl.obolibrary.org/obo/BFO_0000020>
+                <http://purl.obolibrary.org/obo/BFO_0000031>
               )
 ] .
 
 
 [ rdf:type owl:AllDisjointClasses ;
-  owl:members ( obo:BFO_0000008
-                obo:BFO_0000011
-                obo:BFO_0000015
-                obo:BFO_0000035
+  owl:members ( <http://purl.obolibrary.org/obo/BFO_0000008>
+                <http://purl.obolibrary.org/obo/BFO_0000011>
+                <http://purl.obolibrary.org/obo/BFO_0000015>
+                <http://purl.obolibrary.org/obo/BFO_0000035>
               )
 ] .
 
 
 [ rdf:type owl:AllDisjointClasses ;
-  owl:members ( aeon:AEON_0000006
-                aeon:AEON_0000010
-                aeon:AEON_0000011
-                aeon:AEON_0000012
-                aeon:AEON_0000013
+  owl:members ( :AEON_0000006
+                :AEON_0000010
+                :AEON_0000011
+                :AEON_0000012
+                :AEON_0000013
               )
 ] .
 
 
 [ rdf:type owl:AllDifferent ;
-  owl:distinctMembers ( obo:IAO_0000226
-                        obo:IAO_0000227
-                        obo:IAO_0000228
-                        obo:IAO_0000229
+  owl:distinctMembers ( <http://purl.obolibrary.org/obo/IAO_0000226>
+                        <http://purl.obolibrary.org/obo/IAO_0000227>
+                        <http://purl.obolibrary.org/obo/IAO_0000228>
+                        <http://purl.obolibrary.org/obo/IAO_0000229>
                       )
 ] .
 
 
 [ rdf:type owl:AllDifferent ;
-  owl:distinctMembers ( aeon:AEON_0010000
-                        aeon:AEON_0010001
-                        aeon:AEON_0010002
-                        aeon:AEON_0010003
-                        aeon:AEON_0010004
-                        aeon:AEON_0010005
-                        aeon:AEON_0010006
-                        aeon:AEON_0010007
-                        aeon:AEON_0010008
-                        aeon:AEON_0010009
-                        aeon:AEON_0010010
-                        aeon:AEON_0010011
+  owl:distinctMembers ( :AEON_0010000
+                        :AEON_0010001
+                        :AEON_0010002
+                        :AEON_0010003
+                        :AEON_0010004
+                        :AEON_0010005
+                        :AEON_0010006
+                        :AEON_0010007
+                        :AEON_0010008
+                        :AEON_0010009
+                        :AEON_0010010
+                        :AEON_0010011
                       )
 ] .
 
 
-###  Generated by the OWL API (version 4.5.9.2019-02-01T07:24:44Z) https://github.com/owlcs/owlapi
+###  Generated by the OWL API (version 4.5.6) https://github.com/owlcs/owlapi

--- a/aeon.ttl
+++ b/aeon.ttl
@@ -1,9 +1,15 @@
 @prefix : <https://github.com/tibonto/aeon#> .
+@prefix dc: <http://dublincore.org/specifications/dublin-core/dcmi-terms/2012-06-14/> .
+@prefix ns: <http://www.w3.org/2003/06/sw-vocab-status/ns#> .
+@prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix aeon: <https://github.com/tibonto/aeon#> .
+@prefix obda: <https://w3id.org/obda/vocabulary#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @base <https://github.com/tibonto/aeon> .
 
 <https://github.com/tibonto/aeon> rdf:type owl:Ontology ;
@@ -23,46 +29,46 @@
 #################################################################
 
 ###  http://dublincore.org/specifications/dublin-core/dcmi-terms/2012-06-14/creator
-<http://dublincore.org/specifications/dublin-core/dcmi-terms/2012-06-14/creator> rdf:type owl:AnnotationProperty .
+dc:creator rdf:type owl:AnnotationProperty .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000111
-<http://purl.obolibrary.org/obo/IAO_0000111> rdf:type owl:AnnotationProperty ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000111> "editor preferred term"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000122> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000115> "The concise, meaningful, and human-friendly name for a class or property preferred by the ontology developers. (US-English)"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON:Daniel Schober"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000119> "GROUP:OBI:<http://purl.obolibrary.org/obo/obi>"@en ;
-                                             rdfs:isDefinedBy <http://purl.obolibrary.org/obo/iao.owl> ;
-                                             rdfs:label "editor preferred term"@en .
+obo:IAO_0000111 rdf:type owl:AnnotationProperty ;
+                obo:IAO_0000111 "editor preferred term"@en ;
+                obo:IAO_0000114 obo:IAO_0000122 ;
+                obo:IAO_0000115 "The concise, meaningful, and human-friendly name for a class or property preferred by the ontology developers. (US-English)"@en ;
+                obo:IAO_0000117 "PERSON:Daniel Schober"@en ;
+                obo:IAO_0000119 "GROUP:OBI:<http://purl.obolibrary.org/obo/obi>"@en ;
+                rdfs:isDefinedBy obo:iao.owl ;
+                rdfs:label "editor preferred term"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000112
-<http://purl.obolibrary.org/obo/IAO_0000112> rdf:type owl:AnnotationProperty ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000111> "example of usage"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000122> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000115> "A phrase describing how a term should be used and/or a citation to a work which uses it. May also include other kinds of examples that facilitate immediate understanding, such as widely know prototypes or instances of a class, or cases where a relation is said to hold."@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON:Daniel Schober"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000119> "GROUP:OBI:<http://purl.obolibrary.org/obo/obi>"@en ;
-                                             rdfs:isDefinedBy <http://purl.obolibrary.org/obo/iao.owl> ;
-                                             rdfs:label "example of usage"@en .
+obo:IAO_0000112 rdf:type owl:AnnotationProperty ;
+                obo:IAO_0000111 "example of usage"@en ;
+                obo:IAO_0000114 obo:IAO_0000122 ;
+                obo:IAO_0000115 "A phrase describing how a term should be used and/or a citation to a work which uses it. May also include other kinds of examples that facilitate immediate understanding, such as widely know prototypes or instances of a class, or cases where a relation is said to hold."@en ;
+                obo:IAO_0000117 "PERSON:Daniel Schober"@en ;
+                obo:IAO_0000119 "GROUP:OBI:<http://purl.obolibrary.org/obo/obi>"@en ;
+                rdfs:isDefinedBy obo:iao.owl ;
+                rdfs:label "example of usage"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000114
-<http://purl.obolibrary.org/obo/IAO_0000114> rdf:type owl:AnnotationProperty ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000111> "has curation status"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON:Alan Ruttenberg"@en ,
-                                                                                          "PERSON:Bill Bug"@en ,
-                                                                                          "PERSON:Melanie Courtot"@en ;
-                                             rdfs:label "has curation status"@en .
+obo:IAO_0000114 rdf:type owl:AnnotationProperty ;
+                obo:IAO_0000111 "has curation status"@en ;
+                obo:IAO_0000117 "PERSON:Alan Ruttenberg"@en ,
+                                "PERSON:Bill Bug"@en ,
+                                "PERSON:Melanie Courtot"@en ;
+                rdfs:label "has curation status"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000115
-<http://purl.obolibrary.org/obo/IAO_0000115> rdf:type owl:AnnotationProperty ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000111> "definition"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000122> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000115> "The official definition, explaining the meaning of a class or property. Shall be Aristotelian, formalized and normalized. Can be augmented with colloquial definitions."@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000116> """2012-04-05: 
+obo:IAO_0000115 rdf:type owl:AnnotationProperty ;
+                obo:IAO_0000111 "definition"@en ;
+                obo:IAO_0000114 obo:IAO_0000122 ;
+                obo:IAO_0000115 "The official definition, explaining the meaning of a class or property. Shall be Aristotelian, formalized and normalized. Can be augmented with colloquial definitions."@en ;
+                obo:IAO_0000116 """2012-04-05: 
 Barry Smith
 
 The official OBI definition, explaining the meaning of a class or property: 'Shall be Aristotelian, formalized and normalized. Can be augmented with colloquial definitions'  is terrible.
@@ -82,151 +88,151 @@ We don't have definitions of 'meaning' or 'expression' or 'property'. For 'refer
 Personally, I am more comfortable weakening definition to documentation, with instructions as to what is desirable. 
 
 We also have the outstanding issue of how to aim different definitions to different audiences. A clinical audience reading chebi wants a different sort of definition documentation/definition from a chemistry trained audience, and similarly there is a need for a definition that is adequate for an ontologist to work with.  """@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON:Daniel Schober"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000119> "GROUP:OBI:<http://purl.obolibrary.org/obo/obi>"@en ;
-                                             rdfs:isDefinedBy <http://purl.obolibrary.org/obo/iao.owl> ;
-                                             rdfs:label "definition" ,
-                                                        "definition"@en .
+                obo:IAO_0000117 "PERSON:Daniel Schober"@en ;
+                obo:IAO_0000119 "GROUP:OBI:<http://purl.obolibrary.org/obo/obi>"@en ;
+                rdfs:isDefinedBy obo:iao.owl ;
+                rdfs:label "definition" ,
+                           "definition"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000116
-<http://purl.obolibrary.org/obo/IAO_0000116> rdf:type owl:AnnotationProperty ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000111> "editor note"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000122> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000115> "An administrative note intended for its editor. It may not be included in the publication version of the ontology, so it should contain nothing necessary for end users to understand the ontology."@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON:Daniel Schober"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000119> "GROUP:OBI:<http://purl.obofoundry.org/obo/obi>"@en ;
-                                             rdfs:isDefinedBy <http://purl.obolibrary.org/obo/iao.owl> ;
-                                             rdfs:label "editor note"@en .
+obo:IAO_0000116 rdf:type owl:AnnotationProperty ;
+                obo:IAO_0000111 "editor note"@en ;
+                obo:IAO_0000114 obo:IAO_0000122 ;
+                obo:IAO_0000115 "An administrative note intended for its editor. It may not be included in the publication version of the ontology, so it should contain nothing necessary for end users to understand the ontology."@en ;
+                obo:IAO_0000117 "PERSON:Daniel Schober"@en ;
+                obo:IAO_0000119 "GROUP:OBI:<http://purl.obofoundry.org/obo/obi>"@en ;
+                rdfs:isDefinedBy obo:iao.owl ;
+                rdfs:label "editor note"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000117
-<http://purl.obolibrary.org/obo/IAO_0000117> rdf:type owl:AnnotationProperty ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000111> "term editor"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000122> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000115> "Name of editor entering the term in the file. The term editor is a point of contact for information regarding the term. The term editor may be, but is not always, the author of the definition, which may have been worked upon by several people"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000116> "20110707, MC: label update to term editor and definition modified accordingly. See https://github.com/information-artifact-ontology/IAO/issues/115."@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON:Daniel Schober"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000119> "GROUP:OBI:<http://purl.obolibrary.org/obo/obi>"@en ;
-                                             rdfs:isDefinedBy <http://purl.obolibrary.org/obo/iao.owl> ;
-                                             rdfs:label "definition editor" ,
-                                                        "definition editor"@en ,
-                                                        "term editor" ,
-                                                        "term editor"@en .
+obo:IAO_0000117 rdf:type owl:AnnotationProperty ;
+                obo:IAO_0000111 "term editor"@en ;
+                obo:IAO_0000114 obo:IAO_0000122 ;
+                obo:IAO_0000115 "Name of editor entering the term in the file. The term editor is a point of contact for information regarding the term. The term editor may be, but is not always, the author of the definition, which may have been worked upon by several people"@en ;
+                obo:IAO_0000116 "20110707, MC: label update to term editor and definition modified accordingly. See https://github.com/information-artifact-ontology/IAO/issues/115."@en ;
+                obo:IAO_0000117 "PERSON:Daniel Schober"@en ;
+                obo:IAO_0000119 "GROUP:OBI:<http://purl.obolibrary.org/obo/obi>"@en ;
+                rdfs:isDefinedBy obo:iao.owl ;
+                rdfs:label "definition editor" ,
+                           "definition editor"@en ,
+                           "term editor" ,
+                           "term editor"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000118
-<http://purl.obolibrary.org/obo/IAO_0000118> rdf:type owl:AnnotationProperty ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000111> "alternative term"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000125> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000115> "An alternative name for a class or property which means the same thing as the preferred name (semantically equivalent)"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON:Daniel Schober"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000119> "GROUP:OBI:<http://purl.obolibrary.org/obo/obi>"@en ;
-                                             rdfs:isDefinedBy <http://purl.obolibrary.org/obo/iao.owl> ;
-                                             rdfs:label "alternative term"@en .
+obo:IAO_0000118 rdf:type owl:AnnotationProperty ;
+                obo:IAO_0000111 "alternative term"@en ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 "An alternative name for a class or property which means the same thing as the preferred name (semantically equivalent)"@en ;
+                obo:IAO_0000117 "PERSON:Daniel Schober"@en ;
+                obo:IAO_0000119 "GROUP:OBI:<http://purl.obolibrary.org/obo/obi>"@en ;
+                rdfs:isDefinedBy obo:iao.owl ;
+                rdfs:label "alternative term"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000119
-<http://purl.obolibrary.org/obo/IAO_0000119> rdf:type owl:AnnotationProperty ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000111> "definition source"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000122> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000115> "Formal citation, e.g. identifier in external database to indicate / attribute source(s) for the definition. Free text indicate / attribute source(s) for the definition. EXAMPLE: Author Name, URI, MeSH Term C04, PUBMED ID, Wiki uri on 31.01.2007"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON:Daniel Schober"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000119> "Discussion on obo-discuss mailing-list, see http://bit.ly/hgm99w"@en ,
-                                                                                          "GROUP:OBI:<http://purl.obolibrary.org/obo/obi>"@en ;
-                                             rdfs:isDefinedBy <http://purl.obolibrary.org/obo/iao.owl> ;
-                                             rdfs:label "definition source"@en .
+obo:IAO_0000119 rdf:type owl:AnnotationProperty ;
+                obo:IAO_0000111 "definition source"@en ;
+                obo:IAO_0000114 obo:IAO_0000122 ;
+                obo:IAO_0000115 "Formal citation, e.g. identifier in external database to indicate / attribute source(s) for the definition. Free text indicate / attribute source(s) for the definition. EXAMPLE: Author Name, URI, MeSH Term C04, PUBMED ID, Wiki uri on 31.01.2007"@en ;
+                obo:IAO_0000117 "PERSON:Daniel Schober"@en ;
+                obo:IAO_0000119 "Discussion on obo-discuss mailing-list, see http://bit.ly/hgm99w"@en ,
+                                "GROUP:OBI:<http://purl.obolibrary.org/obo/obi>"@en ;
+                rdfs:isDefinedBy obo:iao.owl ;
+                rdfs:label "definition source"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000231
-<http://purl.obolibrary.org/obo/IAO_0000231> rdf:type owl:AnnotationProperty ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000111> "has obsolescence reason"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000115> "Relates an annotation property to an obsolescence reason. The values of obsolescence reasons come from a list of predefined terms, instances of the class obsolescence reason specification."@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON:Alan Ruttenberg"@en ,
-                                                                                          "PERSON:Melanie Courtot"@en ;
-                                             rdfs:label "has obsolescence reason"@en .
+obo:IAO_0000231 rdf:type owl:AnnotationProperty ;
+                obo:IAO_0000111 "has obsolescence reason"@en ;
+                obo:IAO_0000115 "Relates an annotation property to an obsolescence reason. The values of obsolescence reasons come from a list of predefined terms, instances of the class obsolescence reason specification."@en ;
+                obo:IAO_0000117 "PERSON:Alan Ruttenberg"@en ,
+                                "PERSON:Melanie Courtot"@en ;
+                rdfs:label "has obsolescence reason"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000232
-<http://purl.obolibrary.org/obo/IAO_0000232> rdf:type owl:AnnotationProperty ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000111> "curator note"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000122> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000115> "An administrative note of use for a curator but of no use for a user"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON:Alan Ruttenberg"@en ;
-                                             rdfs:isDefinedBy <http://purl.obolibrary.org/obo/iao.owl> ;
-                                             rdfs:label "curator note"@en .
+obo:IAO_0000232 rdf:type owl:AnnotationProperty ;
+                obo:IAO_0000111 "curator note"@en ;
+                obo:IAO_0000114 obo:IAO_0000122 ;
+                obo:IAO_0000115 "An administrative note of use for a curator but of no use for a user"@en ;
+                obo:IAO_0000117 "PERSON:Alan Ruttenberg"@en ;
+                rdfs:isDefinedBy obo:iao.owl ;
+                rdfs:label "curator note"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000233
-<http://purl.obolibrary.org/obo/IAO_0000233> rdf:type owl:AnnotationProperty ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000111> "term tracker item"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000112> "the URI for an OBI Terms ticket at sourceforge, such as https://sourceforge.net/p/obi/obi-terms/772/"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000125> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000115> "An IRI or similar locator for a request or discussion of an ontology term."@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000117> "Person: Jie Zheng, Chris Stoeckert, Alan Ruttenberg"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000119> "Person: Jie Zheng, Chris Stoeckert, Alan Ruttenberg"@en ;
-                                             rdfs:comment "The 'tracker item' can associate a tracker with a specific ontology term."@en ;
-                                             rdfs:label "term tracker item"@en .
+obo:IAO_0000233 rdf:type owl:AnnotationProperty ;
+                obo:IAO_0000111 "term tracker item"@en ;
+                obo:IAO_0000112 "the URI for an OBI Terms ticket at sourceforge, such as https://sourceforge.net/p/obi/obi-terms/772/"@en ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 "An IRI or similar locator for a request or discussion of an ontology term."@en ;
+                obo:IAO_0000117 "Person: Jie Zheng, Chris Stoeckert, Alan Ruttenberg"@en ;
+                obo:IAO_0000119 "Person: Jie Zheng, Chris Stoeckert, Alan Ruttenberg"@en ;
+                rdfs:comment "The 'tracker item' can associate a tracker with a specific ontology term."@en ;
+                rdfs:label "term tracker item"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000234
-<http://purl.obolibrary.org/obo/IAO_0000234> rdf:type owl:AnnotationProperty ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000111> "ontology term requester"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000125> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000115> "The name of the person, project, or organization that motivated inclusion of an ontology term by requesting its addition."@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000117> "Person: Jie Zheng, Chris Stoeckert, Alan Ruttenberg"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000119> "Person: Jie Zheng, Chris Stoeckert, Alan Ruttenberg"@en ;
-                                             rdfs:comment "The 'term requester' can credit the person, organization or project who request the ontology term." ;
-                                             rdfs:label "ontology term requester"@en .
+obo:IAO_0000234 rdf:type owl:AnnotationProperty ;
+                obo:IAO_0000111 "ontology term requester"@en ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 "The name of the person, project, or organization that motivated inclusion of an ontology term by requesting its addition."@en ;
+                obo:IAO_0000117 "Person: Jie Zheng, Chris Stoeckert, Alan Ruttenberg"@en ;
+                obo:IAO_0000119 "Person: Jie Zheng, Chris Stoeckert, Alan Ruttenberg"@en ;
+                rdfs:comment "The 'term requester' can credit the person, organization or project who request the ontology term." ;
+                rdfs:label "ontology term requester"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000412
-<http://purl.obolibrary.org/obo/IAO_0000412> rdf:type owl:AnnotationProperty ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000111> "imported from"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000125> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000115> "For external terms/classes, the ontology from which the term was imported"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON:Alan Ruttenberg"@en ,
-                                                                                          "PERSON:Melanie Courtot"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000119> "GROUP:OBI:<http://purl.obolibrary.org/obo/obi>"@en ;
-                                             rdfs:isDefinedBy <http://purl.obolibrary.org/obo/iao.owl> ;
-                                             rdfs:label "imported from"@en .
+obo:IAO_0000412 rdf:type owl:AnnotationProperty ;
+                obo:IAO_0000111 "imported from"@en ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 "For external terms/classes, the ontology from which the term was imported"@en ;
+                obo:IAO_0000117 "PERSON:Alan Ruttenberg"@en ,
+                                "PERSON:Melanie Courtot"@en ;
+                obo:IAO_0000119 "GROUP:OBI:<http://purl.obolibrary.org/obo/obi>"@en ;
+                rdfs:isDefinedBy obo:iao.owl ;
+                rdfs:label "imported from"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000600
-<http://purl.obolibrary.org/obo/IAO_0000600> rdf:type owl:AnnotationProperty ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000111> "elucidation"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000117> "person:Alan Ruttenberg"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000119> "Person:Barry Smith"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000600> "Primitive terms in a highest-level ontology such as BFO are terms which are so basic to our understanding of reality that there is no way of defining them in a non-circular fashion. For these, therefore, we can provide only elucidations, supplemented by examples and by axioms"@en ;
-                                             rdfs:isDefinedBy <http://purl.obolibrary.org/obo/iao.owl> ;
-                                             rdfs:label "elucidation"@en .
+obo:IAO_0000600 rdf:type owl:AnnotationProperty ;
+                obo:IAO_0000111 "elucidation"@en ;
+                obo:IAO_0000117 "person:Alan Ruttenberg"@en ;
+                obo:IAO_0000119 "Person:Barry Smith"@en ;
+                obo:IAO_0000600 "Primitive terms in a highest-level ontology such as BFO are terms which are so basic to our understanding of reality that there is no way of defining them in a non-circular fashion. For these, therefore, we can provide only elucidations, supplemented by examples and by axioms"@en ;
+                rdfs:isDefinedBy obo:iao.owl ;
+                rdfs:label "elucidation"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0006011
-<http://purl.obolibrary.org/obo/IAO_0006011> rdf:type owl:AnnotationProperty ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000111> "may be identical to"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000115> "A annotation relationship between two terms in an ontology that may refer to the same (natural) type but where more evidence is required before terms are merged."@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000117> "David Osumi-Sutherland"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000233> "#40"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000234> "VFB"@en ;
-                                             rdfs:comment "Edges asserting this should be annotated with to record evidence supporting the assertion and its provenance."@en ;
-                                             rdfs:label "may be identical to"@en .
+obo:IAO_0006011 rdf:type owl:AnnotationProperty ;
+                obo:IAO_0000111 "may be identical to"@en ;
+                obo:IAO_0000115 "A annotation relationship between two terms in an ontology that may refer to the same (natural) type but where more evidence is required before terms are merged."@en ;
+                obo:IAO_0000117 "David Osumi-Sutherland"@en ;
+                obo:IAO_0000233 "#40"@en ;
+                obo:IAO_0000234 "VFB"@en ;
+                rdfs:comment "Edges asserting this should be annotated with to record evidence supporting the assertion and its provenance."@en ;
+                rdfs:label "may be identical to"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0100001
-<http://purl.obolibrary.org/obo/IAO_0100001> rdf:type owl:AnnotationProperty ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000111> "term replaced by"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000125> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000115> "Use on obsolete terms, relating the term to another term that can be used as a substitute"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000117> "Person:Alan Ruttenberg"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000119> "Person:Alan Ruttenberg"@en ;
-                                             rdfs:comment "Add as annotation triples in the granting ontology"@en ;
-                                             rdfs:label "term replaced by"@en .
+obo:IAO_0100001 rdf:type owl:AnnotationProperty ;
+                obo:IAO_0000111 "term replaced by"@en ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 "Use on obsolete terms, relating the term to another term that can be used as a substitute"@en ;
+                obo:IAO_0000117 "Person:Alan Ruttenberg"@en ;
+                obo:IAO_0000119 "Person:Alan Ruttenberg"@en ;
+                rdfs:comment "Add as annotation triples in the granting ontology"@en ;
+                rdfs:label "term replaced by"@en .
 
 
 ###  http://purl.obolibrary.org/obo/RO_0001900
-<http://purl.obolibrary.org/obo/RO_0001900> rdf:type owl:AnnotationProperty ;
-                                            rdfs:label "temporal interpretation"@en .
+obo:RO_0001900 rdf:type owl:AnnotationProperty ;
+               rdfs:label "temporal interpretation"@en .
 
 
 ###  http://purl.org/dc/elements/1.1/contributor
@@ -262,52 +268,52 @@ We also have the outstanding issue of how to aim different definitions to differ
 
 
 ###  http://www.w3.org/2003/06/sw-vocab-status/ns#term_status
-<http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> rdf:type owl:AnnotationProperty .
+ns:term_status rdf:type owl:AnnotationProperty .
 
 
 ###  http://www.w3.org/2004/02/skos/core#altLabel
-<http://www.w3.org/2004/02/skos/core#altLabel> rdf:type owl:AnnotationProperty .
+skos:altLabel rdf:type owl:AnnotationProperty .
 
 
 ###  http://www.w3.org/2004/02/skos/core#definition
-<http://www.w3.org/2004/02/skos/core#definition> rdf:type owl:AnnotationProperty .
+skos:definition rdf:type owl:AnnotationProperty .
 
 
 ###  http://www.w3.org/2004/02/skos/core#example
-<http://www.w3.org/2004/02/skos/core#example> rdf:type owl:AnnotationProperty .
+skos:example rdf:type owl:AnnotationProperty .
 
 
 ###  http://www.w3.org/2004/02/skos/core#prefLabel
-<http://www.w3.org/2004/02/skos/core#prefLabel> rdf:type owl:AnnotationProperty .
+skos:prefLabel rdf:type owl:AnnotationProperty .
 
 
 ###  http://www.w3.org/2004/02/skos/core#scopeNote
-<http://www.w3.org/2004/02/skos/core#scopeNote> rdf:type owl:AnnotationProperty .
+skos:scopeNote rdf:type owl:AnnotationProperty .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000026
-:AEON_0000026 rdf:type owl:AnnotationProperty ;
-              <http://purl.obolibrary.org/obo/IAO_0000117> "Philip Strömert"^^xsd:string ;
-              <http://purl.org/dc/elements/1.1/date> "2020-10-14T15:31:27Z"^^xsd:dateTime ;
-              rdfs:label "maps to"@de .
+aeon:AEON_0000026 rdf:type owl:AnnotationProperty ;
+                  obo:IAO_0000117 "Philip Strömert"^^xsd:string ;
+                  <http://purl.org/dc/elements/1.1/date> "2020-10-14T15:31:27Z"^^xsd:dateTime ;
+                  rdfs:label "maps to"@de .
 
 
 ###  https://github.com/tibonto/aeon#SMW_datatype
-:SMW_datatype rdf:type owl:AnnotationProperty .
+aeon:SMW_datatype rdf:type owl:AnnotationProperty .
 
 
 ###  https://github.com/tibonto/aeon#SMW_import_info
-:SMW_import_info rdf:type owl:AnnotationProperty .
+aeon:SMW_import_info rdf:type owl:AnnotationProperty .
 
 
 ###  https://github.com/tibonto/aeon#WikidataLabel
-:WikidataLabel rdf:type owl:AnnotationProperty ;
-               <http://purl.obolibrary.org/obo/IAO_0000115> "WikidataLabel is used to map a class or property to a certain label in the Wikidata namespace." .
+aeon:WikidataLabel rdf:type owl:AnnotationProperty ;
+                   obo:IAO_0000115 "WikidataLabel is used to map a class or property to a certain label in the Wikidata namespace." .
 
 
 ###  https://github.com/tibonto/aeon#WikidataURI
-:WikidataURI rdf:type owl:AnnotationProperty ;
-             <http://purl.obolibrary.org/obo/IAO_0000115> "WikidataURI is used to map a class or property to the URI in the Wikidata namespace." .
+aeon:WikidataURI rdf:type owl:AnnotationProperty ;
+                 obo:IAO_0000115 "WikidataURI is used to map a class or property to the URI in the Wikidata namespace." .
 
 
 #################################################################
@@ -315,387 +321,387 @@ We also have the outstanding issue of how to aim different definitions to differ
 #################################################################
 
 ###  http://purl.obolibrary.org/obo/BFO_0000050
-<http://purl.obolibrary.org/obo/BFO_0000050> rdf:type owl:ObjectProperty ;
-                                             rdfs:subPropertyOf owl:topObjectProperty ;
-                                             owl:inverseOf <http://purl.obolibrary.org/obo/BFO_0000051> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000111> "is part of"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000112> "my brain is part of my body (continuant parthood, two material entities)"@en ,
-                                                                                          "my stomach cavity is part of my stomach (continuant parthood, immaterial entity is part of material entity)"@en ,
-                                                                                          "this day is part of this year (occurrent parthood)"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000115> "a core relation that holds between a part and its whole"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000116> "Everything is part of itself. Any part of any part of a thing is itself part of that thing. Two distinct things cannot be part of each other."@en ,
-                                                                                          "Occurrents are not subject to change and so parthood between occurrents holds for all the times that the part exists. Many continuants are subject to change, so parthood between continuants will only hold at certain times, but this is difficult to specify in OWL. See https://code.google.com/p/obo-relations/wiki/ROAndTime"@en ,
-                                                                                          """Parthood requires the part and the whole to have compatible classes: only an occurrent can be part of an occurrent; only a process can be part of a process; only a continuant can be part of a continuant; only an independent continuant can be part of an independent continuant; only an immaterial entity can be part of an immaterial entity; only a specifically dependent continuant can be part of a specifically dependent continuant; only a generically dependent continuant can be part of a generically dependent continuant. (This list is not exhaustive.)
+obo:BFO_0000050 rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf owl:topObjectProperty ;
+                owl:inverseOf obo:BFO_0000051 ;
+                obo:IAO_0000111 "is part of"@en ;
+                obo:IAO_0000112 "my brain is part of my body (continuant parthood, two material entities)"@en ,
+                                "my stomach cavity is part of my stomach (continuant parthood, immaterial entity is part of material entity)"@en ,
+                                "this day is part of this year (occurrent parthood)"@en ;
+                obo:IAO_0000115 "a core relation that holds between a part and its whole"@en ;
+                obo:IAO_0000116 "Everything is part of itself. Any part of any part of a thing is itself part of that thing. Two distinct things cannot be part of each other."@en ,
+                                "Occurrents are not subject to change and so parthood between occurrents holds for all the times that the part exists. Many continuants are subject to change, so parthood between continuants will only hold at certain times, but this is difficult to specify in OWL. See https://code.google.com/p/obo-relations/wiki/ROAndTime"@en ,
+                                """Parthood requires the part and the whole to have compatible classes: only an occurrent can be part of an occurrent; only a process can be part of a process; only a continuant can be part of a continuant; only an independent continuant can be part of an independent continuant; only an immaterial entity can be part of an immaterial entity; only a specifically dependent continuant can be part of a specifically dependent continuant; only a generically dependent continuant can be part of a generically dependent continuant. (This list is not exhaustive.)
 
 A continuant cannot be part of an occurrent: use 'participates in'. An occurrent cannot be part of a continuant: use 'has participant'. A material entity cannot be part of an immaterial entity: use 'has location'. A specifically dependent continuant cannot be part of an independent continuant: use 'inheres in'. An independent continuant cannot be part of a specifically dependent continuant: use 'bearer of'."""@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000118> "part_of"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/ro/releases/2020-12-18/ro.owl"^^xsd:string ;
-                                             rdfs:label "part of"@en ;
-                                             rdfs:seeAlso <http://ontologydesignpatterns.org/wiki/Community:Parts_and_Collections> ,
-                                                          <http://ontologydesignpatterns.org/wiki/Submissions:PartOf> ,
-                                                          "http://www.obofoundry.org/ro/#OBO_REL:part_of" .
+                obo:IAO_0000118 "part_of"@en ;
+                obo:IAO_0000412 "http://purl.obolibrary.org/obo/ro/releases/2020-12-18/ro.owl"^^xsd:string ;
+                rdfs:label "part of"@en ;
+                rdfs:seeAlso <http://ontologydesignpatterns.org/wiki/Community:Parts_and_Collections> ,
+                             <http://ontologydesignpatterns.org/wiki/Submissions:PartOf> ,
+                             "http://www.obofoundry.org/ro/#OBO_REL:part_of" .
 
 
 ###  http://purl.obolibrary.org/obo/BFO_0000051
-<http://purl.obolibrary.org/obo/BFO_0000051> rdf:type owl:ObjectProperty ;
-                                             rdfs:subPropertyOf owl:topObjectProperty ;
-                                             rdf:type owl:TransitiveProperty ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000111> "has part"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000112> "my body has part my brain (continuant parthood, two material entities)"@en ,
-                                                                                          "my stomach has part my stomach cavity (continuant parthood, material entity has part immaterial entity)"@en ,
-                                                                                          "this year has part this day (occurrent parthood)"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000115> "a core relation that holds between a whole and its part"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000116> "Everything has itself as a part. Any part of any part of a thing is itself part of that thing. Two distinct things cannot have each other as a part."@en ,
-                                                                                          "Occurrents are not subject to change and so parthood between occurrents holds for all the times that the part exists. Many continuants are subject to change, so parthood between continuants will only hold at certain times, but this is difficult to specify in OWL. See https://code.google.com/p/obo-relations/wiki/ROAndTime"@en ,
-                                                                                          """Parthood requires the part and the whole to have compatible classes: only an occurrent have an occurrent as part; only a process can have a process as part; only a continuant can have a continuant as part; only an independent continuant can have an independent continuant as part; only a specifically dependent continuant can have a specifically dependent continuant as part; only a generically dependent continuant can have a generically dependent continuant as part. (This list is not exhaustive.)
+obo:BFO_0000051 rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf owl:topObjectProperty ;
+                rdf:type owl:TransitiveProperty ;
+                obo:IAO_0000111 "has part"@en ;
+                obo:IAO_0000112 "my body has part my brain (continuant parthood, two material entities)"@en ,
+                                "my stomach has part my stomach cavity (continuant parthood, material entity has part immaterial entity)"@en ,
+                                "this year has part this day (occurrent parthood)"@en ;
+                obo:IAO_0000115 "a core relation that holds between a whole and its part"@en ;
+                obo:IAO_0000116 "Everything has itself as a part. Any part of any part of a thing is itself part of that thing. Two distinct things cannot have each other as a part."@en ,
+                                "Occurrents are not subject to change and so parthood between occurrents holds for all the times that the part exists. Many continuants are subject to change, so parthood between continuants will only hold at certain times, but this is difficult to specify in OWL. See https://code.google.com/p/obo-relations/wiki/ROAndTime"@en ,
+                                """Parthood requires the part and the whole to have compatible classes: only an occurrent have an occurrent as part; only a process can have a process as part; only a continuant can have a continuant as part; only an independent continuant can have an independent continuant as part; only a specifically dependent continuant can have a specifically dependent continuant as part; only a generically dependent continuant can have a generically dependent continuant as part. (This list is not exhaustive.)
 
 A continuant cannot have an occurrent as part: use 'participates in'. An occurrent cannot have a continuant as part: use 'has participant'. An immaterial entity cannot have a material entity as part: use 'location of'. An independent continuant cannot have a specifically dependent continuant as part: use 'bearer of'. A specifically dependent continuant cannot have an independent continuant as part: use 'inheres in'."""@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000118> "has_part"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/ro/releases/2020-12-18/ro.owl"^^xsd:string ;
-                                             rdfs:label "has part"@en .
+                obo:IAO_0000118 "has_part"@en ;
+                obo:IAO_0000412 "http://purl.obolibrary.org/obo/ro/releases/2020-12-18/ro.owl"^^xsd:string ;
+                rdfs:label "has part"@en .
 
 
 ###  http://purl.obolibrary.org/obo/BFO_0000054
-<http://purl.obolibrary.org/obo/BFO_0000054> rdf:type owl:ObjectProperty ;
-                                             rdfs:subPropertyOf owl:topObjectProperty ;
-                                             owl:inverseOf <http://purl.obolibrary.org/obo/BFO_0000055> ;
-                                             rdfs:domain <http://purl.obolibrary.org/obo/BFO_0000017> ;
-                                             rdfs:range <http://purl.obolibrary.org/obo/BFO_0000015> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000111> "realized in"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000112> "this disease is realized in this disease course"@en ,
-                                                                                          "this fragility is realized in this shattering"@en ,
-                                                                                          "this investigator role is realized in this investigation"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000118> "is realized by"@en ,
-                                                                                          "realized_in"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/ro/releases/2020-12-18/ro.owl"^^xsd:string ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000600> "[copied from inverse property 'realizes'] to say that b realizes c at t is to assert that there is some material entity d & b is a process which has participant d at t & c is a disposition or role of which d is bearer_of at t& the type instantiated by b is correlated with the type instantiated by c. (axiom label in BFO2 Reference: [059-003])"@en ;
-                                             rdfs:comment "Paraphrase of elucidation: a relation between a realizable entity and a process, where there is some material entity that is bearer of the realizable entity and participates in the process, and the realizable entity comes to be realized in the course of the process" ;
-                                             rdfs:isDefinedBy <http://purl.obolibrary.org/obo/bfo.owl> ;
-                                             rdfs:label "realized in"@en .
+obo:BFO_0000054 rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf owl:topObjectProperty ;
+                owl:inverseOf obo:BFO_0000055 ;
+                rdfs:domain obo:BFO_0000017 ;
+                rdfs:range obo:BFO_0000015 ;
+                obo:IAO_0000111 "realized in"@en ;
+                obo:IAO_0000112 "this disease is realized in this disease course"@en ,
+                                "this fragility is realized in this shattering"@en ,
+                                "this investigator role is realized in this investigation"@en ;
+                obo:IAO_0000118 "is realized by"@en ,
+                                "realized_in"@en ;
+                obo:IAO_0000412 "http://purl.obolibrary.org/obo/ro/releases/2020-12-18/ro.owl"^^xsd:string ;
+                obo:IAO_0000600 "[copied from inverse property 'realizes'] to say that b realizes c at t is to assert that there is some material entity d & b is a process which has participant d at t & c is a disposition or role of which d is bearer_of at t& the type instantiated by b is correlated with the type instantiated by c. (axiom label in BFO2 Reference: [059-003])"@en ;
+                rdfs:comment "Paraphrase of elucidation: a relation between a realizable entity and a process, where there is some material entity that is bearer of the realizable entity and participates in the process, and the realizable entity comes to be realized in the course of the process" ;
+                rdfs:isDefinedBy obo:bfo.owl ;
+                rdfs:label "realized in"@en .
 
 
 ###  http://purl.obolibrary.org/obo/BFO_0000055
-<http://purl.obolibrary.org/obo/BFO_0000055> rdf:type owl:ObjectProperty ;
-                                             rdfs:subPropertyOf owl:topObjectProperty ;
-                                             rdfs:domain <http://purl.obolibrary.org/obo/BFO_0000015> ;
-                                             rdfs:range <http://purl.obolibrary.org/obo/BFO_0000017> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000111> "realizes"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000112> "this disease course realizes this disease"@en ,
-                                                                                          "this investigation realizes this investigator role"@en ,
-                                                                                          "this shattering realizes this fragility"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/ro/releases/2020-12-18/ro.owl"^^xsd:string ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000600> "to say that b realizes c at t is to assert that there is some material entity d & b is a process which has participant d at t & c is a disposition or role of which d is bearer_of at t& the type instantiated by b is correlated with the type instantiated by c. (axiom label in BFO2 Reference: [059-003])"@en ;
-                                             rdfs:comment "Paraphrase of elucidation: a relation between a process and a realizable entity, where there is some material entity that is bearer of the realizable entity and participates in the process, and the realizable entity comes to be realized in the course of the process" ;
-                                             rdfs:isDefinedBy <http://purl.obolibrary.org/obo/iao.owl> ;
-                                             rdfs:label "realizes"@en .
+obo:BFO_0000055 rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf owl:topObjectProperty ;
+                rdfs:domain obo:BFO_0000015 ;
+                rdfs:range obo:BFO_0000017 ;
+                obo:IAO_0000111 "realizes"@en ;
+                obo:IAO_0000112 "this disease course realizes this disease"@en ,
+                                "this investigation realizes this investigator role"@en ,
+                                "this shattering realizes this fragility"@en ;
+                obo:IAO_0000412 "http://purl.obolibrary.org/obo/ro/releases/2020-12-18/ro.owl"^^xsd:string ;
+                obo:IAO_0000600 "to say that b realizes c at t is to assert that there is some material entity d & b is a process which has participant d at t & c is a disposition or role of which d is bearer_of at t& the type instantiated by b is correlated with the type instantiated by c. (axiom label in BFO2 Reference: [059-003])"@en ;
+                rdfs:comment "Paraphrase of elucidation: a relation between a process and a realizable entity, where there is some material entity that is bearer of the realizable entity and participates in the process, and the realizable entity comes to be realized in the course of the process" ;
+                rdfs:isDefinedBy obo:iao.owl ;
+                rdfs:label "realizes"@en .
 
 
 ###  http://purl.obolibrary.org/obo/BFO_0000066
-<http://purl.obolibrary.org/obo/BFO_0000066> rdf:type owl:ObjectProperty ;
-                                             rdfs:subPropertyOf owl:topObjectProperty ;
-                                             owl:inverseOf <http://purl.obolibrary.org/obo/BFO_0000067> ;
-                                             rdfs:domain <http://purl.obolibrary.org/obo/BFO_0000003> ;
-                                             rdfs:range <http://purl.obolibrary.org/obo/BFO_0000004> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000111> "occurs in"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000115> "b occurs_in c =def b is a process and c is a material entity or immaterial entity& there exists a spatiotemporal region r and b occupies_spatiotemporal_region r.& forall(t) if b exists_at t then c exists_at t & there exist spatial regions s and s’ where & b spatially_projects_onto s at t& c is occupies_spatial_region s’ at t& s is a proper_continuant_part_of s’ at t"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000118> "occurs_in"@en ,
-                                                                                          "unfolds in"@en ,
-                                                                                          "unfolds_in"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/ro/releases/2020-12-18/ro.owl"^^xsd:string ;
-                                             rdfs:comment "Paraphrase of definition: a relation between a process and an independent continuant, in which the process takes place entirely within the independent continuant" ;
-                                             rdfs:isDefinedBy <http://purl.obolibrary.org/obo/bfo.owl> ;
-                                             rdfs:label "occurs in"@en .
+obo:BFO_0000066 rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf owl:topObjectProperty ;
+                owl:inverseOf obo:BFO_0000067 ;
+                rdfs:domain obo:BFO_0000003 ;
+                rdfs:range obo:BFO_0000004 ;
+                obo:IAO_0000111 "occurs in"@en ;
+                obo:IAO_0000115 "b occurs_in c =def b is a process and c is a material entity or immaterial entity& there exists a spatiotemporal region r and b occupies_spatiotemporal_region r.& forall(t) if b exists_at t then c exists_at t & there exist spatial regions s and s’ where & b spatially_projects_onto s at t& c is occupies_spatial_region s’ at t& s is a proper_continuant_part_of s’ at t"@en ;
+                obo:IAO_0000118 "occurs_in"@en ,
+                                "unfolds in"@en ,
+                                "unfolds_in"@en ;
+                obo:IAO_0000412 "http://purl.obolibrary.org/obo/ro/releases/2020-12-18/ro.owl"^^xsd:string ;
+                rdfs:comment "Paraphrase of definition: a relation between a process and an independent continuant, in which the process takes place entirely within the independent continuant" ;
+                rdfs:isDefinedBy obo:bfo.owl ;
+                rdfs:label "occurs in"@en .
 
 
 ###  http://purl.obolibrary.org/obo/BFO_0000067
-<http://purl.obolibrary.org/obo/BFO_0000067> rdf:type owl:ObjectProperty ;
-                                             rdfs:subPropertyOf owl:topObjectProperty ;
-                                             rdfs:domain <http://purl.obolibrary.org/obo/BFO_0000004> ;
-                                             rdfs:range <http://purl.obolibrary.org/obo/BFO_0000003> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000111> "site of"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000115> "[copied from inverse property 'occurs in'] b occurs_in c =def b is a process and c is a material entity or immaterial entity& there exists a spatiotemporal region r and b occupies_spatiotemporal_region r.& forall(t) if b exists_at t then c exists_at t & there exist spatial regions s and s’ where & b spatially_projects_onto s at t& c is occupies_spatial_region s’ at t& s is a proper_continuant_part_of s’ at t"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/ro/releases/2020-12-18/ro.owl"^^xsd:string ;
-                                             rdfs:comment "Paraphrase of definition: a relation between an independent continuant and a process, in which the process takes place entirely within the independent continuant" ;
-                                             rdfs:isDefinedBy <http://purl.obolibrary.org/obo/bfo.owl> ;
-                                             rdfs:label "contains process"@en .
+obo:BFO_0000067 rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf owl:topObjectProperty ;
+                rdfs:domain obo:BFO_0000004 ;
+                rdfs:range obo:BFO_0000003 ;
+                obo:IAO_0000111 "site of"@en ;
+                obo:IAO_0000115 "[copied from inverse property 'occurs in'] b occurs_in c =def b is a process and c is a material entity or immaterial entity& there exists a spatiotemporal region r and b occupies_spatiotemporal_region r.& forall(t) if b exists_at t then c exists_at t & there exist spatial regions s and s’ where & b spatially_projects_onto s at t& c is occupies_spatial_region s’ at t& s is a proper_continuant_part_of s’ at t"@en ;
+                obo:IAO_0000412 "http://purl.obolibrary.org/obo/ro/releases/2020-12-18/ro.owl"^^xsd:string ;
+                rdfs:comment "Paraphrase of definition: a relation between an independent continuant and a process, in which the process takes place entirely within the independent continuant" ;
+                rdfs:isDefinedBy obo:bfo.owl ;
+                rdfs:label "contains process"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000136
-<http://purl.obolibrary.org/obo/IAO_0000136> rdf:type owl:ObjectProperty ;
-                                             rdfs:subPropertyOf owl:topObjectProperty ;
-                                             rdfs:domain <http://purl.obolibrary.org/obo/IAO_0000030> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000112> "This document is about information artifacts and their representations"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000125> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000115> "A (currently) primitive relation that relates an information artifact to an entity."@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000116> """7/6/2009 Alan Ruttenberg. Following discussion with Jonathan Rees, and introduction of \"mentions\" relation. Weaken the is_about relationship to be primitive. 
+obo:IAO_0000136 rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf owl:topObjectProperty ;
+                rdfs:domain obo:IAO_0000030 ;
+                obo:IAO_0000112 "This document is about information artifacts and their representations"@en ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 "A (currently) primitive relation that relates an information artifact to an entity."@en ;
+                obo:IAO_0000116 """7/6/2009 Alan Ruttenberg. Following discussion with Jonathan Rees, and introduction of \"mentions\" relation. Weaken the is_about relationship to be primitive. 
 
 We will try to build it back up by elaborating the various subproperties that are more precisely defined.
 
 Some currently missing phenomena that should be considered \"about\" are predications - \"The only person who knows the answer is sitting beside me\" , Allegory, Satire, and other literary forms that can be topical without explicitly mentioning the topic."""@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000117> "person:Alan Ruttenberg"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000119> "Smith, Ceusters, Ruttenberg, 2000 years of philosophy"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/iao/2020-12-09/iao.owl"^^xsd:string ;
-                                             rdfs:label "is about"@en ;
-                                             :AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P921\", \"label\": \"main_subjectLabel\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Property:Field\", \"label\": \"Field\"}, \"gnd\": {\"uri\": \"https://d-nb.info/standards/elementset/gnd#topic\", \"label\": \"Topic that is related to a corporate body, conference, person, family, subject heading or work.\"}}"^^xsd:string ;
-                                             :SMW_datatype "Text" ;
-                                             :SMW_import_info "Controlled vocabulary in [[MediaWiki:Smw_allows_list_Subject]] [[Category:IAO]] [[Category:Imported vocabulary]]" .
+                obo:IAO_0000117 "person:Alan Ruttenberg"@en ;
+                obo:IAO_0000119 "Smith, Ceusters, Ruttenberg, 2000 years of philosophy"@en ;
+                obo:IAO_0000412 "http://purl.obolibrary.org/obo/iao/2020-12-09/iao.owl"^^xsd:string ;
+                rdfs:label "is about"@en ;
+                aeon:AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P921\", \"label\": \"main_subjectLabel\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Property:Field\", \"label\": \"Field\"}, \"gnd\": {\"uri\": \"https://d-nb.info/standards/elementset/gnd#topic\", \"label\": \"Topic that is related to a corporate body, conference, person, family, subject heading or work.\"}}"^^xsd:string ;
+                aeon:SMW_datatype "Text" ;
+                aeon:SMW_import_info "Controlled vocabulary in [[MediaWiki:Smw_allows_list_Subject]] [[Category:IAO]] [[Category:Imported vocabulary]]" .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000219
-<http://purl.obolibrary.org/obo/IAO_0000219> rdf:type owl:ObjectProperty ;
-                                             rdfs:subPropertyOf <http://purl.obolibrary.org/obo/IAO_0000136> ;
-                                             owl:inverseOf <http://purl.obolibrary.org/obo/IAO_0000235> ;
-                                             rdfs:domain <http://purl.obolibrary.org/obo/IAO_0000030> ;
-                                             rdfs:range <http://purl.obolibrary.org/obo/BFO_0000001> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000112> "A person's name denotes the person. A variable name in a computer program denotes some piece of memory. Lexically equivalent strings can denote different things, for instance \"Alan\" can denote different people. In each case of use, there is a case of the denotation relation obtaining, between \"Alan\" and the person that is being named."@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000115> "A relation obtaining between an information content entity and some portion of reality. Denotation is what happens when someone creates an information content entity E in order to specifically refer to something. The only relation between E and the thing is that E can be used to 'pick out' the thing. This relation connects those two together. Freedictionary.com sense 3: To signify directly; refer to specifically"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000116> """2009-11-10 Alan Ruttenberg. Old definition said the following to emphasize the generic nature of this relation. We no longer have 'specifically denotes', which would have been primitive, so make this relation primitive.
+obo:IAO_0000219 rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf obo:IAO_0000136 ;
+                owl:inverseOf obo:IAO_0000235 ;
+                rdfs:domain obo:IAO_0000030 ;
+                rdfs:range obo:BFO_0000001 ;
+                obo:IAO_0000112 "A person's name denotes the person. A variable name in a computer program denotes some piece of memory. Lexically equivalent strings can denote different things, for instance \"Alan\" can denote different people. In each case of use, there is a case of the denotation relation obtaining, between \"Alan\" and the person that is being named."@en ;
+                obo:IAO_0000115 "A relation obtaining between an information content entity and some portion of reality. Denotation is what happens when someone creates an information content entity E in order to specifically refer to something. The only relation between E and the thing is that E can be used to 'pick out' the thing. This relation connects those two together. Freedictionary.com sense 3: To signify directly; refer to specifically"@en ;
+                obo:IAO_0000116 """2009-11-10 Alan Ruttenberg. Old definition said the following to emphasize the generic nature of this relation. We no longer have 'specifically denotes', which would have been primitive, so make this relation primitive.
 g denotes r =def 
 r is a portion of reality
 there is some c that is a concretization of g 
 every c that is a concretization of g specifically denotes r"""@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000117> "person:Alan Ruttenberg"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000119> "Conversations with Barry Smith, Werner Ceusters, Bjoern Peters, Michel Dumontier, Melanie Courtot, James Malone, Bill Hogan"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/iao/2020-12-09/iao.owl"^^xsd:string ;
-                                             rdfs:comment ""@en ;
-                                             rdfs:label "denotes"@en .
+                obo:IAO_0000117 "person:Alan Ruttenberg"@en ;
+                obo:IAO_0000119 "Conversations with Barry Smith, Werner Ceusters, Bjoern Peters, Michel Dumontier, Melanie Courtot, James Malone, Bill Hogan"@en ;
+                obo:IAO_0000412 "http://purl.obolibrary.org/obo/iao/2020-12-09/iao.owl"^^xsd:string ;
+                rdfs:comment ""@en ;
+                rdfs:label "denotes"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000235
-<http://purl.obolibrary.org/obo/IAO_0000235> rdf:type owl:ObjectProperty ;
-                                             rdfs:subPropertyOf owl:topObjectProperty ;
-                                             rdfs:domain <http://purl.obolibrary.org/obo/BFO_0000001> ;
-                                             rdfs:range <http://purl.obolibrary.org/obo/IAO_0000030> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000115> "inverse of the relation 'denotes'"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000117> "Person: Jie Zheng, Chris Stoeckert, Mike Conlon"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000233> <https://github.com/information-artifact-ontology/IAO/issues/206> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/iao/2020-12-09/iao.owl"^^xsd:string ;
-                                             rdfs:comment "Definiton: Some entity is denoted by an information content entity."@en ;
-                                             rdfs:label "denoted by"@en .
+obo:IAO_0000235 rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf owl:topObjectProperty ;
+                rdfs:domain obo:BFO_0000001 ;
+                rdfs:range obo:IAO_0000030 ;
+                obo:IAO_0000115 "inverse of the relation 'denotes'"@en ;
+                obo:IAO_0000117 "Person: Jie Zheng, Chris Stoeckert, Mike Conlon"@en ;
+                obo:IAO_0000233 <https://github.com/information-artifact-ontology/IAO/issues/206> ;
+                obo:IAO_0000412 "http://purl.obolibrary.org/obo/iao/2020-12-09/iao.owl"^^xsd:string ;
+                rdfs:comment "Definiton: Some entity is denoted by an information content entity."@en ;
+                rdfs:label "denoted by"@en .
 
 
 ###  http://purl.obolibrary.org/obo/RO_0000052
-<http://purl.obolibrary.org/obo/RO_0000052> rdf:type owl:ObjectProperty ;
-                                            rdfs:subPropertyOf owl:topObjectProperty ;
-                                            owl:inverseOf <http://purl.obolibrary.org/obo/RO_0000053> ;
-                                            rdfs:domain <http://purl.obolibrary.org/obo/BFO_0000020> ;
-                                            rdfs:range <http://purl.obolibrary.org/obo/BFO_0000004> ;
-                                            <http://purl.obolibrary.org/obo/IAO_0000111> "inheres in"@en ;
-                                            <http://purl.obolibrary.org/obo/IAO_0000112> "this fragility inheres in this vase"@en ,
-                                                                                         "this red color inheres in this apple"@en ;
-                                            <http://purl.obolibrary.org/obo/IAO_0000115> "a relation between a specifically dependent continuant (the dependent) and an independent continuant (the bearer), in which the dependent specifically depends on the bearer for its existence"@en ;
-                                            <http://purl.obolibrary.org/obo/IAO_0000116> "A dependent inheres in its bearer at all times for which the dependent exists."@en ;
-                                            <http://purl.obolibrary.org/obo/IAO_0000118> "inheres_in"@en ;
-                                            <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/ro/releases/2020-12-18/ro.owl"^^xsd:string ;
-                                            rdfs:label "inheres in"@en .
+obo:RO_0000052 rdf:type owl:ObjectProperty ;
+               rdfs:subPropertyOf owl:topObjectProperty ;
+               owl:inverseOf obo:RO_0000053 ;
+               rdfs:domain obo:BFO_0000020 ;
+               rdfs:range obo:BFO_0000004 ;
+               obo:IAO_0000111 "inheres in"@en ;
+               obo:IAO_0000112 "this fragility inheres in this vase"@en ,
+                               "this red color inheres in this apple"@en ;
+               obo:IAO_0000115 "a relation between a specifically dependent continuant (the dependent) and an independent continuant (the bearer), in which the dependent specifically depends on the bearer for its existence"@en ;
+               obo:IAO_0000116 "A dependent inheres in its bearer at all times for which the dependent exists."@en ;
+               obo:IAO_0000118 "inheres_in"@en ;
+               obo:IAO_0000412 "http://purl.obolibrary.org/obo/ro/releases/2020-12-18/ro.owl"^^xsd:string ;
+               rdfs:label "inheres in"@en .
 
 
 ###  http://purl.obolibrary.org/obo/RO_0000053
-<http://purl.obolibrary.org/obo/RO_0000053> rdf:type owl:ObjectProperty ;
-                                            rdfs:subPropertyOf owl:topObjectProperty ;
-                                            rdfs:domain <http://purl.obolibrary.org/obo/BFO_0000004> ;
-                                            rdfs:range <http://purl.obolibrary.org/obo/BFO_0000020> ;
-                                            <http://purl.obolibrary.org/obo/IAO_0000111> "bearer of"@en ;
-                                            <http://purl.obolibrary.org/obo/IAO_0000112> "this apple is bearer of this red color"@en ,
-                                                                                         "this vase is bearer of this fragility"@en ;
-                                            <http://purl.obolibrary.org/obo/IAO_0000115> "a relation between an independent continuant (the bearer) and a specifically dependent continuant (the dependent), in which the dependent specifically depends on the bearer for its existence"@en ;
-                                            <http://purl.obolibrary.org/obo/IAO_0000116> "A bearer can have many dependents, and its dependents can exist for different periods of time, but none of its dependents can exist when the bearer does not exist."@en ;
-                                            <http://purl.obolibrary.org/obo/IAO_0000118> "bearer_of"@en ,
-                                                                                         "is bearer of"@en ;
-                                            <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/ro/releases/2020-12-18/ro.owl"^^xsd:string ;
-                                            <http://purl.obolibrary.org/obo/RO_0001900> <http://purl.obolibrary.org/obo/RO_0001901> ;
-                                            rdfs:label "bearer of"@en .
+obo:RO_0000053 rdf:type owl:ObjectProperty ;
+               rdfs:subPropertyOf owl:topObjectProperty ;
+               rdfs:domain obo:BFO_0000004 ;
+               rdfs:range obo:BFO_0000020 ;
+               obo:IAO_0000111 "bearer of"@en ;
+               obo:IAO_0000112 "this apple is bearer of this red color"@en ,
+                               "this vase is bearer of this fragility"@en ;
+               obo:IAO_0000115 "a relation between an independent continuant (the bearer) and a specifically dependent continuant (the dependent), in which the dependent specifically depends on the bearer for its existence"@en ;
+               obo:IAO_0000116 "A bearer can have many dependents, and its dependents can exist for different periods of time, but none of its dependents can exist when the bearer does not exist."@en ;
+               obo:IAO_0000118 "bearer_of"@en ,
+                               "is bearer of"@en ;
+               obo:IAO_0000412 "http://purl.obolibrary.org/obo/ro/releases/2020-12-18/ro.owl"^^xsd:string ;
+               obo:RO_0001900 obo:RO_0001901 ;
+               rdfs:label "bearer of"@en .
 
 
 ###  http://purl.obolibrary.org/obo/RO_0000056
-<http://purl.obolibrary.org/obo/RO_0000056> rdf:type owl:ObjectProperty ;
-                                            rdfs:subPropertyOf owl:topObjectProperty ;
-                                            owl:inverseOf <http://purl.obolibrary.org/obo/RO_0000057> ;
-                                            rdfs:domain <http://purl.obolibrary.org/obo/BFO_0000002> ;
-                                            rdfs:range <http://purl.obolibrary.org/obo/BFO_0000003> ;
-                                            <http://purl.obolibrary.org/obo/IAO_0000111> "participates in"@en ;
-                                            <http://purl.obolibrary.org/obo/IAO_0000112> "this blood clot participates in this blood coagulation"@en ,
-                                                                                         "this input material (or this output material) participates in this process"@en ,
-                                                                                         "this investigator participates in this investigation"@en ;
-                                            <http://purl.obolibrary.org/obo/IAO_0000115> "a relation between a continuant and a process, in which the continuant is somehow involved in the process"@en ;
-                                            <http://purl.obolibrary.org/obo/IAO_0000118> "participates_in"@en ;
-                                            <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/ro/releases/2020-12-18/ro.owl"^^xsd:string ;
-                                            rdfs:label "participates in"@en .
+obo:RO_0000056 rdf:type owl:ObjectProperty ;
+               rdfs:subPropertyOf owl:topObjectProperty ;
+               owl:inverseOf obo:RO_0000057 ;
+               rdfs:domain obo:BFO_0000002 ;
+               rdfs:range obo:BFO_0000003 ;
+               obo:IAO_0000111 "participates in"@en ;
+               obo:IAO_0000112 "this blood clot participates in this blood coagulation"@en ,
+                               "this input material (or this output material) participates in this process"@en ,
+                               "this investigator participates in this investigation"@en ;
+               obo:IAO_0000115 "a relation between a continuant and a process, in which the continuant is somehow involved in the process"@en ;
+               obo:IAO_0000118 "participates_in"@en ;
+               obo:IAO_0000412 "http://purl.obolibrary.org/obo/ro/releases/2020-12-18/ro.owl"^^xsd:string ;
+               rdfs:label "participates in"@en .
 
 
 ###  http://purl.obolibrary.org/obo/RO_0000057
-<http://purl.obolibrary.org/obo/RO_0000057> rdf:type owl:ObjectProperty ;
-                                            rdfs:subPropertyOf owl:topObjectProperty ;
-                                            rdfs:domain <http://purl.obolibrary.org/obo/BFO_0000003> ;
-                                            rdfs:range <http://purl.obolibrary.org/obo/BFO_0000002> ;
-                                            <http://purl.obolibrary.org/obo/IAO_0000111> "has participant"@en ;
-                                            <http://purl.obolibrary.org/obo/IAO_0000112> "this blood coagulation has participant this blood clot"@en ,
-                                                                                         "this investigation has participant this investigator"@en ,
-                                                                                         "this process has participant this input material (or this output material)"@en ;
-                                            <http://purl.obolibrary.org/obo/IAO_0000115> "a relation between a process and a continuant, in which the continuant is somehow involved in the process"@en ;
-                                            <http://purl.obolibrary.org/obo/IAO_0000116> "Has_participant is a primitive instance-level relation between a process, a continuant, and a time at which the continuant participates in some way in the process. The relation obtains, for example, when this particular process of oxygen exchange across this particular alveolar membrane has_participant this particular sample of hemoglobin at this particular time."@en ;
-                                            <http://purl.obolibrary.org/obo/IAO_0000118> "has_participant"@en ;
-                                            <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/ro/releases/2020-12-18/ro.owl"^^xsd:string ;
-                                            <http://purl.org/dc/elements/1.1/source> "http://www.obofoundry.org/ro/#OBO_REL:has_participant" ;
-                                            rdfs:label "has participant"@en .
+obo:RO_0000057 rdf:type owl:ObjectProperty ;
+               rdfs:subPropertyOf owl:topObjectProperty ;
+               rdfs:domain obo:BFO_0000003 ;
+               rdfs:range obo:BFO_0000002 ;
+               obo:IAO_0000111 "has participant"@en ;
+               obo:IAO_0000112 "this blood coagulation has participant this blood clot"@en ,
+                               "this investigation has participant this investigator"@en ,
+                               "this process has participant this input material (or this output material)"@en ;
+               obo:IAO_0000115 "a relation between a process and a continuant, in which the continuant is somehow involved in the process"@en ;
+               obo:IAO_0000116 "Has_participant is a primitive instance-level relation between a process, a continuant, and a time at which the continuant participates in some way in the process. The relation obtains, for example, when this particular process of oxygen exchange across this particular alveolar membrane has_participant this particular sample of hemoglobin at this particular time."@en ;
+               obo:IAO_0000118 "has_participant"@en ;
+               obo:IAO_0000412 "http://purl.obolibrary.org/obo/ro/releases/2020-12-18/ro.owl"^^xsd:string ;
+               <http://purl.org/dc/elements/1.1/source> "http://www.obofoundry.org/ro/#OBO_REL:has_participant" ;
+               rdfs:label "has participant"@en .
 
 
 ###  http://purl.obolibrary.org/obo/RO_0000081
-<http://purl.obolibrary.org/obo/RO_0000081> rdf:type owl:ObjectProperty ;
-                                            rdfs:subPropertyOf <http://purl.obolibrary.org/obo/RO_0000052> ;
-                                            owl:inverseOf <http://purl.obolibrary.org/obo/RO_0000087> ;
-                                            rdfs:domain <http://purl.obolibrary.org/obo/BFO_0000023> ;
-                                            rdfs:range <http://purl.obolibrary.org/obo/BFO_0000004> ;
-                                            <http://purl.obolibrary.org/obo/IAO_0000112> "this investigator role is a role of this person"@en ;
-                                            <http://purl.obolibrary.org/obo/IAO_0000115> "a relation between a role and an independent continuant (the bearer), in which the role specifically depends on the bearer for its existence"@en ;
-                                            <http://purl.obolibrary.org/obo/IAO_0000116> "A role inheres in its bearer at all times for which the role exists, however the role need not be realized at all the times that the role exists."@en ;
-                                            <http://purl.obolibrary.org/obo/IAO_0000118> "is role of"@en ,
-                                                                                         "role_of"@en ;
-                                            <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/ro/releases/2020-12-18/ro.owl"^^xsd:string ;
-                                            rdfs:label "role of"@en .
+obo:RO_0000081 rdf:type owl:ObjectProperty ;
+               rdfs:subPropertyOf obo:RO_0000052 ;
+               owl:inverseOf obo:RO_0000087 ;
+               rdfs:domain obo:BFO_0000023 ;
+               rdfs:range obo:BFO_0000004 ;
+               obo:IAO_0000112 "this investigator role is a role of this person"@en ;
+               obo:IAO_0000115 "a relation between a role and an independent continuant (the bearer), in which the role specifically depends on the bearer for its existence"@en ;
+               obo:IAO_0000116 "A role inheres in its bearer at all times for which the role exists, however the role need not be realized at all the times that the role exists."@en ;
+               obo:IAO_0000118 "is role of"@en ,
+                               "role_of"@en ;
+               obo:IAO_0000412 "http://purl.obolibrary.org/obo/ro/releases/2020-12-18/ro.owl"^^xsd:string ;
+               rdfs:label "role of"@en .
 
 
 ###  http://purl.obolibrary.org/obo/RO_0000087
-<http://purl.obolibrary.org/obo/RO_0000087> rdf:type owl:ObjectProperty ;
-                                            rdfs:subPropertyOf <http://purl.obolibrary.org/obo/RO_0000053> ;
-                                            rdfs:domain <http://purl.obolibrary.org/obo/BFO_0000004> ;
-                                            rdfs:range <http://purl.obolibrary.org/obo/BFO_0000023> ;
-                                            <http://purl.obolibrary.org/obo/IAO_0000112> "this person has role this investigator role (more colloquially: this person has this role of investigator)"@en ;
-                                            <http://purl.obolibrary.org/obo/IAO_0000115> "a relation between an independent continuant (the bearer) and a role, in which the role specifically depends on the bearer for its existence"@en ;
-                                            <http://purl.obolibrary.org/obo/IAO_0000116> "A bearer can have many roles, and its roles can exist for different periods of time, but none of its roles can exist when the bearer does not exist. A role need not be realized at all the times that the role exists."@en ;
-                                            <http://purl.obolibrary.org/obo/IAO_0000118> "has_role"@en ;
-                                            <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/ro/releases/2020-12-18/ro.owl"^^xsd:string ;
-                                            rdfs:label "has role"@en .
+obo:RO_0000087 rdf:type owl:ObjectProperty ;
+               rdfs:subPropertyOf obo:RO_0000053 ;
+               rdfs:domain obo:BFO_0000004 ;
+               rdfs:range obo:BFO_0000023 ;
+               obo:IAO_0000112 "this person has role this investigator role (more colloquially: this person has this role of investigator)"@en ;
+               obo:IAO_0000115 "a relation between an independent continuant (the bearer) and a role, in which the role specifically depends on the bearer for its existence"@en ;
+               obo:IAO_0000116 "A bearer can have many roles, and its roles can exist for different periods of time, but none of its roles can exist when the bearer does not exist. A role need not be realized at all the times that the role exists."@en ;
+               obo:IAO_0000118 "has_role"@en ;
+               obo:IAO_0000412 "http://purl.obolibrary.org/obo/ro/releases/2020-12-18/ro.owl"^^xsd:string ;
+               rdfs:label "has role"@en .
 
 
 ###  http://purl.obolibrary.org/obo/RO_0002012
-<http://purl.obolibrary.org/obo/RO_0002012> rdf:type owl:ObjectProperty ;
-                                            rdfs:subPropertyOf <http://purl.obolibrary.org/obo/BFO_0000050> ;
-                                            rdfs:domain <http://purl.obolibrary.org/obo/BFO_0000003> ;
-                                            rdfs:range <http://purl.obolibrary.org/obo/BFO_0000003> ;
-                                            <http://purl.obolibrary.org/obo/IAO_0000115> "A part of relation that applies only between occurents." ;
-                                            <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/ro/releases/2021-03-08/ro.owl"^^xsd:string ;
-                                            rdfs:label "occurent part of" .
+obo:RO_0002012 rdf:type owl:ObjectProperty ;
+               rdfs:subPropertyOf obo:BFO_0000050 ;
+               rdfs:domain obo:BFO_0000003 ;
+               rdfs:range obo:BFO_0000003 ;
+               obo:IAO_0000115 "A part of relation that applies only between occurents." ;
+               obo:IAO_0000412 "http://purl.obolibrary.org/obo/ro/releases/2021-03-08/ro.owl"^^xsd:string ;
+               rdfs:label "occurent part of" .
 
 
 ###  http://purl.obolibrary.org/obo/RO_0002234
-<http://purl.obolibrary.org/obo/RO_0002234> rdf:type owl:ObjectProperty ;
-                                            rdfs:subPropertyOf <http://purl.obolibrary.org/obo/RO_0000057> ;
-                                            rdfs:domain <http://purl.obolibrary.org/obo/BFO_0000003> ;
-                                            rdfs:range <http://purl.obolibrary.org/obo/BFO_0000002> ;
-                                            <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000125> ;
-                                            <http://purl.obolibrary.org/obo/IAO_0000115> "p has output c iff c is a participant in p, c is present at the end of p, and c is not present at the beginning of p." ;
-                                            <http://purl.obolibrary.org/obo/IAO_0000117> "Chris Mungall" ;
-                                            <http://purl.obolibrary.org/obo/IAO_0000118> "produces" ;
-                                            <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/ro/releases/2020-12-18/ro.owl"^^xsd:string ;
-                                            rdfs:label "has output"@en .
+obo:RO_0002234 rdf:type owl:ObjectProperty ;
+               rdfs:subPropertyOf obo:RO_0000057 ;
+               rdfs:domain obo:BFO_0000003 ;
+               rdfs:range obo:BFO_0000002 ;
+               obo:IAO_0000114 obo:IAO_0000125 ;
+               obo:IAO_0000115 "p has output c iff c is a participant in p, c is present at the end of p, and c is not present at the beginning of p." ;
+               obo:IAO_0000117 "Chris Mungall" ;
+               obo:IAO_0000118 "produces" ;
+               obo:IAO_0000412 "http://purl.obolibrary.org/obo/ro/releases/2020-12-18/ro.owl"^^xsd:string ;
+               rdfs:label "has output"@en .
 
 
 ###  http://purl.obolibrary.org/obo/RO_0002350
-<http://purl.obolibrary.org/obo/RO_0002350> rdf:type owl:ObjectProperty ;
-                                            rdfs:subPropertyOf <http://purl.obolibrary.org/obo/BFO_0000050> ;
-                                            <http://purl.obolibrary.org/obo/IAO_0000112> "An organism that is a member of a population of organisms" ;
-                                            <http://purl.obolibrary.org/obo/IAO_0000115> "is member of is a mereological relation between a item and a collection." ;
-                                            <http://purl.obolibrary.org/obo/IAO_0000118> "is member of" ,
-                                                                                         "member part of" ;
-                                            <http://purl.obolibrary.org/obo/IAO_0000119> "SIO" ;
-                                            <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/ro/releases/2020-12-18/ro.owl"^^xsd:string ;
-                                            <http://purl.obolibrary.org/obo/RO_0001900> <http://purl.obolibrary.org/obo/RO_0001901> ;
-                                            rdfs:label "member of"@en .
+obo:RO_0002350 rdf:type owl:ObjectProperty ;
+               rdfs:subPropertyOf obo:BFO_0000050 ;
+               obo:IAO_0000112 "An organism that is a member of a population of organisms" ;
+               obo:IAO_0000115 "is member of is a mereological relation between a item and a collection." ;
+               obo:IAO_0000118 "is member of" ,
+                               "member part of" ;
+               obo:IAO_0000119 "SIO" ;
+               obo:IAO_0000412 "http://purl.obolibrary.org/obo/ro/releases/2020-12-18/ro.owl"^^xsd:string ;
+               obo:RO_0001900 obo:RO_0001901 ;
+               rdfs:label "member of"@en .
 
 
 ###  http://purl.obolibrary.org/obo/RO_0002351
-<http://purl.obolibrary.org/obo/RO_0002351> rdf:type owl:ObjectProperty ;
-                                            rdfs:subPropertyOf <http://purl.obolibrary.org/obo/BFO_0000051> ;
-                                            <http://purl.obolibrary.org/obo/IAO_0000115> "has member is a mereological relation between a collection and an item." ;
-                                            <http://purl.obolibrary.org/obo/IAO_0000119> "SIO" ;
-                                            <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/ro/releases/2020-12-18/ro.owl"^^xsd:string ;
-                                            <http://purl.obolibrary.org/obo/RO_0001900> <http://purl.obolibrary.org/obo/RO_0001901> ;
-                                            rdfs:label "has member"@en .
+obo:RO_0002351 rdf:type owl:ObjectProperty ;
+               rdfs:subPropertyOf obo:BFO_0000051 ;
+               obo:IAO_0000115 "has member is a mereological relation between a collection and an item." ;
+               obo:IAO_0000119 "SIO" ;
+               obo:IAO_0000412 "http://purl.obolibrary.org/obo/ro/releases/2020-12-18/ro.owl"^^xsd:string ;
+               obo:RO_0001900 obo:RO_0001901 ;
+               rdfs:label "has member"@en .
 
 
 ###  http://purl.obolibrary.org/obo/RO_0002353
-<http://purl.obolibrary.org/obo/RO_0002353> rdf:type owl:ObjectProperty ;
-                                            rdfs:subPropertyOf <http://purl.obolibrary.org/obo/RO_0000056> ;
-                                            rdfs:domain <http://purl.obolibrary.org/obo/BFO_0000002> ;
-                                            rdfs:range <http://purl.obolibrary.org/obo/BFO_0000003> ;
-                                            <http://purl.obolibrary.org/obo/IAO_0000115> "inverse of has output" ;
-                                            <http://purl.obolibrary.org/obo/IAO_0000117> "Chris Mungall" ;
-                                            <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/ro/releases/2020-12-18/ro.owl"^^xsd:string ;
-                                            rdfs:label "output of"@en .
+obo:RO_0002353 rdf:type owl:ObjectProperty ;
+               rdfs:subPropertyOf obo:RO_0000056 ;
+               rdfs:domain obo:BFO_0000002 ;
+               rdfs:range obo:BFO_0000003 ;
+               obo:IAO_0000115 "inverse of has output" ;
+               obo:IAO_0000117 "Chris Mungall" ;
+               obo:IAO_0000412 "http://purl.obolibrary.org/obo/ro/releases/2020-12-18/ro.owl"^^xsd:string ;
+               rdfs:label "output of"@en .
 
 
 ###  http://purl.obolibrary.org/obo/TXPO_0002523
-<http://purl.obolibrary.org/obo/TXPO_0002523> rdf:type owl:ObjectProperty ;
-                                              rdfs:subPropertyOf <http://purl.obolibrary.org/obo/BFO_0000051> ;
-                                              <http://purl.obolibrary.org/obo/IAO_0000115> "\"has ocurrent part\" is a relation that holds between a whole occurrent (process) and its part." ;
-                                              <http://purl.obolibrary.org/obo/IAO_0000232> "There is no RO relation 'has occurent part' which can serve as the inverse of http://purl.obolibrary.org/obo/RO_0002012 (occurent part of). One might use the BFO2020 (BFO_0000132), or more precicesly BFO_0000138 (proper occurent part of). But this will generate problems due to the incompatibility as of now (Feb 2021) between BFO2020 and RO."@en ;
-                                              <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/txpo/releases/2020-03-03/txpo.owl"^^xsd:string ;
-                                              rdfs:label "has occurrent part" .
+obo:TXPO_0002523 rdf:type owl:ObjectProperty ;
+                 rdfs:subPropertyOf obo:BFO_0000051 ;
+                 obo:IAO_0000115 "\"has ocurrent part\" is a relation that holds between a whole occurrent (process) and its part." ;
+                 obo:IAO_0000232 "There is no RO relation 'has occurent part' which can serve as the inverse of http://purl.obolibrary.org/obo/RO_0002012 (occurent part of). One might use the BFO2020 (BFO_0000132), or more precicesly BFO_0000138 (proper occurent part of). But this will generate problems due to the incompatibility as of now (Feb 2021) between BFO2020 and RO."@en ;
+                 obo:IAO_0000412 "http://purl.obolibrary.org/obo/txpo/releases/2020-03-03/txpo.owl"^^xsd:string ;
+                 rdfs:label "has occurrent part" .
 
 
 ###  http://www.w3.org/2002/07/owl#topObjectProperty
-owl:topObjectProperty <http://purl.obolibrary.org/obo/IAO_0000115> """'has academic field' is a primitive, instance-level relation obtaining between a planned process and the skos:Concept subclass 'academic field'. 
+owl:topObjectProperty obo:IAO_0000115 """'has academic field' is a primitive, instance-level relation obtaining between a planned process and the skos:Concept subclass 'academic field'. 
 To say p has academic field x =def. p is a planned process, there is some x that is an academic field of p."""@en .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000032
-:AEON_0000032 rdf:type owl:ObjectProperty ;
-              owl:inverseOf :event_type_of ;
-              rdfs:domain :AEON_0000001 ;
-              rdfs:range :AEON_0000004 ;
-              <http://purl.obolibrary.org/obo/IAO_0000115> "A relation obtaining between a planned process and a skos:Concept that is used to descibe the social format of an 'academic event'."@en ;
-              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"@en ;
-              rdfs:label "has event type"@en ;
-              :AEON_0000026 "{\"wikidata\": {\"uri\": null, \"label\": \"event_type\"}, \"openresearch\": {\"uri\": null, \"label\": \"Type\"}}"^^xsd:string ;
-              :SMW_datatype "Text" ;
-              :SMW_import_info """The allowed value list for this property is defined in [[MediaWiki:Smw_allows_list_has_event_type]].
+aeon:AEON_0000032 rdf:type owl:ObjectProperty ;
+                  owl:inverseOf aeon:event_type_of ;
+                  rdfs:domain aeon:AEON_0000001 ;
+                  rdfs:range aeon:AEON_0000004 ;
+                  obo:IAO_0000115 "A relation obtaining between a planned process and a skos:Concept that is used to descibe the social format of an 'academic event'."@en ;
+                  obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
+                  rdfs:label "has event type"@en ;
+                  aeon:AEON_0000026 "{\"wikidata\": {\"uri\": null, \"label\": \"event_type\"}, \"openresearch\": {\"uri\": null, \"label\": \"Type\"}}"^^xsd:string ;
+                  aeon:SMW_datatype "Text" ;
+                  aeon:SMW_import_info """The allowed value list for this property is defined in [[MediaWiki:Smw_allows_list_has_event_type]].
 [[Category:AEON]] [[Category:Imported vocabulary]]""" ;
-              :WikidataLabel "event_type" .
+                  aeon:WikidataLabel "event_type" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000033
-:AEON_0000033 rdf:type owl:ObjectProperty ;
-              rdfs:subPropertyOf <http://purl.obolibrary.org/obo/IAO_0000235> ;
-              rdfs:domain <http://purl.obolibrary.org/obo/BFO_0000001> ;
-              rdfs:range :AEON_0000034 ;
-              <http://purl.obolibrary.org/obo/IAO_0000115> "A relation obtaining between an entity and a distributed identifier that is used to denote the entity."@en ;
-              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"@en ,
-                                                           "Philip Stroemert"^^xsd:string ;
-              rdfs:label "has distributed identifier"@en ;
-              <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> <http://purl.obolibrary.org/obo/IAO_0000423> .
+aeon:AEON_0000033 rdf:type owl:ObjectProperty ;
+                  rdfs:subPropertyOf obo:IAO_0000235 ;
+                  rdfs:domain obo:BFO_0000001 ;
+                  rdfs:range aeon:AEON_0000034 ;
+                  obo:IAO_0000115 "A relation obtaining between an entity and a distributed identifier that is used to denote the entity."@en ;
+                  obo:IAO_0000117 "PERSON: Philip Strömert"@en ,
+                                  "Philip Stroemert"^^xsd:string ;
+                  rdfs:label "has distributed identifier"@en ;
+                  ns:term_status obo:IAO_0000423 .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000040
-:AEON_0000040 rdf:type owl:ObjectProperty ;
-              owl:inverseOf :academic_field_of ;
-              rdfs:domain <http://purl.obolibrary.org/obo/OBI_0000011> ;
-              rdfs:range :AEON_0000027 ;
-              <http://purl.obolibrary.org/obo/IAO_0000115> "A relation obtaining between a planned process and a skos:Concept that is used to descibe the scientific subject of the planned process according to some controlled vocabulary or thesaurus."@en ;
-              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"@en ;
-              rdfs:label "has academic field"@en .
+aeon:AEON_0000040 rdf:type owl:ObjectProperty ;
+                  owl:inverseOf aeon:academic_field_of ;
+                  rdfs:domain obo:OBI_0000011 ;
+                  rdfs:range aeon:AEON_0000027 ;
+                  obo:IAO_0000115 "A relation obtaining between a planned process and a skos:Concept that is used to descibe the scientific subject of the planned process according to some controlled vocabulary or thesaurus."@en ;
+                  obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
+                  rdfs:label "has academic field"@en .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000041
-:AEON_0000041 rdf:type owl:ObjectProperty ;
-              owl:inverseOf :topic_of ;
-              rdfs:domain <http://purl.obolibrary.org/obo/OBI_0000011> ;
-              rdfs:range :AEON_0000028 ;
-              <http://purl.obolibrary.org/obo/IAO_0000117> "A relation obtaining between a planned process and a skos:Concept that is used to descibe the theme of the planned process."@en ,
-                                                           "PERSON: Philip Strömert"@en ;
-              rdfs:label "has topic"@en .
+aeon:AEON_0000041 rdf:type owl:ObjectProperty ;
+                  owl:inverseOf aeon:topic_of ;
+                  rdfs:domain obo:OBI_0000011 ;
+                  rdfs:range aeon:AEON_0000028 ;
+                  obo:IAO_0000117 "A relation obtaining between a planned process and a skos:Concept that is used to descibe the theme of the planned process."@en ,
+                                  "PERSON: Philip Strömert"@en ;
+                  rdfs:label "has topic"@en .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000043
-:AEON_0000043 rdf:type owl:ObjectProperty ;
-              rdfs:subPropertyOf owl:topObjectProperty ;
-              rdfs:domain :AEON_0000001 ;
-              rdfs:range :AEON_0000030 ;
-              <http://purl.obolibrary.org/obo/IAO_0000115> "A relation obtaining between a planned process and an 'information content entity' that is about the amount of money one has to pay in order to be an allowed participant of the planned process."@en ;
-              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"@en ;
-              rdfs:label "has fee"@en ;
-              :SMW_datatype "Text" ;
-              :SMW_import_info """The allowed value list for this property is defined in [[MediaWiki:Smw_allows_list_Has_fee]].
+aeon:AEON_0000043 rdf:type owl:ObjectProperty ;
+                  rdfs:subPropertyOf owl:topObjectProperty ;
+                  rdfs:domain aeon:AEON_0000001 ;
+                  rdfs:range aeon:AEON_0000030 ;
+                  obo:IAO_0000115 "A relation obtaining between a planned process and an 'information content entity' that is about the amount of money one has to pay in order to be an allowed participant of the planned process."@en ;
+                  obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
+                  rdfs:label "has fee"@en ;
+                  aeon:SMW_datatype "Text" ;
+                  aeon:SMW_import_info """The allowed value list for this property is defined in [[MediaWiki:Smw_allows_list_Has_fee]].
 
 [[partOfSubobject::Template:Subobject Fee]]
 
@@ -703,220 +709,220 @@ To say p has academic field x =def. p is a planned process, there is some x that
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000045
-:AEON_0000045 rdf:type owl:ObjectProperty ;
-              rdfs:subPropertyOf <http://purl.obolibrary.org/obo/RO_0000057> ;
-              owl:inverseOf :contibutes_to ;
-              rdfs:domain <http://purl.obolibrary.org/obo/OBI_0000011> ;
-              rdfs:range :contributor ;
-              <http://purl.obolibrary.org/obo/IAO_0000115> "'has contributor' is a relation obtaining between a planned process and a person or organization that holds a contributor role which is being realized by the planned process. A contribution to a planned process takes place when someone works on the planning or realization of a planned process."@en ,
-                                                           "A relation obtaining between an entity and its corresponding Wikidata entity identifier."@en ;
-              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"@en ;
-              rdfs:label "has contributor"@en ;
-              :SMW_datatype "Page" ;
-              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:AEON_0000045 rdf:type owl:ObjectProperty ;
+                  rdfs:subPropertyOf obo:RO_0000057 ;
+                  owl:inverseOf aeon:contibutes_to ;
+                  rdfs:domain obo:OBI_0000011 ;
+                  rdfs:range aeon:contributor ;
+                  obo:IAO_0000115 "'has contributor' is a relation obtaining between a planned process and a person or organization that holds a contributor role which is being realized by the planned process. A contribution to a planned process takes place when someone works on the planning or realization of a planned process."@en ,
+                                  "A relation obtaining between an entity and its corresponding Wikidata entity identifier."@en ;
+                  obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
+                  rdfs:label "has contributor"@en ;
+                  aeon:SMW_datatype "Page" ;
+                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000046
-:AEON_0000046 rdf:type owl:ObjectProperty ;
-              rdfs:subPropertyOf :AEON_0000045 ;
-              owl:inverseOf :attends_at ;
-              rdfs:domain <http://purl.obolibrary.org/obo/OBI_0000011> ;
-              rdfs:range :attendee ;
-              <http://purl.obolibrary.org/obo/IAO_0000115> "A relation obtaining between a planned process and a person that holds an attendee role which is being realized by the planned process."@en ;
-              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"@en ;
-              rdfs:label "has attendee"@en ;
-              :AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P710\", \"label\": \"participantLabel\"}}"^^xsd:string ;
-              :SMW_datatype "Page" ;
-              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" ;
-              :WikidataLabel "participantLabel" ;
-              :WikidataURI "https://www.wikidata.org/wiki/Property:P710" .
+aeon:AEON_0000046 rdf:type owl:ObjectProperty ;
+                  rdfs:subPropertyOf aeon:AEON_0000045 ;
+                  owl:inverseOf aeon:attends_at ;
+                  rdfs:domain obo:OBI_0000011 ;
+                  rdfs:range aeon:attendee ;
+                  obo:IAO_0000115 "A relation obtaining between a planned process and a person that holds an attendee role which is being realized by the planned process."@en ;
+                  obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
+                  rdfs:label "has attendee"@en ;
+                  aeon:AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P710\", \"label\": \"participantLabel\"}}"^^xsd:string ;
+                  aeon:SMW_datatype "Page" ;
+                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" ;
+                  aeon:WikidataLabel "participantLabel" ;
+                  aeon:WikidataURI "https://www.wikidata.org/wiki/Property:P710" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000047
-:AEON_0000047 rdf:type owl:ObjectProperty ;
-              rdfs:subPropertyOf :AEON_0000045 ;
-              owl:inverseOf :moderates_at ;
-              rdfs:domain <http://purl.obolibrary.org/obo/OBI_0000011> ;
-              rdfs:range :moderator ;
-              <http://purl.obolibrary.org/obo/IAO_0000115> "A relation obtaining between a planned process and a person that holds a moderator role which is being realized by the planned process."@en ;
-              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"@en ;
-              rdfs:label "has moderator"@en ;
-              :SMW_datatype "Page" ;
-              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:AEON_0000047 rdf:type owl:ObjectProperty ;
+                  rdfs:subPropertyOf aeon:AEON_0000045 ;
+                  owl:inverseOf aeon:moderates_at ;
+                  rdfs:domain obo:OBI_0000011 ;
+                  rdfs:range aeon:moderator ;
+                  obo:IAO_0000115 "A relation obtaining between a planned process and a person that holds a moderator role which is being realized by the planned process."@en ;
+                  obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
+                  rdfs:label "has moderator"@en ;
+                  aeon:SMW_datatype "Page" ;
+                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000048
-:AEON_0000048 rdf:type owl:ObjectProperty ;
-              rdfs:subPropertyOf :AEON_0000045 ;
-              owl:inverseOf :organizes ;
-              rdfs:domain <http://purl.obolibrary.org/obo/OBI_0000011> ;
-              rdfs:range :organizer ;
-              <http://purl.obolibrary.org/obo/IAO_0000115> "A relation obtaining between a planned process and a person or organization that holds an organizer role which is being realized by the planned process."@en ;
-              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"@en ;
-              rdfs:label "has organizer"@en ;
-              :AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P664\", \"label\": \"organizerLabel\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Property:Has_organizer\", \"label\": \"Has_organizer\"},\"crossref\": {\"api_proceedings_endpoint_uri\": \"https://api.crossref.org/types/proceedings/works?select=event\", \"json_api_key\": {\"event\": \"sponsor\"}}}"^^xsd:string ;
-              :SMW_datatype "Page" ;
-              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" ;
-              :WikidataLabel "organizerLabel" ;
-              :WikidataURI "https://www.wikidata.org/wiki/Property:P664" .
+aeon:AEON_0000048 rdf:type owl:ObjectProperty ;
+                  rdfs:subPropertyOf aeon:AEON_0000045 ;
+                  owl:inverseOf aeon:organizes ;
+                  rdfs:domain obo:OBI_0000011 ;
+                  rdfs:range aeon:organizer ;
+                  obo:IAO_0000115 "A relation obtaining between a planned process and a person or organization that holds an organizer role which is being realized by the planned process."@en ;
+                  obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
+                  rdfs:label "has organizer"@en ;
+                  aeon:AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P664\", \"label\": \"organizerLabel\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Property:Has_organizer\", \"label\": \"Has_organizer\"},\"crossref\": {\"api_proceedings_endpoint_uri\": \"https://api.crossref.org/types/proceedings/works?select=event\", \"json_api_key\": {\"event\": \"sponsor\"}}}"^^xsd:string ;
+                  aeon:SMW_datatype "Page" ;
+                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" ;
+                  aeon:WikidataLabel "organizerLabel" ;
+                  aeon:WikidataURI "https://www.wikidata.org/wiki/Property:P664" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000049
-:AEON_0000049 rdf:type owl:ObjectProperty ;
-              rdfs:subPropertyOf :AEON_0000045 ;
-              owl:inverseOf :reviews_at ;
-              rdfs:domain <http://purl.obolibrary.org/obo/OBI_0000011> ;
-              rdfs:range :reviewer ;
-              <http://purl.obolibrary.org/obo/IAO_0000115> "A relation obtaining between a planned process and a person that holds a reviewer role which is being realized by the planned process."@en ;
-              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"@en ;
-              rdfs:label "has reviewer"@en ;
-              :SMW_datatype "Page" ;
-              :SMW_import_info """[[partOfSubobject::Template:Subobject Contributor]]
+aeon:AEON_0000049 rdf:type owl:ObjectProperty ;
+                  rdfs:subPropertyOf aeon:AEON_0000045 ;
+                  owl:inverseOf aeon:reviews_at ;
+                  rdfs:domain obo:OBI_0000011 ;
+                  rdfs:range aeon:reviewer ;
+                  obo:IAO_0000115 "A relation obtaining between a planned process and a person that holds a reviewer role which is being realized by the planned process."@en ;
+                  obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
+                  rdfs:label "has reviewer"@en ;
+                  aeon:SMW_datatype "Page" ;
+                  aeon:SMW_import_info """[[partOfSubobject::Template:Subobject Contributor]]
 
 [[Category:AEON]] [[Category:Imported vocabulary]]""" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000050
-:AEON_0000050 rdf:type owl:ObjectProperty ;
-              rdfs:subPropertyOf :AEON_0000045 ;
-              owl:inverseOf :speaks_at ;
-              rdfs:domain <http://purl.obolibrary.org/obo/OBI_0000011> ;
-              rdfs:range :speaker ;
-              <http://purl.obolibrary.org/obo/IAO_0000115> "A relation obtaining between a planned process and a person that holds a presenter role which is being realized by the planned process."@en ;
-              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"@en ;
-              rdfs:label "has presenter"@en ;
-              :AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P823\", \"label\": \"speaker\"}}"^^xsd:string ;
-              :SMW_datatype "Page" ;
-              :SMW_import_info """[[partOfSubobject::Template:Subobject Contributor]]
+aeon:AEON_0000050 rdf:type owl:ObjectProperty ;
+                  rdfs:subPropertyOf aeon:AEON_0000045 ;
+                  owl:inverseOf aeon:speaks_at ;
+                  rdfs:domain obo:OBI_0000011 ;
+                  rdfs:range aeon:speaker ;
+                  obo:IAO_0000115 "A relation obtaining between a planned process and a person that holds a presenter role which is being realized by the planned process."@en ;
+                  obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
+                  rdfs:label "has presenter"@en ;
+                  aeon:AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P823\", \"label\": \"speaker\"}}"^^xsd:string ;
+                  aeon:SMW_datatype "Page" ;
+                  aeon:SMW_import_info """[[partOfSubobject::Template:Subobject Contributor]]
 
 [[Category:AEON]] [[Category:Imported vocabulary]]""" ;
-              :WikidataLabel "speaker" ;
-              :WikidataURI "https://www.wikidata.org/wiki/Property:P823" .
+                  aeon:WikidataLabel "speaker" ;
+                  aeon:WikidataURI "https://www.wikidata.org/wiki/Property:P823" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000051
-:AEON_0000051 rdf:type owl:ObjectProperty ;
-              rdfs:subPropertyOf :AEON_0000045 ;
-              owl:inverseOf :sponsors ;
-              rdfs:domain <http://purl.obolibrary.org/obo/OBI_0000011> ;
-              rdfs:range :sponsor ;
-              <http://purl.obolibrary.org/obo/IAO_0000115> "A relation obtaining between a planned process and a person or organization that holds a sponsor role which is being realized by the planned process."@en ;
-              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"@en ;
-              rdfs:label "has sponsor"@en ;
-              :SMW_datatype "Page" ;
-              :SMW_import_info """[[partOfSubobject::Template:Subobject Sponsor]]
+aeon:AEON_0000051 rdf:type owl:ObjectProperty ;
+                  rdfs:subPropertyOf aeon:AEON_0000045 ;
+                  owl:inverseOf aeon:sponsors ;
+                  rdfs:domain obo:OBI_0000011 ;
+                  rdfs:range aeon:sponsor ;
+                  obo:IAO_0000115 "A relation obtaining between a planned process and a person or organization that holds a sponsor role which is being realized by the planned process."@en ;
+                  obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
+                  rdfs:label "has sponsor"@en ;
+                  aeon:SMW_datatype "Page" ;
+                  aeon:SMW_import_info """[[partOfSubobject::Template:Subobject Sponsor]]
 
 [[Category:AEON]] [[Category:Imported vocabulary]]""" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000052
-:AEON_0000052 rdf:type owl:ObjectProperty ;
-              rdfs:subPropertyOf :AEON_0000048 ;
-              owl:inverseOf :committee_member_in ;
-              rdfs:domain <http://purl.obolibrary.org/obo/OBI_0000011> ;
-              rdfs:range :committee_member ;
-              <http://purl.obolibrary.org/obo/IAO_0000115> "A relation obtaining between a planned process and a person that holds a committee member role which is being realized by the planned process."@en ;
-              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"@en ;
-              rdfs:label "has committee member"@en ;
-              :SMW_datatype "Page" ;
-              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:AEON_0000052 rdf:type owl:ObjectProperty ;
+                  rdfs:subPropertyOf aeon:AEON_0000048 ;
+                  owl:inverseOf aeon:committee_member_in ;
+                  rdfs:domain obo:OBI_0000011 ;
+                  rdfs:range aeon:committee_member ;
+                  obo:IAO_0000115 "A relation obtaining between a planned process and a person that holds a committee member role which is being realized by the planned process."@en ;
+                  obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
+                  rdfs:label "has committee member"@en ;
+                  aeon:SMW_datatype "Page" ;
+                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000053
-:AEON_0000053 rdf:type owl:ObjectProperty ;
-              rdfs:subPropertyOf :AEON_0000048 ;
-              owl:inverseOf :contact_person_of ;
-              rdfs:domain <http://purl.obolibrary.org/obo/OBI_0000011> ;
-              rdfs:range :contact_person ;
-              <http://purl.obolibrary.org/obo/IAO_0000115> "A relation obtaining between a planned process and a person that holds a contact person role which is being realized by the planned process."@en ;
-              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"@en ;
-              rdfs:label "has contact person"@en ;
-              :SMW_datatype "Page" ;
-              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:AEON_0000053 rdf:type owl:ObjectProperty ;
+                  rdfs:subPropertyOf aeon:AEON_0000048 ;
+                  owl:inverseOf aeon:contact_person_of ;
+                  rdfs:domain obo:OBI_0000011 ;
+                  rdfs:range aeon:contact_person ;
+                  obo:IAO_0000115 "A relation obtaining between a planned process and a person that holds a contact person role which is being realized by the planned process."@en ;
+                  obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
+                  rdfs:label "has contact person"@en ;
+                  aeon:SMW_datatype "Page" ;
+                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000054
-:AEON_0000054 rdf:type owl:ObjectProperty ;
-              rdfs:subPropertyOf :AEON_0000050 ;
-              owl:inverseOf :holds_keynote_at ;
-              rdfs:domain <http://purl.obolibrary.org/obo/OBI_0000011> ;
-              rdfs:range :keynote_speaker ;
-              <http://purl.obolibrary.org/obo/IAO_0000115> "A relation between a planned process and a person that holds a keynote speaker role which is being realized by the planned process."@en ;
-              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"@en ;
-              rdfs:label "has keynote speaker"@en ;
-              :SMW_datatype "Page" ;
-              :SMW_import_info """[[partOfSubobject::Template:Subobject Contributor]]
+aeon:AEON_0000054 rdf:type owl:ObjectProperty ;
+                  rdfs:subPropertyOf aeon:AEON_0000050 ;
+                  owl:inverseOf aeon:holds_keynote_at ;
+                  rdfs:domain obo:OBI_0000011 ;
+                  rdfs:range aeon:keynote_speaker ;
+                  obo:IAO_0000115 "A relation between a planned process and a person that holds a keynote speaker role which is being realized by the planned process."@en ;
+                  obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
+                  rdfs:label "has keynote speaker"@en ;
+                  aeon:SMW_datatype "Page" ;
+                  aeon:SMW_import_info """[[partOfSubobject::Template:Subobject Contributor]]
                          
 [[Category:AEON]] [[Category:Imported vocabulary]]""" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000055
-:AEON_0000055 rdf:type owl:ObjectProperty ;
-              rdfs:subPropertyOf :AEON_0000052 ;
-              owl:inverseOf :committee_chair_in ;
-              rdfs:domain <http://purl.obolibrary.org/obo/OBI_0000011> ;
-              rdfs:range :committee_chair ;
-              <http://purl.obolibrary.org/obo/IAO_0000115> "A relation obtaining between a planned process and a person that holds a committee chair role which is being realized by the planned process."@en ;
-              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"@en ;
-              rdfs:label "has committee chair"@en ;
-              :SMW_datatype "Page" ;
-              :SMW_import_info """[[partOfSubobject::Template:Subobject Contributor]]
+aeon:AEON_0000055 rdf:type owl:ObjectProperty ;
+                  rdfs:subPropertyOf aeon:AEON_0000052 ;
+                  owl:inverseOf aeon:committee_chair_in ;
+                  rdfs:domain obo:OBI_0000011 ;
+                  rdfs:range aeon:committee_chair ;
+                  obo:IAO_0000115 "A relation obtaining between a planned process and a person that holds a committee chair role which is being realized by the planned process."@en ;
+                  obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
+                  rdfs:label "has committee chair"@en ;
+                  aeon:SMW_datatype "Page" ;
+                  aeon:SMW_import_info """[[partOfSubobject::Template:Subobject Contributor]]
 
 [[Category:AEON]] [[Category:Imported vocabulary]]""" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000075
-:AEON_0000075 rdf:type owl:ObjectProperty ;
-              rdfs:subPropertyOf <http://purl.obolibrary.org/obo/IAO_0000235> ;
-              rdfs:domain <http://purl.obolibrary.org/obo/IAO_0000027> ;
-              rdfs:range :AEON_0000016 ;
-              <http://purl.obolibrary.org/obo/IAO_0000115> "A relation obtaining between a data item and its corresponding digital object identifier."@en ;
-              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"@en ;
-              rdfs:label "has DOI"@en ;
-              <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> <http://purl.obolibrary.org/obo/IAO_0000423> ;
-              :SMW_datatype "External identifier" ;
-              :SMW_import_info """External formatter uri [[External formatter uri::https://doi.org/$1]]
+aeon:AEON_0000075 rdf:type owl:ObjectProperty ;
+                  rdfs:subPropertyOf obo:IAO_0000235 ;
+                  rdfs:domain obo:IAO_0000027 ;
+                  rdfs:range aeon:AEON_0000016 ;
+                  obo:IAO_0000115 "A relation obtaining between a data item and its corresponding digital object identifier."@en ;
+                  obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
+                  rdfs:label "has DOI"@en ;
+                  ns:term_status obo:IAO_0000423 ;
+                  aeon:SMW_datatype "External identifier" ;
+                  aeon:SMW_import_info """External formatter uri [[External formatter uri::https://doi.org/$1]]
 
 [[Category:AEON]] [[Category:Imported vocabulary]]""" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000076
-:AEON_0000076 rdf:type owl:ObjectProperty ;
-              rdfs:subPropertyOf <http://purl.obolibrary.org/obo/IAO_0000235> ;
-              rdfs:domain <http://purl.obolibrary.org/obo/BFO_0000001> ;
-              rdfs:range :AEON_0000017 ;
-              <http://purl.obolibrary.org/obo/IAO_0000115> "A relation obtaining between an entity and the identifier used by the German national library to denote the entity."@en ;
-              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"@en ;
-              rdfs:label "has GND"@en ;
-              <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> <http://purl.obolibrary.org/obo/IAO_0000423> ;
-              :AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P227\", \"label\": \"GND_ID\"}, \"gnd\": {\"uri\": \"https://d-nb.info/standards/elementset/gnd#gndIdentifier\", \"label\": \"GND-Identifier\"}}"^^xsd:string ;
-              :SMW_datatype "External identifier" ;
-              :SMW_import_info """External formatter uri [[External formatter uri::http://d-nb.info/gnd/$1]]
+aeon:AEON_0000076 rdf:type owl:ObjectProperty ;
+                  rdfs:subPropertyOf obo:IAO_0000235 ;
+                  rdfs:domain obo:BFO_0000001 ;
+                  rdfs:range aeon:AEON_0000017 ;
+                  obo:IAO_0000115 "A relation obtaining between an entity and the identifier used by the German national library to denote the entity."@en ;
+                  obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
+                  rdfs:label "has GND"@en ;
+                  ns:term_status obo:IAO_0000423 ;
+                  aeon:AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P227\", \"label\": \"GND_ID\"}, \"gnd\": {\"uri\": \"https://d-nb.info/standards/elementset/gnd#gndIdentifier\", \"label\": \"GND-Identifier\"}}"^^xsd:string ;
+                  aeon:SMW_datatype "External identifier" ;
+                  aeon:SMW_import_info """External formatter uri [[External formatter uri::http://d-nb.info/gnd/$1]]
 
 [[partOfSubobject::Template:Subobject External_Process_ID]]
 [[partOfSubobject::Template:Subobject Person_ID]]
 [[partOfSubobject::Template:Subobject Organization_ID]]
 
 [[Category:AEON]] [[Category:Imported vocabulary]]""" ;
-              :WikidataLabel "GND_ID" ;
-              :WikidataURI "https://www.wikidata.org/wiki/Property:P227" .
+                  aeon:WikidataLabel "GND_ID" ;
+                  aeon:WikidataURI "https://www.wikidata.org/wiki/Property:P227" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000077
-:AEON_0000077 rdf:type owl:ObjectProperty ;
-              rdfs:subPropertyOf <http://purl.obolibrary.org/obo/IAO_0000235> ;
-              rdfs:domain [ rdf:type owl:Class ;
-                            owl:unionOf ( <http://purl.obolibrary.org/obo/NCBITaxon_9606>
-                                          <http://purl.obolibrary.org/obo/OBI_0000245>
-                                        )
-                          ] ;
-              rdfs:range :AEON_0000018 ;
-              <http://purl.obolibrary.org/obo/IAO_0000115> "A relation obtaining between a person or organization and the 'international standard name identifier' used to denote the entity."@en ;
-              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"@en ;
-              rdfs:label "has ISNI"@en ;
-              <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> <http://purl.obolibrary.org/obo/IAO_0000423> ;
-              :SMW_datatype "External identifier" ;
-              :SMW_import_info """External formatter uri [[External formatter uri::https://isni.org/isni/$1]]
+aeon:AEON_0000077 rdf:type owl:ObjectProperty ;
+                  rdfs:subPropertyOf obo:IAO_0000235 ;
+                  rdfs:domain [ rdf:type owl:Class ;
+                                owl:unionOf ( obo:NCBITaxon_9606
+                                              obo:OBI_0000245
+                                            )
+                              ] ;
+                  rdfs:range aeon:AEON_0000018 ;
+                  obo:IAO_0000115 "A relation obtaining between a person or organization and the 'international standard name identifier' used to denote the entity."@en ;
+                  obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
+                  rdfs:label "has ISNI"@en ;
+                  ns:term_status obo:IAO_0000423 ;
+                  aeon:SMW_datatype "External identifier" ;
+                  aeon:SMW_import_info """External formatter uri [[External formatter uri::https://isni.org/isni/$1]]
 
 [[partOfSubobject::Template:Subobject Person_ID]]
 [[partOfSubobject::Template:Subobject Organization_ID]]
@@ -925,16 +931,16 @@ To say p has academic field x =def. p is a planned process, there is some x that
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000078
-:AEON_0000078 rdf:type owl:ObjectProperty ;
-              rdfs:subPropertyOf <http://purl.obolibrary.org/obo/IAO_0000235> ;
-              rdfs:domain <http://purl.obolibrary.org/obo/NCBITaxon_9606> ;
-              rdfs:range :AEON_0000019 ;
-              <http://purl.obolibrary.org/obo/IAO_0000115> "A relation obtaining between a person and the 'open researcher and contributor identifier' used to denote the entity."@en ;
-              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"@en ;
-              rdfs:label "has ORCID"@en ;
-              <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> <http://purl.obolibrary.org/obo/IAO_0000423> ;
-              :SMW_datatype "External identifier" ;
-              :SMW_import_info """External formatter uri [[External formatter uri::https://orcid.org/$1]]
+aeon:AEON_0000078 rdf:type owl:ObjectProperty ;
+                  rdfs:subPropertyOf obo:IAO_0000235 ;
+                  rdfs:domain obo:NCBITaxon_9606 ;
+                  rdfs:range aeon:AEON_0000019 ;
+                  obo:IAO_0000115 "A relation obtaining between a person and the 'open researcher and contributor identifier' used to denote the entity."@en ;
+                  obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
+                  rdfs:label "has ORCID"@en ;
+                  ns:term_status obo:IAO_0000423 ;
+                  aeon:SMW_datatype "External identifier" ;
+                  aeon:SMW_import_info """External formatter uri [[External formatter uri::https://orcid.org/$1]]
 
 [[partOfSubobject::Template:Subobject Person_ID]]
 
@@ -942,16 +948,16 @@ To say p has academic field x =def. p is a planned process, there is some x that
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000079
-:AEON_0000079 rdf:type owl:ObjectProperty ;
-              rdfs:subPropertyOf <http://purl.obolibrary.org/obo/IAO_0000235> ;
-              rdfs:domain <http://purl.obolibrary.org/obo/OBI_0000245> ;
-              rdfs:range :AEON_0000020 ;
-              <http://purl.obolibrary.org/obo/IAO_0000115> "A relation obtaining between a person and the 'research organization registry identifier' used to denote the entity."@en ;
-              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"@en ;
-              rdfs:label "has ROR"@en ;
-              <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> <http://purl.obolibrary.org/obo/IAO_0000423> ;
-              :SMW_datatype "External identifier" ;
-              :SMW_import_info """External formatter uri [[External formatter uri::https://ror.org/$1]]
+aeon:AEON_0000079 rdf:type owl:ObjectProperty ;
+                  rdfs:subPropertyOf obo:IAO_0000235 ;
+                  rdfs:domain obo:OBI_0000245 ;
+                  rdfs:range aeon:AEON_0000020 ;
+                  obo:IAO_0000115 "A relation obtaining between a person and the 'research organization registry identifier' used to denote the entity."@en ;
+                  obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
+                  rdfs:label "has ROR"@en ;
+                  ns:term_status obo:IAO_0000423 ;
+                  aeon:SMW_datatype "External identifier" ;
+                  aeon:SMW_import_info """External formatter uri [[External formatter uri::https://ror.org/$1]]
 
 [[partOfSubobject::Template:Subobject Organization_ID]]
 
@@ -959,329 +965,329 @@ To say p has academic field x =def. p is a planned process, there is some x that
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000080
-:AEON_0000080 rdf:type owl:ObjectProperty ;
-              rdfs:subPropertyOf <http://purl.obolibrary.org/obo/IAO_0000235> ;
-              rdfs:domain <http://purl.obolibrary.org/obo/BFO_0000001> ;
-              rdfs:range :AEON_0000021 ;
-              <http://purl.obolibrary.org/obo/IAO_0000115> "A relation obtaining between an entity and its corresponding Wikidata entity identifier."@en ;
-              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"@en ;
-              rdfs:label "has Wikidata QID"@en ;
-              <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> <http://purl.obolibrary.org/obo/IAO_0000423> ;
-              :AEON_0000026 "{\"wikidata\": {\"uri\": null, \"label\": \"itemID\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Property:Wikidataid\", \"label\": \"Wikidataid\"}}"^^xsd:string ;
-              :SMW_datatype "External identifier" ;
-              :SMW_import_info """External formatter uri [[External formatter uri::https://www.wikidata.org/wiki/$1]]
+aeon:AEON_0000080 rdf:type owl:ObjectProperty ;
+                  rdfs:subPropertyOf obo:IAO_0000235 ;
+                  rdfs:domain obo:BFO_0000001 ;
+                  rdfs:range aeon:AEON_0000021 ;
+                  obo:IAO_0000115 "A relation obtaining between an entity and its corresponding Wikidata entity identifier."@en ;
+                  obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
+                  rdfs:label "has Wikidata QID"@en ;
+                  ns:term_status obo:IAO_0000423 ;
+                  aeon:AEON_0000026 "{\"wikidata\": {\"uri\": null, \"label\": \"itemID\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Property:Wikidataid\", \"label\": \"Wikidataid\"}}"^^xsd:string ;
+                  aeon:SMW_datatype "External identifier" ;
+                  aeon:SMW_import_info """External formatter uri [[External formatter uri::https://www.wikidata.org/wiki/$1]]
 
 [[partOfSubobject::Template:Subobject Process_External_ID]]
 [[partOfSubobject::Template:Subobject Person_ID]]
 [[partOfSubobject::Template:Subobject Organization_ID]]
 
 [[Category:AEON]] [[Category:Imported vocabulary]]""" ;
-              :WikidataLabel "itemID" .
+                  aeon:WikidataLabel "itemID" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000081
-:AEON_0000081 rdf:type owl:ObjectProperty ;
-              rdfs:subPropertyOf <http://purl.obolibrary.org/obo/TXPO_0002523> ;
-              owl:inverseOf :AEON_0000084 ;
-              rdfs:domain :AEON_0000002 ;
-              rdfs:range :AEON_0000001 ;
-              <http://purl.obolibrary.org/obo/IAO_0000115> "A relation obtaining between an academic event series and an academic event. It is used to express that the academic event is part of a specific event series."@en ;
-              rdfs:label "has academic event"@en ;
-              :SMW_datatype "Page" ;
-              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:AEON_0000081 rdf:type owl:ObjectProperty ;
+                  rdfs:subPropertyOf obo:TXPO_0002523 ;
+                  owl:inverseOf aeon:AEON_0000084 ;
+                  rdfs:domain aeon:AEON_0000002 ;
+                  rdfs:range aeon:AEON_0000001 ;
+                  obo:IAO_0000115 "A relation obtaining between an academic event series and an academic event. It is used to express that the academic event is part of a specific event series."@en ;
+                  rdfs:label "has academic event"@en ;
+                  aeon:SMW_datatype "Page" ;
+                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000082
-:AEON_0000082 rdf:type owl:ObjectProperty ;
-              rdfs:subPropertyOf <http://purl.obolibrary.org/obo/RO_0002012> ;
-              owl:inverseOf :has_collocated_event ;
-              rdfs:domain :AEON_0000001 ;
-              rdfs:range :AEON_0000001 ;
-              <http://purl.obolibrary.org/obo/IAO_0000115> "see inverse property"@en ;
-              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"@en ;
-              rdfs:label "collocated event of"@en ;
-              :SMW_datatype "Page" ;
-              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:AEON_0000082 rdf:type owl:ObjectProperty ;
+                  rdfs:subPropertyOf obo:RO_0002012 ;
+                  owl:inverseOf aeon:has_collocated_event ;
+                  rdfs:domain aeon:AEON_0000001 ;
+                  rdfs:range aeon:AEON_0000001 ;
+                  obo:IAO_0000115 "see inverse property"@en ;
+                  obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
+                  rdfs:label "collocated event of"@en ;
+                  aeon:SMW_datatype "Page" ;
+                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000083
-:AEON_0000083 rdf:type owl:ObjectProperty ;
-              rdfs:subPropertyOf <http://purl.obolibrary.org/obo/RO_0002012> ;
-              owl:inverseOf :has_joint_event ;
-              rdfs:domain :AEON_0000001 ;
-              rdfs:range :AEON_0000001 ;
-              <http://purl.obolibrary.org/obo/IAO_0000115> "see inverse property"@en ;
-              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"@en ;
-              rdfs:label "joint event of"@en ;
-              :SMW_datatype "Page" ;
-              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:AEON_0000083 rdf:type owl:ObjectProperty ;
+                  rdfs:subPropertyOf obo:RO_0002012 ;
+                  owl:inverseOf aeon:has_joint_event ;
+                  rdfs:domain aeon:AEON_0000001 ;
+                  rdfs:range aeon:AEON_0000001 ;
+                  obo:IAO_0000115 "see inverse property"@en ;
+                  obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
+                  rdfs:label "joint event of"@en ;
+                  aeon:SMW_datatype "Page" ;
+                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000084
-:AEON_0000084 rdf:type owl:ObjectProperty ;
-              rdfs:subPropertyOf <http://purl.obolibrary.org/obo/RO_0002012> ;
-              rdfs:domain :AEON_0000001 ;
-              rdfs:range :AEON_0000002 ;
-              <http://purl.obolibrary.org/obo/IAO_0000115> "see inverse property"@en ;
-              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"@en ;
-              rdfs:label "part of series"@en ;
-              :AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P179\", \"label\": \"part_of_the_seriesLabel\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Property:Event_in_series\", \"label\": \"Event_in_series\"}}"^^xsd:string ;
-              :SMW_datatype "Page" ;
-              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:AEON_0000084 rdf:type owl:ObjectProperty ;
+                  rdfs:subPropertyOf obo:RO_0002012 ;
+                  rdfs:domain aeon:AEON_0000001 ;
+                  rdfs:range aeon:AEON_0000002 ;
+                  obo:IAO_0000115 "see inverse property"@en ;
+                  obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
+                  rdfs:label "part of series"@en ;
+                  aeon:AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P179\", \"label\": \"part_of_the_seriesLabel\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Property:Event_in_series\", \"label\": \"Event_in_series\"}}"^^xsd:string ;
+                  aeon:SMW_datatype "Page" ;
+                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000085
-:AEON_0000085 rdf:type owl:ObjectProperty ;
-              rdfs:subPropertyOf <http://purl.obolibrary.org/obo/RO_0002012> ;
-              owl:inverseOf :has_umbrella_event ;
-              rdfs:domain :AEON_0000001 ;
-              rdfs:range :AEON_0000001 ;
-              <http://purl.obolibrary.org/obo/IAO_0000115> "see inverse property"@en ;
-              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"@en ;
-              rdfs:label "umbrella event of"@en ;
-              :SMW_datatype "Page" ;
-              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:AEON_0000085 rdf:type owl:ObjectProperty ;
+                  rdfs:subPropertyOf obo:RO_0002012 ;
+                  owl:inverseOf aeon:has_umbrella_event ;
+                  rdfs:domain aeon:AEON_0000001 ;
+                  rdfs:range aeon:AEON_0000001 ;
+                  obo:IAO_0000115 "see inverse property"@en ;
+                  obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
+                  rdfs:label "umbrella event of"@en ;
+                  aeon:SMW_datatype "Page" ;
+                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000086
-:AEON_0000086 rdf:type owl:ObjectProperty ;
-              rdfs:subPropertyOf <http://purl.obolibrary.org/obo/BFO_0000066> ;
-              rdfs:domain :AEON_0000001 ;
-              rdfs:range :AEON_0000023 ;
-              rdfs:label "occurs in country"@en ;
-              :AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P17\", \"label\": \"countryLabel\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Property:Has_location_country\", \"label\": \"Has_location_country\"}}"^^xsd:string ;
-              :SMW_datatype "Text" ;
-              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" ;
-              :WikidataLabel "countryLabel" ;
-              :WikidataURI "https://www.wikidata.org/wiki/Property:P17" .
+aeon:AEON_0000086 rdf:type owl:ObjectProperty ;
+                  rdfs:subPropertyOf obo:BFO_0000066 ;
+                  rdfs:domain aeon:AEON_0000001 ;
+                  rdfs:range aeon:AEON_0000023 ;
+                  rdfs:label "occurs in country"@en ;
+                  aeon:AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P17\", \"label\": \"countryLabel\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Property:Has_location_country\", \"label\": \"Has_location_country\"}}"^^xsd:string ;
+                  aeon:SMW_datatype "Text" ;
+                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" ;
+                  aeon:WikidataLabel "countryLabel" ;
+                  aeon:WikidataURI "https://www.wikidata.org/wiki/Property:P17" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000087
-:AEON_0000087 rdf:type owl:ObjectProperty ;
-              rdfs:subPropertyOf <http://purl.obolibrary.org/obo/BFO_0000066> ;
-              rdfs:domain :AEON_0000001 ;
-              rdfs:range :AEON_0000022 ;
-              rdfs:label "occurs in city"@en ;
-              :AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P276\", \"label\": \"locationLabel\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Property:Has_location_city\", \"label\": \"Has_location_city\"}, \"gnd\": {\"uri\": \"https://d-nb.info/standards/elementset/gnd#placeOfConferenceOrEvent\", \"label\": \"Place of conference or event\"}}"^^xsd:string ;
-              :SMW_datatype "Text" ;
-              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:AEON_0000087 rdf:type owl:ObjectProperty ;
+                  rdfs:subPropertyOf obo:BFO_0000066 ;
+                  rdfs:domain aeon:AEON_0000001 ;
+                  rdfs:range aeon:AEON_0000022 ;
+                  rdfs:label "occurs in city"@en ;
+                  aeon:AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P276\", \"label\": \"locationLabel\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Property:Has_location_city\", \"label\": \"Has_location_city\"}, \"gnd\": {\"uri\": \"https://d-nb.info/standards/elementset/gnd#placeOfConferenceOrEvent\", \"label\": \"Place of conference or event\"}}"^^xsd:string ;
+                  aeon:SMW_datatype "Text" ;
+                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000088
-:AEON_0000088 rdf:type owl:ObjectProperty ;
-              rdfs:subPropertyOf <http://purl.obolibrary.org/obo/BFO_0000066> ;
-              rdfs:domain :AEON_0000001 ;
-              rdfs:range :AEON_0000024 ;
-              rdfs:label "occurs in state"@en ;
-              :AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P131\", \"label\": \"located_in_the_administrative_territorial_entityLabel\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Property:Has_location_state\", \"label\": \"Has_location_state\"}}"^^xsd:string ;
-              :SMW_datatype "Text" ;
-              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:AEON_0000088 rdf:type owl:ObjectProperty ;
+                  rdfs:subPropertyOf obo:BFO_0000066 ;
+                  rdfs:domain aeon:AEON_0000001 ;
+                  rdfs:range aeon:AEON_0000024 ;
+                  rdfs:label "occurs in state"@en ;
+                  aeon:AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P131\", \"label\": \"located_in_the_administrative_territorial_entityLabel\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Property:Has_location_state\", \"label\": \"Has_location_state\"}}"^^xsd:string ;
+                  aeon:SMW_datatype "Text" ;
+                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000089
-:AEON_0000089 rdf:type owl:ObjectProperty ;
-              rdfs:subPropertyOf <http://purl.obolibrary.org/obo/BFO_0000066> ;
-              rdfs:domain :AEON_0000001 ;
-              rdfs:range :AEON_0000025 ;
-              rdfs:label "occurs in venue"@en ;
-              :SMW_datatype "Text" ;
-              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:AEON_0000089 rdf:type owl:ObjectProperty ;
+                  rdfs:subPropertyOf obo:BFO_0000066 ;
+                  rdfs:domain aeon:AEON_0000001 ;
+                  rdfs:range aeon:AEON_0000025 ;
+                  rdfs:label "occurs in venue"@en ;
+                  aeon:SMW_datatype "Text" ;
+                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000090
-:AEON_0000090 rdf:type owl:ObjectProperty ;
-              rdfs:subPropertyOf <http://purl.obolibrary.org/obo/BFO_0000066> ;
-              rdfs:domain :AEON_0000001 ;
-              rdfs:range :AEON_0000029 ;
-              rdfs:label "occurs in virtual place"@en ;
-              :SMW_datatype "URL" ;
-              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:AEON_0000090 rdf:type owl:ObjectProperty ;
+                  rdfs:subPropertyOf obo:BFO_0000066 ;
+                  rdfs:domain aeon:AEON_0000001 ;
+                  rdfs:range aeon:AEON_0000029 ;
+                  rdfs:label "occurs in virtual place"@en ;
+                  aeon:SMW_datatype "URL" ;
+                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#academic_field_of
-:academic_field_of rdf:type owl:ObjectProperty ;
-                   rdfs:domain :AEON_0000027 ;
-                   rdfs:range <http://purl.obolibrary.org/obo/OBI_0000011> ;
-                   <http://purl.obolibrary.org/obo/IAO_0000115> "see inverse property"@en ;
-                   <http://purl.obolibrary.org/obo/IAO_0000117> "StroemertP"^^xsd:string ;
-                   rdfs:label "academicfield of"@en .
+aeon:academic_field_of rdf:type owl:ObjectProperty ;
+                       rdfs:domain aeon:AEON_0000027 ;
+                       rdfs:range obo:OBI_0000011 ;
+                       obo:IAO_0000115 "see inverse property"@en ;
+                       obo:IAO_0000117 "StroemertP"^^xsd:string ;
+                       rdfs:label "academicfield of"@en .
 
 
 ###  https://github.com/tibonto/aeon#attends_at
-:attends_at rdf:type owl:ObjectProperty ;
-            rdfs:subPropertyOf :contibutes_to ;
-            rdfs:domain :attendee ;
-            rdfs:range <http://purl.obolibrary.org/obo/OBI_0000011> ;
-            <http://purl.obolibrary.org/obo/IAO_0000115> "see inverse relation"@en ;
-            <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string ;
-            rdfs:label "attentds at"@en .
+aeon:attends_at rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf aeon:contibutes_to ;
+                rdfs:domain aeon:attendee ;
+                rdfs:range obo:OBI_0000011 ;
+                obo:IAO_0000115 "see inverse relation"@en ;
+                obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string ;
+                rdfs:label "attentds at"@en .
 
 
 ###  https://github.com/tibonto/aeon#committee_chair_in
-:committee_chair_in rdf:type owl:ObjectProperty ;
-                    rdfs:subPropertyOf :committee_member_in ;
-                    rdfs:domain :committee_chair ;
-                    rdfs:range <http://purl.obolibrary.org/obo/OBI_0000011> ;
-                    <http://purl.obolibrary.org/obo/IAO_0000115> "see inverse relation"@en ;
-                    <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string ;
-                    rdfs:label "committee chair in"@en .
+aeon:committee_chair_in rdf:type owl:ObjectProperty ;
+                        rdfs:subPropertyOf aeon:committee_member_in ;
+                        rdfs:domain aeon:committee_chair ;
+                        rdfs:range obo:OBI_0000011 ;
+                        obo:IAO_0000115 "see inverse relation"@en ;
+                        obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string ;
+                        rdfs:label "committee chair in"@en .
 
 
 ###  https://github.com/tibonto/aeon#committee_member_in
-:committee_member_in rdf:type owl:ObjectProperty ;
-                     rdfs:subPropertyOf :organizes ;
-                     rdfs:domain :committee_member ;
-                     rdfs:range <http://purl.obolibrary.org/obo/OBI_0000011> ;
-                     <http://purl.obolibrary.org/obo/IAO_0000115> "see inverse relation"@en ;
-                     <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string ;
-                     rdfs:label "committee member in"@en .
+aeon:committee_member_in rdf:type owl:ObjectProperty ;
+                         rdfs:subPropertyOf aeon:organizes ;
+                         rdfs:domain aeon:committee_member ;
+                         rdfs:range obo:OBI_0000011 ;
+                         obo:IAO_0000115 "see inverse relation"@en ;
+                         obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string ;
+                         rdfs:label "committee member in"@en .
 
 
 ###  https://github.com/tibonto/aeon#contact_person_of
-:contact_person_of rdf:type owl:ObjectProperty ;
-                   rdfs:subPropertyOf :organizes ;
-                   rdfs:domain :contact_person ;
-                   rdfs:range <http://purl.obolibrary.org/obo/OBI_0000011> ;
-                   <http://purl.obolibrary.org/obo/IAO_0000115> "see inverse relation"@en ;
-                   <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string ;
-                   rdfs:label "contact person of"@en .
+aeon:contact_person_of rdf:type owl:ObjectProperty ;
+                       rdfs:subPropertyOf aeon:organizes ;
+                       rdfs:domain aeon:contact_person ;
+                       rdfs:range obo:OBI_0000011 ;
+                       obo:IAO_0000115 "see inverse relation"@en ;
+                       obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string ;
+                       rdfs:label "contact person of"@en .
 
 
 ###  https://github.com/tibonto/aeon#contibutes_to
-:contibutes_to rdf:type owl:ObjectProperty ;
-               rdfs:subPropertyOf <http://purl.obolibrary.org/obo/RO_0000056> ;
-               rdfs:domain :contributor ;
-               rdfs:range <http://purl.obolibrary.org/obo/OBI_0000011> ;
-               <http://purl.obolibrary.org/obo/IAO_0000115> "see inverse relation"@en ;
-               <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string ;
-               rdfs:label "contributes to"@en .
+aeon:contibutes_to rdf:type owl:ObjectProperty ;
+                   rdfs:subPropertyOf obo:RO_0000056 ;
+                   rdfs:domain aeon:contributor ;
+                   rdfs:range obo:OBI_0000011 ;
+                   obo:IAO_0000115 "see inverse relation"@en ;
+                   obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string ;
+                   rdfs:label "contributes to"@en .
 
 
 ###  https://github.com/tibonto/aeon#event_type_of
-:event_type_of rdf:type owl:ObjectProperty ;
-               rdfs:domain :AEON_0000004 ;
-               rdfs:range :AEON_0000001 ;
-               <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string ;
-               rdfs:label "event type of"@en .
+aeon:event_type_of rdf:type owl:ObjectProperty ;
+                   rdfs:domain aeon:AEON_0000004 ;
+                   rdfs:range aeon:AEON_0000001 ;
+                   obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string ;
+                   rdfs:label "event type of"@en .
 
 
 ###  https://github.com/tibonto/aeon#has_WikiCFP_ID
-:has_WikiCFP_ID rdf:type owl:ObjectProperty ;
-                rdfs:subPropertyOf <http://purl.obolibrary.org/obo/IAO_0000235> ;
-                rdfs:domain [ rdf:type owl:Class ;
-                              owl:unionOf ( :AEON_0000001
-                                            :AEON_0000002
-                                          )
-                            ] ;
-                rdfs:range :wikiCFP_ID ;
-                <http://purl.obolibrary.org/obo/IAO_0000115> "A relation obtaining between an academic event or event series and its corresponding WikiCFP identifier."@en ;
-                <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string ;
-                rdfs:label "has WikiCFP ID"@en ;
-                <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> <http://purl.obolibrary.org/obo/IAO_0000423> ;
-                :AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P5127\", \"label\": \"WikiCFP_conference_series_ID\"}}" .
+aeon:has_WikiCFP_ID rdf:type owl:ObjectProperty ;
+                    rdfs:subPropertyOf obo:IAO_0000235 ;
+                    rdfs:domain [ rdf:type owl:Class ;
+                                  owl:unionOf ( aeon:AEON_0000001
+                                                aeon:AEON_0000002
+                                              )
+                                ] ;
+                    rdfs:range aeon:wikiCFP_ID ;
+                    obo:IAO_0000115 "A relation obtaining between an academic event or event series and its corresponding WikiCFP identifier."@en ;
+                    obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string ;
+                    rdfs:label "has WikiCFP ID"@en ;
+                    ns:term_status obo:IAO_0000423 ;
+                    aeon:AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P5127\", \"label\": \"WikiCFP_conference_series_ID\"}}" .
 
 
 ###  https://github.com/tibonto/aeon#has_collocated_event
-:has_collocated_event rdf:type owl:ObjectProperty ;
-                      rdfs:subPropertyOf <http://purl.obolibrary.org/obo/TXPO_0002523> ;
-                      rdfs:domain :AEON_0000001 ;
-                      rdfs:range :AEON_0000001 ;
-                      <http://purl.obolibrary.org/obo/IAO_0000115> """A relation obtaining between an academic event and another academic event. 
+aeon:has_collocated_event rdf:type owl:ObjectProperty ;
+                          rdfs:subPropertyOf obo:TXPO_0002523 ;
+                          rdfs:domain aeon:AEON_0000001 ;
+                          rdfs:range aeon:AEON_0000001 ;
+                          obo:IAO_0000115 """A relation obtaining between an academic event and another academic event. 
 A collocated event is an event that takes place at the same location and time as another academic event."""@en ;
-                      <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string ;
-                      rdfs:label "has collocated event"@en .
+                          obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string ;
+                          rdfs:label "has collocated event"@en .
 
 
 ###  https://github.com/tibonto/aeon#has_joint_event
-:has_joint_event rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf <http://purl.obolibrary.org/obo/TXPO_0002523> ;
-                 rdfs:domain :AEON_0000001 ;
-                 rdfs:range :AEON_0000001 ;
-                 <http://purl.obolibrary.org/obo/IAO_0000115> """A relation obtaining between an academic event and another academic event. 
+aeon:has_joint_event rdf:type owl:ObjectProperty ;
+                     rdfs:subPropertyOf obo:TXPO_0002523 ;
+                     rdfs:domain aeon:AEON_0000001 ;
+                     rdfs:range aeon:AEON_0000001 ;
+                     obo:IAO_0000115 """A relation obtaining between an academic event and another academic event. 
 A joint event is an event that shares some of the planning and organizing logistics with another academic event, but is otherwise independent from it."""@en ;
-                 <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string ;
-                 rdfs:label "has joint event"@en .
+                     obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string ;
+                     rdfs:label "has joint event"@en .
 
 
 ###  https://github.com/tibonto/aeon#has_umbrella_event
-:has_umbrella_event rdf:type owl:ObjectProperty ;
-                    rdfs:subPropertyOf <http://purl.obolibrary.org/obo/TXPO_0002523> ;
-                    rdfs:domain :AEON_0000001 ;
-                    rdfs:range :AEON_0000001 ;
-                    <http://purl.obolibrary.org/obo/IAO_0000115> """A relation obtaining between an academic event and another academic event or eent series. 
+aeon:has_umbrella_event rdf:type owl:ObjectProperty ;
+                        rdfs:subPropertyOf obo:TXPO_0002523 ;
+                        rdfs:domain aeon:AEON_0000001 ;
+                        rdfs:range aeon:AEON_0000001 ;
+                        obo:IAO_0000115 """A relation obtaining between an academic event and another academic event or eent series. 
 An umbrelle event is a superordinate event that combines several smaller academic events at the same time
 To say p 'has umbrella event' d =def. there exists an academic event d that is a 
 superordinate event of p and that there must be other academic events that have the same relation.."""@en ;
-                    <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string ;
-                    rdfs:label "has umbrella event"@en .
+                        obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string ;
+                        rdfs:label "has umbrella event"@en .
 
 
 ###  https://github.com/tibonto/aeon#holds_keynote_at
-:holds_keynote_at rdf:type owl:ObjectProperty ;
-                  rdfs:subPropertyOf :speaks_at ;
-                  rdfs:domain :keynote_speaker ;
-                  rdfs:range <http://purl.obolibrary.org/obo/OBI_0000011> ;
-                  <http://purl.obolibrary.org/obo/IAO_0000115> "see inverse relation"@en ;
-                  <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string ;
-                  rdfs:label "holds keynote speech at"@en .
+aeon:holds_keynote_at rdf:type owl:ObjectProperty ;
+                      rdfs:subPropertyOf aeon:speaks_at ;
+                      rdfs:domain aeon:keynote_speaker ;
+                      rdfs:range obo:OBI_0000011 ;
+                      obo:IAO_0000115 "see inverse relation"@en ;
+                      obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string ;
+                      rdfs:label "holds keynote speech at"@en .
 
 
 ###  https://github.com/tibonto/aeon#moderates_at
-:moderates_at rdf:type owl:ObjectProperty ;
-              rdfs:subPropertyOf :contibutes_to ;
-              rdfs:domain :moderator ;
-              rdfs:range <http://purl.obolibrary.org/obo/OBI_0000011> ;
-              <http://purl.obolibrary.org/obo/IAO_0000115> "see inverse relation"@en ;
-              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string ;
-              rdfs:label "moderates at"@en .
+aeon:moderates_at rdf:type owl:ObjectProperty ;
+                  rdfs:subPropertyOf aeon:contibutes_to ;
+                  rdfs:domain aeon:moderator ;
+                  rdfs:range obo:OBI_0000011 ;
+                  obo:IAO_0000115 "see inverse relation"@en ;
+                  obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string ;
+                  rdfs:label "moderates at"@en .
 
 
 ###  https://github.com/tibonto/aeon#organizes
-:organizes rdf:type owl:ObjectProperty ;
-           rdfs:subPropertyOf :contibutes_to ;
-           rdfs:domain :organizer ;
-           rdfs:range <http://purl.obolibrary.org/obo/OBI_0000011> ;
-           <http://purl.obolibrary.org/obo/IAO_0000115> "see inverse relation"@en ;
-           <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string ;
-           rdfs:label "organizes"@en .
+aeon:organizes rdf:type owl:ObjectProperty ;
+               rdfs:subPropertyOf aeon:contibutes_to ;
+               rdfs:domain aeon:organizer ;
+               rdfs:range obo:OBI_0000011 ;
+               obo:IAO_0000115 "see inverse relation"@en ;
+               obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string ;
+               rdfs:label "organizes"@en .
 
 
 ###  https://github.com/tibonto/aeon#reviews_at
-:reviews_at rdf:type owl:ObjectProperty ;
-            rdfs:subPropertyOf :contibutes_to ;
-            rdfs:domain :reviewer ;
-            rdfs:range <http://purl.obolibrary.org/obo/OBI_0000011> ;
-            <http://purl.obolibrary.org/obo/IAO_0000115> "see inverse relation"@en ;
-            <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string ;
-            rdfs:label "reviews at"@en .
+aeon:reviews_at rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf aeon:contibutes_to ;
+                rdfs:domain aeon:reviewer ;
+                rdfs:range obo:OBI_0000011 ;
+                obo:IAO_0000115 "see inverse relation"@en ;
+                obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string ;
+                rdfs:label "reviews at"@en .
 
 
 ###  https://github.com/tibonto/aeon#speaks_at
-:speaks_at rdf:type owl:ObjectProperty ;
-           rdfs:subPropertyOf :contibutes_to ;
-           rdfs:domain :speaker ;
-           rdfs:range <http://purl.obolibrary.org/obo/OBI_0000011> ;
-           <http://purl.obolibrary.org/obo/IAO_0000115> "see inverse relation"@en ;
-           <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string ;
-           rdfs:label "presents at"@en .
+aeon:speaks_at rdf:type owl:ObjectProperty ;
+               rdfs:subPropertyOf aeon:contibutes_to ;
+               rdfs:domain aeon:speaker ;
+               rdfs:range obo:OBI_0000011 ;
+               obo:IAO_0000115 "see inverse relation"@en ;
+               obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string ;
+               rdfs:label "presents at"@en .
 
 
 ###  https://github.com/tibonto/aeon#sponsors
-:sponsors rdf:type owl:ObjectProperty ;
-          rdfs:subPropertyOf :contibutes_to ;
-          rdfs:domain :sponsor ;
-          rdfs:range <http://purl.obolibrary.org/obo/OBI_0000011> ;
-          <http://purl.obolibrary.org/obo/IAO_0000115> "see inverse relation"@en ;
-          <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string .
+aeon:sponsors rdf:type owl:ObjectProperty ;
+              rdfs:subPropertyOf aeon:contibutes_to ;
+              rdfs:domain aeon:sponsor ;
+              rdfs:range obo:OBI_0000011 ;
+              obo:IAO_0000115 "see inverse relation"@en ;
+              obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string .
 
 
 ###  https://github.com/tibonto/aeon#topic_of
-:topic_of rdf:type owl:ObjectProperty ;
-          rdfs:domain :AEON_0000028 ;
-          rdfs:range <http://purl.obolibrary.org/obo/OBI_0000011> ;
-          <http://purl.obolibrary.org/obo/IAO_0000115> "see inverse property"@en ;
-          <http://purl.obolibrary.org/obo/IAO_0000117> "StroemertP"^^xsd:string ;
-          rdfs:label "topic of"@en .
+aeon:topic_of rdf:type owl:ObjectProperty ;
+              rdfs:domain aeon:AEON_0000028 ;
+              rdfs:range obo:OBI_0000011 ;
+              obo:IAO_0000115 "see inverse property"@en ;
+              obo:IAO_0000117 "StroemertP"^^xsd:string ;
+              rdfs:label "topic of"@en .
 
 
 #################################################################
@@ -1293,22 +1299,22 @@ owl:topDataProperty rdfs:range rdfs:Literal .
 
 
 ###  https://github.com/tibonto/aeon#CORE_ranking
-:CORE_ranking rdf:type owl:DatatypeProperty ;
-              rdfs:subPropertyOf :metric ;
-              rdfs:domain :AEON_0000001 ;
-              rdfs:label "CORE ranking"@en ;
-              :SMW_datatype "Text" ;
-              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:CORE_ranking rdf:type owl:DatatypeProperty ;
+                  rdfs:subPropertyOf aeon:metric ;
+                  rdfs:domain aeon:AEON_0000001 ;
+                  rdfs:label "CORE ranking"@en ;
+                  aeon:SMW_datatype "Text" ;
+                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#ID
-:ID rdf:type owl:DatatypeProperty ;
-    rdfs:subPropertyOf owl:topDataProperty ;
-    rdfs:domain <http://purl.obolibrary.org/obo/IAO_0020000> ;
-    <http://purl.obolibrary.org/obo/IAO_0000115> "The literal value of an identifier."@en ;
-    rdfs:label "identifier"@en ;
-    :SMW_datatype "Text" ;
-    :SMW_import_info """[[partOfSubobject::Template:Subobject External_Process_ID]]
+aeon:ID rdf:type owl:DatatypeProperty ;
+        rdfs:subPropertyOf owl:topDataProperty ;
+        rdfs:domain obo:IAO_0020000 ;
+        obo:IAO_0000115 "The literal value of an identifier."@en ;
+        rdfs:label "identifier"@en ;
+        aeon:SMW_datatype "Text" ;
+        aeon:SMW_import_info """[[partOfSubobject::Template:Subobject External_Process_ID]]
 [[partOfSubobject::Template:Subobject Person_ID]]
 [[partOfSubobject::Template:Subobject Organization_ID]]
 
@@ -1316,14 +1322,14 @@ owl:topDataProperty rdfs:range rdfs:Literal .
 
 
 ###  https://github.com/tibonto/aeon#ID_URL
-:ID_URL rdf:type owl:DatatypeProperty ;
-        rdfs:subPropertyOf :ID ;
-        rdfs:domain <http://purl.obolibrary.org/obo/IAO_0020000> ;
-        rdfs:range xsd:anyURI ;
-        rdfs:comment "The literal value of the full URL used by the identifier scheme, based on the concatination of base URL and ID (ID_URL:value = ID_base_URL:value + ID:value)."@en ;
-        rdfs:label "identifier URI"@en ;
-        :SMW_datatype "URL" ;
-        :SMW_import_info """[[partOfSubobject::Template:Subobject External_Process_ID]]
+aeon:ID_URL rdf:type owl:DatatypeProperty ;
+            rdfs:subPropertyOf aeon:ID ;
+            rdfs:domain obo:IAO_0020000 ;
+            rdfs:range xsd:anyURI ;
+            rdfs:comment "The literal value of the full URL used by the identifier scheme, based on the concatination of base URL and ID (ID_URL:value = ID_base_URL:value + ID:value)."@en ;
+            rdfs:label "identifier URI"@en ;
+            aeon:SMW_datatype "URL" ;
+            aeon:SMW_import_info """[[partOfSubobject::Template:Subobject External_Process_ID]]
 [[partOfSubobject::Template:Subobject Person_ID]]
 [[partOfSubobject::Template:Subobject Organization_ID]]
 
@@ -1331,14 +1337,14 @@ owl:topDataProperty rdfs:range rdfs:Literal .
 
 
 ###  https://github.com/tibonto/aeon#ID_base_URL
-:ID_base_URL rdf:type owl:DatatypeProperty ;
-             rdfs:subPropertyOf :ID ;
-             rdfs:domain <http://purl.obolibrary.org/obo/IAO_0020000> ;
-             rdfs:range xsd:anyURI ;
-             rdfs:comment "The literal value of the base URL used by the identifier scheme."@en ;
-             rdfs:label "identifier base URI"@en ;
-             :SMW_datatype "URL" ;
-             :SMW_import_info """[[partOfSubobject::Template:Subobject External_Process_ID]]
+aeon:ID_base_URL rdf:type owl:DatatypeProperty ;
+                 rdfs:subPropertyOf aeon:ID ;
+                 rdfs:domain obo:IAO_0020000 ;
+                 rdfs:range xsd:anyURI ;
+                 rdfs:comment "The literal value of the base URL used by the identifier scheme."@en ;
+                 rdfs:label "identifier base URI"@en ;
+                 aeon:SMW_datatype "URL" ;
+                 aeon:SMW_import_info """[[partOfSubobject::Template:Subobject External_Process_ID]]
 [[partOfSubobject::Template:Subobject Person_ID]]
 [[partOfSubobject::Template:Subobject Organization_ID]]
 
@@ -1346,209 +1352,209 @@ owl:topDataProperty rdfs:range rdfs:Literal .
 
 
 ###  https://github.com/tibonto/aeon#abstract_deadline
-:abstract_deadline rdf:type owl:DatatypeProperty ;
-                   rdfs:subPropertyOf :deadline ;
-                   rdfs:domain :AEON_0000001 ;
-                   rdfs:range xsd:dateTimeStamp ;
-                   rdfs:label "abstract deadline"@en ;
-                   :SMW_datatype "Date" ;
-                   :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:abstract_deadline rdf:type owl:DatatypeProperty ;
+                       rdfs:subPropertyOf aeon:deadline ;
+                       rdfs:domain aeon:AEON_0000001 ;
+                       rdfs:range xsd:dateTimeStamp ;
+                       rdfs:label "abstract deadline"@en ;
+                       aeon:SMW_datatype "Date" ;
+                       aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#acceptance_rate
-:acceptance_rate rdf:type owl:DatatypeProperty ;
-                 rdfs:subPropertyOf :metric ;
-                 rdfs:domain :AEON_0000001 ;
-                 rdfs:label "acceptance rate"@en ;
-                 :SMW_datatype "Number" ;
-                 :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:acceptance_rate rdf:type owl:DatatypeProperty ;
+                     rdfs:subPropertyOf aeon:metric ;
+                     rdfs:domain aeon:AEON_0000001 ;
+                     rdfs:label "acceptance rate"@en ;
+                     aeon:SMW_datatype "Number" ;
+                     aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#accepted_papers
-:accepted_papers rdf:type owl:DatatypeProperty ;
-                 rdfs:subPropertyOf :metric ;
-                 rdfs:domain :AEON_0000001 ;
-                 rdfs:label "accepted papers"@en ;
-                 :SMW_datatype "Number" ;
-                 :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:accepted_papers rdf:type owl:DatatypeProperty ;
+                     rdfs:subPropertyOf aeon:metric ;
+                     rdfs:domain aeon:AEON_0000001 ;
+                     rdfs:label "accepted papers"@en ;
+                     aeon:SMW_datatype "Number" ;
+                     aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#accepted_short_papers
-:accepted_short_papers rdf:type owl:DatatypeProperty ;
-                       rdfs:subPropertyOf :metric ;
-                       rdfs:domain :AEON_0000001 ;
-                       rdfs:label "accepted short papers"@en ;
-                       :SMW_datatype "Number" ;
-                       :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:accepted_short_papers rdf:type owl:DatatypeProperty ;
+                           rdfs:subPropertyOf aeon:metric ;
+                           rdfs:domain aeon:AEON_0000001 ;
+                           rdfs:label "accepted short papers"@en ;
+                           aeon:SMW_datatype "Number" ;
+                           aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#camera-ready_deadline
-:camera-ready_deadline rdf:type owl:DatatypeProperty ;
-                       rdfs:subPropertyOf :deadline ;
-                       rdfs:domain :AEON_0000001 ;
-                       rdfs:range xsd:dateTimeStamp ;
-                       rdfs:label "camera-ready deadline"@en ;
-                       :SMW_datatype "Date" ;
-                       :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:camera-ready_deadline rdf:type owl:DatatypeProperty ;
+                           rdfs:subPropertyOf aeon:deadline ;
+                           rdfs:domain aeon:AEON_0000001 ;
+                           rdfs:range xsd:dateTimeStamp ;
+                           rdfs:label "camera-ready deadline"@en ;
+                           aeon:SMW_datatype "Date" ;
+                           aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#city
-:city rdf:type owl:DatatypeProperty ;
-      rdfs:subPropertyOf :location ;
-      rdfs:domain :AEON_0000022 ;
-      rdfs:label "city"@en ;
-      :SMW_datatype "Text" ;
-      :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:city rdf:type owl:DatatypeProperty ;
+          rdfs:subPropertyOf aeon:location ;
+          rdfs:domain aeon:AEON_0000022 ;
+          rdfs:label "city"@en ;
+          aeon:SMW_datatype "Text" ;
+          aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#contact
-:contact rdf:type owl:DatatypeProperty ;
-         rdfs:subPropertyOf owl:topDataProperty ;
-         rdfs:domain :AEON_0000009 ;
-         rdfs:label "contact"@en ;
-         :SMW_datatype "Text" ;
-         :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:contact rdf:type owl:DatatypeProperty ;
+             rdfs:subPropertyOf owl:topDataProperty ;
+             rdfs:domain aeon:AEON_0000009 ;
+             rdfs:label "contact"@en ;
+             aeon:SMW_datatype "Text" ;
+             aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#contact_email
-:contact_email rdf:type owl:DatatypeProperty ;
-               rdfs:subPropertyOf :contact ;
-               rdfs:domain :AEON_0000009 ;
-               rdfs:label "contact email"@en ;
-               :SMW_datatype "Email" ;
-               :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:contact_email rdf:type owl:DatatypeProperty ;
+                   rdfs:subPropertyOf aeon:contact ;
+                   rdfs:domain aeon:AEON_0000009 ;
+                   rdfs:label "contact email"@en ;
+                   aeon:SMW_datatype "Email" ;
+                   aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#contact_person_name
-:contact_person_name rdf:type owl:DatatypeProperty ;
-                     rdfs:subPropertyOf :contact ;
-                     rdfs:domain :AEON_0000009 ;
-                     rdfs:label "contact person"@en ;
-                     :SMW_datatype "Text" ;
-                     :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:contact_person_name rdf:type owl:DatatypeProperty ;
+                         rdfs:subPropertyOf aeon:contact ;
+                         rdfs:domain aeon:AEON_0000009 ;
+                         rdfs:label "contact person"@en ;
+                         aeon:SMW_datatype "Text" ;
+                         aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#contact_phone
-:contact_phone rdf:type owl:DatatypeProperty ;
-               rdfs:subPropertyOf :contact ;
-               rdfs:domain :AEON_0000009 ;
-               rdfs:label "contact phone"@en ;
-               :SMW_datatype "Telephone number" ;
-               :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:contact_phone rdf:type owl:DatatypeProperty ;
+                   rdfs:subPropertyOf aeon:contact ;
+                   rdfs:domain aeon:AEON_0000009 ;
+                   rdfs:label "contact phone"@en ;
+                   aeon:SMW_datatype "Telephone number" ;
+                   aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#coordinates
-:coordinates rdf:type owl:DatatypeProperty ;
-             rdfs:subPropertyOf :location ;
-             rdfs:domain <http://purl.obolibrary.org/obo/GAZ_00000448> ;
-             rdfs:label "coordinates"@en ;
-             :SMW_datatype "Geographic coordinates" ;
-             :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:coordinates rdf:type owl:DatatypeProperty ;
+                 rdfs:subPropertyOf aeon:location ;
+                 rdfs:domain obo:GAZ_00000448 ;
+                 rdfs:label "coordinates"@en ;
+                 aeon:SMW_datatype "Geographic coordinates" ;
+                 aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#country
-:country rdf:type owl:DatatypeProperty ;
-         rdfs:subPropertyOf :location ;
-         rdfs:domain :AEON_0000023 ;
-         rdfs:label "country"@en ;
-         :SMW_datatype "Text" ;
-         :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:country rdf:type owl:DatatypeProperty ;
+             rdfs:subPropertyOf aeon:location ;
+             rdfs:domain aeon:AEON_0000023 ;
+             rdfs:label "country"@en ;
+             aeon:SMW_datatype "Text" ;
+             aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#deadline
-:deadline rdf:type owl:DatatypeProperty ;
-          rdfs:subPropertyOf owl:topDataProperty ;
-          rdfs:domain :AEON_0000001 ;
-          rdfs:range xsd:dateTime ;
-          rdfs:label "deadline"@en ;
-          :SMW_datatype "Date" ;
-          :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:deadline rdf:type owl:DatatypeProperty ;
+              rdfs:subPropertyOf owl:topDataProperty ;
+              rdfs:domain aeon:AEON_0000001 ;
+              rdfs:range xsd:dateTime ;
+              rdfs:label "deadline"@en ;
+              aeon:SMW_datatype "Date" ;
+              aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#demo_deadline
-:demo_deadline rdf:type owl:DatatypeProperty ;
-               rdfs:subPropertyOf :deadline ;
-               rdfs:domain :AEON_0000001 ;
-               rdfs:range xsd:dateTimeStamp ;
-               rdfs:label "demo deadline"@en ;
-               :SMW_datatype "Date" ;
-               :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:demo_deadline rdf:type owl:DatatypeProperty ;
+                   rdfs:subPropertyOf aeon:deadline ;
+                   rdfs:domain aeon:AEON_0000001 ;
+                   rdfs:range xsd:dateTimeStamp ;
+                   rdfs:label "demo deadline"@en ;
+                   aeon:SMW_datatype "Date" ;
+                   aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#duration
-:duration rdf:type owl:DatatypeProperty ;
-          rdfs:subPropertyOf owl:topDataProperty ;
-          rdfs:domain :AEON_0000001 ;
-          rdfs:label "duration"@en ;
-          :AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P2047\", \"label\": \"duration\"}, \"gnd\": {\"uri\": \"https://d-nb.info/standards/elementset/gnd#dateOfConferenceOrEvent\", \"label\": \"Date of conference or event\"}}"^^xsd:string ;
-          :SMW_datatype "Quantity" ;
-          :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" ;
-          :WikidataLabel "duration" ;
-          :WikidataURI "https://www.wikidata.org/wiki/Property:P2047" .
+aeon:duration rdf:type owl:DatatypeProperty ;
+              rdfs:subPropertyOf owl:topDataProperty ;
+              rdfs:domain aeon:AEON_0000001 ;
+              rdfs:label "duration"@en ;
+              aeon:AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P2047\", \"label\": \"duration\"}, \"gnd\": {\"uri\": \"https://d-nb.info/standards/elementset/gnd#dateOfConferenceOrEvent\", \"label\": \"Date of conference or event\"}}"^^xsd:string ;
+              aeon:SMW_datatype "Quantity" ;
+              aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" ;
+              aeon:WikidataLabel "duration" ;
+              aeon:WikidataURI "https://www.wikidata.org/wiki/Property:P2047" .
 
 
 ###  https://github.com/tibonto/aeon#end_date
-:end_date rdf:type owl:DatatypeProperty ;
-          rdfs:subPropertyOf :duration ;
-          rdfs:domain :AEON_0000001 ;
-          rdfs:range xsd:dateTimeStamp ;
-          rdfs:label "end date"@en ;
-          :AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P582\", \"label\": \"end_time\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Property:End_date\", \"label\": \"End_date\"},\"crossref\": {\"api_proceedings_endpoint_uri\": \"https://api.crossref.org/types/proceedings/works?select=event\", \"json_api_key\": {\"event\": \"end\"}}}"^^xsd:string ;
-          :SMW_datatype "Date" ;
-          :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" ;
-          :WikidataLabel "end_time" ;
-          :WikidataURI "https://www.wikidata.org/wiki/Property:P582" .
+aeon:end_date rdf:type owl:DatatypeProperty ;
+              rdfs:subPropertyOf aeon:duration ;
+              rdfs:domain aeon:AEON_0000001 ;
+              rdfs:range xsd:dateTimeStamp ;
+              rdfs:label "end date"@en ;
+              aeon:AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P582\", \"label\": \"end_time\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Property:End_date\", \"label\": \"End_date\"},\"crossref\": {\"api_proceedings_endpoint_uri\": \"https://api.crossref.org/types/proceedings/works?select=event\", \"json_api_key\": {\"event\": \"end\"}}}"^^xsd:string ;
+              aeon:SMW_datatype "Date" ;
+              aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" ;
+              aeon:WikidataLabel "end_time" ;
+              aeon:WikidataURI "https://www.wikidata.org/wiki/Property:P582" .
 
 
 ###  https://github.com/tibonto/aeon#event_frequency
-:event_frequency rdf:type owl:DatatypeProperty ;
-                 rdfs:subPropertyOf :metric ;
-                 rdfs:domain :AEON_0000002 ;
-                 <http://purl.obolibrary.org/obo/IAO_0000115> "The event frequency is the literal value of the number of month until the next event in a certain takes place." ;
-                 rdfs:label "event frequency"@en ;
-                 :AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P2257\", \"label\": \"event_interval_inmonths\"}}"^^xsd:string ;
-                 :SMW_datatype "Quantity" ;
-                 :SMW_import_info """[[Corresponds to::1 month]] [[Corresponds to::1 months]] [[display units::months]]
+aeon:event_frequency rdf:type owl:DatatypeProperty ;
+                     rdfs:subPropertyOf aeon:metric ;
+                     rdfs:domain aeon:AEON_0000002 ;
+                     obo:IAO_0000115 "The event frequency is the literal value of the number of month until the next event in a certain takes place." ;
+                     rdfs:label "event frequency"@en ;
+                     aeon:AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P2257\", \"label\": \"event_interval_inmonths\"}}"^^xsd:string ;
+                     aeon:SMW_datatype "Quantity" ;
+                     aeon:SMW_import_info """[[Corresponds to::1 month]] [[Corresponds to::1 months]] [[display units::months]]
 
 [[Category:AEON]] [[Category:Imported vocabulary]]""" ;
-                 :WikidataLabel "event_interval_inmonths" ;
-                 :WikidataURI "https://www.wikidata.org/wiki/Property:P2257" .
+                     aeon:WikidataLabel "event_interval_inmonths" ;
+                     aeon:WikidataURI "https://www.wikidata.org/wiki/Property:P2257" .
 
 
 ###  https://github.com/tibonto/aeon#event_number
-:event_number rdf:type owl:DatatypeProperty ;
-              rdfs:domain :AEON_0000001 ;
-              rdfs:range xsd:string ;
-              <http://purl.obolibrary.org/obo/IAO_0000115> "The ordinal number of an academic event, if it is a part of an event series." ;
-              rdfs:label "event number"@en ;
-              :AEON_0000026 "{\"crossref\": {\"api_proceedings_endpoint_uri\": \"https://api.crossref.org/types/proceedings/works?select=event\", \"json_api_key\": {\"event\": \"number\"}}}"^^xsd:string ;
-              :SMW_datatype "Text" ;
-              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:event_number rdf:type owl:DatatypeProperty ;
+                  rdfs:domain aeon:AEON_0000001 ;
+                  rdfs:range xsd:string ;
+                  obo:IAO_0000115 "The ordinal number of an academic event, if it is a part of an event series." ;
+                  rdfs:label "event number"@en ;
+                  aeon:AEON_0000026 "{\"crossref\": {\"api_proceedings_endpoint_uri\": \"https://api.crossref.org/types/proceedings/works?select=event\", \"json_api_key\": {\"event\": \"number\"}}}"^^xsd:string ;
+                  aeon:SMW_datatype "Text" ;
+                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#event_status
-:event_status rdf:type owl:DatatypeProperty ;
-              rdfs:subPropertyOf owl:topDataProperty ;
-              rdfs:domain :AEON_0000001 ;
-              rdfs:range [ rdf:type rdfs:Datatype ;
-                           owl:oneOf [ rdf:type rdf:List ;
-                                       rdf:first "as scheduled" ;
-                                       rdf:rest [ rdf:type rdf:List ;
-                                                  rdf:first "canceled" ;
-                                                  rdf:rest [ rdf:type rdf:List ;
-                                                             rdf:first "delayed" ;
-                                                             rdf:rest [ rdf:type rdf:List ;
-                                                                        rdf:first "planned" ;
-                                                                        rdf:rest [ rdf:type rdf:List ;
-                                                                                   rdf:first "postponed" ;
-                                                                                   rdf:rest rdf:nil
-                                                                                 ]
-                                                                      ]
-                                                           ]
-                                                ]
-                                     ]
-                         ] ;
-              rdfs:comment """maps_to: DataCite:dateType 
+aeon:event_status rdf:type owl:DatatypeProperty ;
+                  rdfs:subPropertyOf owl:topDataProperty ;
+                  rdfs:domain aeon:AEON_0000001 ;
+                  rdfs:range [ rdf:type rdfs:Datatype ;
+                               owl:oneOf [ rdf:type rdf:List ;
+                                           rdf:first "as scheduled" ;
+                                           rdf:rest [ rdf:type rdf:List ;
+                                                      rdf:first "canceled" ;
+                                                      rdf:rest [ rdf:type rdf:List ;
+                                                                 rdf:first "delayed" ;
+                                                                 rdf:rest [ rdf:type rdf:List ;
+                                                                            rdf:first "planned" ;
+                                                                            rdf:rest [ rdf:type rdf:List ;
+                                                                                       rdf:first "postponed" ;
+                                                                                       rdf:rest rdf:nil
+                                                                                     ]
+                                                                          ]
+                                                               ]
+                                                    ]
+                                         ]
+                             ] ;
+                  rdfs:comment """maps_to: DataCite:dateType 
 ---
 allowed value mapping 
 ConfIDent → DataCite
@@ -1556,52 +1562,52 @@ ConfIDent → DataCite
 scheduled → valid
 postponed → updated
 cancled → withdrawn"""@en ;
-              rdfs:label "event status"@en ;
-              :SMW_datatype "Text" ;
-              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+                  rdfs:label "event status"@en ;
+                  aeon:SMW_datatype "Text" ;
+                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#event_type_other
-:event_type_other rdf:type owl:DatatypeProperty ;
-                  rdfs:subPropertyOf owl:topDataProperty ;
-                  rdfs:domain :AEON_0000004 ;
-                  rdfs:range xsd:string ;
-                  rdfs:label "event type other"@en ;
-                  :SMW_datatype "Text" ;
-                  :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:event_type_other rdf:type owl:DatatypeProperty ;
+                      rdfs:subPropertyOf owl:topDataProperty ;
+                      rdfs:domain aeon:AEON_0000004 ;
+                      rdfs:range xsd:string ;
+                      rdfs:label "event type other"@en ;
+                      aeon:SMW_datatype "Text" ;
+                      aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#event_year
-:event_year rdf:type owl:DatatypeProperty ;
-            rdfs:domain :AEON_0000001 ;
-            rdfs:range xsd:integer ;
-            <http://purl.obolibrary.org/obo/IAO_0000115> "The year in which an event takes place."@en ;
-            rdfs:label "event year"@en ;
-            :SMW_datatype "Date" ;
-            :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:event_year rdf:type owl:DatatypeProperty ;
+                rdfs:domain aeon:AEON_0000001 ;
+                rdfs:range xsd:integer ;
+                obo:IAO_0000115 "The year in which an event takes place."@en ;
+                rdfs:label "event year"@en ;
+                aeon:SMW_datatype "Date" ;
+                aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#fee
-:fee rdf:type owl:DatatypeProperty ;
-     rdfs:subPropertyOf owl:topDataProperty ;
-     rdfs:domain :AEON_0000030 ;
-     <http://purl.obolibrary.org/obo/IAO_0000115> "The literal value of the type of fee an aeon:event can have."@en ;
-     <http://purl.obolibrary.org/obo/IAO_0000600> "There are various type of fees for an event, such as the regular fee, a reduced fee, a member fee and so forth." ;
-     rdfs:label "fee"@en ;
-     :SMW_datatype "Text" ;
-     :SMW_import_info """[[partOfSubobject::Template:Subobject Fee]]
+aeon:fee rdf:type owl:DatatypeProperty ;
+         rdfs:subPropertyOf owl:topDataProperty ;
+         rdfs:domain aeon:AEON_0000030 ;
+         obo:IAO_0000115 "The literal value of the type of fee an aeon:event can have."@en ;
+         obo:IAO_0000600 "There are various type of fees for an event, such as the regular fee, a reduced fee, a member fee and so forth." ;
+         rdfs:label "fee"@en ;
+         aeon:SMW_datatype "Text" ;
+         aeon:SMW_import_info """[[partOfSubobject::Template:Subobject Fee]]
 
 [[Category:AEON]] [[Category:Imported vocabulary]]""" .
 
 
 ###  https://github.com/tibonto/aeon#fee_currency
-:fee_currency rdf:type owl:DatatypeProperty ;
-              rdfs:subPropertyOf :fee ;
-              rdfs:domain :AEON_0000030 ;
-              rdfs:comment "This property should have a value from the controlled list defined by the ISO_4217 standard (https://en.wikipedia.org/wiki/ISO_4217)." ;
-              rdfs:label "fee currency"@en ;
-              :SMW_datatype "Text" ;
-              :SMW_import_info """Controlled vocabulary in [[MediaWiki:Smw_allows_list_Fee_currency]]
+aeon:fee_currency rdf:type owl:DatatypeProperty ;
+                  rdfs:subPropertyOf aeon:fee ;
+                  rdfs:domain aeon:AEON_0000030 ;
+                  rdfs:comment "This property should have a value from the controlled list defined by the ISO_4217 standard (https://en.wikipedia.org/wiki/ISO_4217)." ;
+                  rdfs:label "fee currency"@en ;
+                  aeon:SMW_datatype "Text" ;
+                  aeon:SMW_import_info """Controlled vocabulary in [[MediaWiki:Smw_allows_list_Fee_currency]]
 
 [[partOfSubobject::Template:Subobject Fee]]
 
@@ -1609,36 +1615,36 @@ cancled → withdrawn"""@en ;
 
 
 ###  https://github.com/tibonto/aeon#fee_value
-:fee_value rdf:type owl:DatatypeProperty ;
-           rdfs:subPropertyOf :fee ;
-           rdfs:domain :AEON_0000030 ;
-           rdfs:label "fee value"@en ;
-           :SMW_datatype "Number" ;
-           :SMW_import_info """[[partOfSubobject::Template:Subobject Fee]]
+aeon:fee_value rdf:type owl:DatatypeProperty ;
+               rdfs:subPropertyOf aeon:fee ;
+               rdfs:domain aeon:AEON_0000030 ;
+               rdfs:label "fee value"@en ;
+               aeon:SMW_datatype "Number" ;
+               aeon:SMW_import_info """[[partOfSubobject::Template:Subobject Fee]]
 
 [[Category:AEON]] [[Category:Imported vocabulary]]""" .
 
 
 ###  https://github.com/tibonto/aeon#first_name
-:first_name rdf:type owl:DatatypeProperty ;
-            rdfs:subPropertyOf :personal_name ;
-            rdfs:domain <http://purl.obolibrary.org/obo/NCBITaxon_9606> ;
-            rdfs:range xsd:string ;
-            <http://purl.obolibrary.org/obo/IAO_0000115> "The literal value of the first name of a person."@en ;
-            rdfs:label "first name"@en ;
-            :SMW_datatype "Text" ;
-            :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:first_name rdf:type owl:DatatypeProperty ;
+                rdfs:subPropertyOf aeon:personal_name ;
+                rdfs:domain obo:NCBITaxon_9606 ;
+                rdfs:range xsd:string ;
+                obo:IAO_0000115 "The literal value of the first name of a person."@en ;
+                rdfs:label "first name"@en ;
+                aeon:SMW_datatype "Text" ;
+                aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#landing_page
-:landing_page rdf:type owl:DatatypeProperty ;
-              rdfs:subPropertyOf :ID ;
-              rdfs:domain <http://purl.obolibrary.org/obo/IAO_0020000> ;
-              rdfs:range xsd:anyURI ;
-              rdfs:comment "The literal value of the landing page (URL) an ID resolves to when following the ID_URL."@en ;
-              rdfs:label "identifier landing page"@en ;
-              :SMW_datatype "URL" ;
-              :SMW_import_info """[[partOfSubobject::Template:Subobject External_Process_ID]]
+aeon:landing_page rdf:type owl:DatatypeProperty ;
+                  rdfs:subPropertyOf aeon:ID ;
+                  rdfs:domain obo:IAO_0020000 ;
+                  rdfs:range xsd:anyURI ;
+                  rdfs:comment "The literal value of the landing page (URL) an ID resolves to when following the ID_URL."@en ;
+                  rdfs:label "identifier landing page"@en ;
+                  aeon:SMW_datatype "URL" ;
+                  aeon:SMW_import_info """[[partOfSubobject::Template:Subobject External_Process_ID]]
 [[partOfSubobject::Template:Subobject Person_ID]]
 [[partOfSubobject::Template:Subobject Organization_ID]]
 
@@ -1646,347 +1652,347 @@ cancled → withdrawn"""@en ;
 
 
 ###  https://github.com/tibonto/aeon#language
-:language rdf:type owl:DatatypeProperty ;
-          rdfs:subPropertyOf owl:topDataProperty ;
-          rdfs:label "language"@en ;
-          :AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P2936\", \"label\": \"language_usedLabel\"}}"^^xsd:string ;
-          :SMW_datatype "Text" ;
-          :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" ;
-          :WikidataLabel "language_usedLabel" ;
-          :WikidataURI "https://www.wikidata.org/wiki/Property:P2936" .
+aeon:language rdf:type owl:DatatypeProperty ;
+              rdfs:subPropertyOf owl:topDataProperty ;
+              rdfs:label "language"@en ;
+              aeon:AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P2936\", \"label\": \"language_usedLabel\"}}"^^xsd:string ;
+              aeon:SMW_datatype "Text" ;
+              aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" ;
+              aeon:WikidataLabel "language_usedLabel" ;
+              aeon:WikidataURI "https://www.wikidata.org/wiki/Property:P2936" .
 
 
 ###  https://github.com/tibonto/aeon#last_name
-:last_name rdf:type owl:DatatypeProperty ;
-           rdfs:subPropertyOf :personal_name ;
-           rdfs:domain <http://purl.obolibrary.org/obo/NCBITaxon_9606> ;
-           rdfs:range xsd:string ;
-           <http://purl.obolibrary.org/obo/IAO_0000115> "The literal value of the last name, or family name, of a person."@en ;
-           rdfs:label "last name"@en ;
-           :SMW_datatype "Text" ;
-           :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:last_name rdf:type owl:DatatypeProperty ;
+               rdfs:subPropertyOf aeon:personal_name ;
+               rdfs:domain obo:NCBITaxon_9606 ;
+               rdfs:range xsd:string ;
+               obo:IAO_0000115 "The literal value of the last name, or family name, of a person."@en ;
+               rdfs:label "last name"@en ;
+               aeon:SMW_datatype "Text" ;
+               aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#location
-:location rdf:type owl:DatatypeProperty ;
-          rdfs:subPropertyOf owl:topDataProperty ;
-          rdfs:domain <http://purl.obolibrary.org/obo/BFO_0000029> ;
-          rdfs:label "location"@en ;
-          :SMW_datatype "Text" ;
-          :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:location rdf:type owl:DatatypeProperty ;
+              rdfs:subPropertyOf owl:topDataProperty ;
+              rdfs:domain obo:BFO_0000029 ;
+              rdfs:label "location"@en ;
+              aeon:SMW_datatype "Text" ;
+              aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#logo
-:logo rdf:type owl:DatatypeProperty ;
-      rdfs:subPropertyOf owl:topDataProperty ;
-      rdfs:label "logo"@en ;
-      :SMW_datatype "Page" ;
-      :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:logo rdf:type owl:DatatypeProperty ;
+          rdfs:subPropertyOf owl:topDataProperty ;
+          rdfs:label "logo"@en ;
+          aeon:SMW_datatype "Page" ;
+          aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#meeting_URL
-:meeting_URL rdf:type owl:DatatypeProperty ;
-             rdfs:subPropertyOf :location ;
-             rdfs:domain :AEON_0000029 ;
-             rdfs:range xsd:anyURI ;
-             rdfs:label "meeting URL"@en ;
-             :SMW_datatype "URL" ;
-             :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:meeting_URL rdf:type owl:DatatypeProperty ;
+                 rdfs:subPropertyOf aeon:location ;
+                 rdfs:domain aeon:AEON_0000029 ;
+                 rdfs:range xsd:anyURI ;
+                 rdfs:label "meeting URL"@en ;
+                 aeon:SMW_datatype "URL" ;
+                 aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#metric
-:metric rdf:type owl:DatatypeProperty ;
-        rdfs:subPropertyOf owl:topDataProperty ;
-        rdfs:domain <http://purl.obolibrary.org/obo/OBI_0000011> ;
-        rdfs:label "metric"@en ;
-        :SMW_datatype "Text" ;
-        :SMW_import_info """[[partOfSubobject::Template:Subobject Metric]]
+aeon:metric rdf:type owl:DatatypeProperty ;
+            rdfs:subPropertyOf owl:topDataProperty ;
+            rdfs:domain obo:OBI_0000011 ;
+            rdfs:label "metric"@en ;
+            aeon:SMW_datatype "Text" ;
+            aeon:SMW_import_info """[[partOfSubobject::Template:Subobject Metric]]
 
 [[Category:AEON]] [[Category:Imported vocabulary]]""" .
 
 
 ###  https://github.com/tibonto/aeon#name
-:name rdf:type owl:DatatypeProperty ;
-      rdfs:subPropertyOf owl:topDataProperty ;
-      <http://purl.obolibrary.org/obo/IAO_0000115> "The literal value of the name of a thing."@en ;
-      rdfs:label "name"@en ;
-      :SMW_datatype "Text" ;
-      :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:name rdf:type owl:DatatypeProperty ;
+          rdfs:subPropertyOf owl:topDataProperty ;
+          obo:IAO_0000115 "The literal value of the name of a thing."@en ;
+          rdfs:label "name"@en ;
+          aeon:SMW_datatype "Text" ;
+          aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#notification_deadline
-:notification_deadline rdf:type owl:DatatypeProperty ;
-                       rdfs:subPropertyOf :deadline ;
-                       rdfs:domain :AEON_0000001 ;
-                       rdfs:range xsd:dateTimeStamp ;
-                       rdfs:label "notification deadline"@en ;
-                       :SMW_datatype "Date" ;
-                       :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:notification_deadline rdf:type owl:DatatypeProperty ;
+                           rdfs:subPropertyOf aeon:deadline ;
+                           rdfs:domain aeon:AEON_0000001 ;
+                           rdfs:range xsd:dateTimeStamp ;
+                           rdfs:label "notification deadline"@en ;
+                           aeon:SMW_datatype "Date" ;
+                           aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#number_of_attendees
-:number_of_attendees rdf:type owl:DatatypeProperty ;
-                     rdfs:subPropertyOf :metric ;
-                     rdfs:domain :AEON_0000001 ;
-                     rdfs:label "number of attendess"@en ;
-                     :AEON_0000026 "{\"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Property:Attendees\", \"label\": \"Attendees\"}}"^^xsd:string ;
-                     :SMW_datatype "Number" ;
-                     :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:number_of_attendees rdf:type owl:DatatypeProperty ;
+                         rdfs:subPropertyOf aeon:metric ;
+                         rdfs:domain aeon:AEON_0000001 ;
+                         rdfs:label "number of attendess"@en ;
+                         aeon:AEON_0000026 "{\"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Property:Attendees\", \"label\": \"Attendees\"}}"^^xsd:string ;
+                         aeon:SMW_datatype "Number" ;
+                         aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#number_of_tracks
-:number_of_tracks rdf:type owl:DatatypeProperty ;
-                  rdfs:subPropertyOf :metric ;
-                  rdfs:domain :AEON_0000001 ;
-                  rdfs:label "number of tracks"@en ;
-                  :SMW_datatype "Number" ;
-                  :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:number_of_tracks rdf:type owl:DatatypeProperty ;
+                      rdfs:subPropertyOf aeon:metric ;
+                      rdfs:domain aeon:AEON_0000001 ;
+                      rdfs:label "number of tracks"@en ;
+                      aeon:SMW_datatype "Number" ;
+                      aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#organizational_name
-:organizational_name rdf:type owl:DatatypeProperty ;
-                     rdfs:subPropertyOf :name ;
-                     rdfs:domain <http://purl.obolibrary.org/obo/OBI_0000245> ;
-                     rdfs:range xsd:string ;
-                     <http://purl.obolibrary.org/obo/IAO_0000115> "The literal value of the name to denote an organization."@en ;
-                     rdfs:label "organizational name"@en ;
-                     :SMW_datatype "Text" ;
-                     :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:organizational_name rdf:type owl:DatatypeProperty ;
+                         rdfs:subPropertyOf aeon:name ;
+                         rdfs:domain obo:OBI_0000245 ;
+                         rdfs:range xsd:string ;
+                         obo:IAO_0000115 "The literal value of the name to denote an organization."@en ;
+                         rdfs:label "organizational name"@en ;
+                         aeon:SMW_datatype "Text" ;
+                         aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#paper_deadline
-:paper_deadline rdf:type owl:DatatypeProperty ;
-                rdfs:subPropertyOf :deadline ;
-                rdfs:domain :AEON_0000001 ;
-                rdfs:range xsd:dateTimeStamp ;
-                rdfs:label "paper deadline"@en ;
-                :SMW_datatype "Date" ;
-                :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:paper_deadline rdf:type owl:DatatypeProperty ;
+                    rdfs:subPropertyOf aeon:deadline ;
+                    rdfs:domain aeon:AEON_0000001 ;
+                    rdfs:range xsd:dateTimeStamp ;
+                    rdfs:label "paper deadline"@en ;
+                    aeon:SMW_datatype "Date" ;
+                    aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#personal_name
-:personal_name rdf:type owl:DatatypeProperty ;
-               rdfs:subPropertyOf :name ;
-               rdfs:domain <http://purl.obolibrary.org/obo/NCBITaxon_9606> ;
-               rdfs:range xsd:string ;
-               <http://purl.obolibrary.org/obo/IAO_0000115> "The literal value of the name to denote a person."@en ;
-               rdfs:label "personal name"@en ;
-               :SMW_datatype "Text" ;
-               :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:personal_name rdf:type owl:DatatypeProperty ;
+                   rdfs:subPropertyOf aeon:name ;
+                   rdfs:domain obo:NCBITaxon_9606 ;
+                   rdfs:range xsd:string ;
+                   obo:IAO_0000115 "The literal value of the name to denote a person."@en ;
+                   rdfs:label "personal name"@en ;
+                   aeon:SMW_datatype "Text" ;
+                   aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#poster_deadline
-:poster_deadline rdf:type owl:DatatypeProperty ;
-                 rdfs:subPropertyOf :deadline ;
-                 rdfs:domain :AEON_0000001 ;
-                 rdfs:range xsd:dateTimeStamp ;
-                 rdfs:label "poster deadline"@en ;
-                 :SMW_datatype "Date" ;
-                 :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:poster_deadline rdf:type owl:DatatypeProperty ;
+                     rdfs:subPropertyOf aeon:deadline ;
+                     rdfs:domain aeon:AEON_0000001 ;
+                     rdfs:range xsd:dateTimeStamp ;
+                     rdfs:label "poster deadline"@en ;
+                     aeon:SMW_datatype "Date" ;
+                     aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#previous_end_date
-:previous_end_date rdf:type owl:DatatypeProperty ;
-                   rdfs:subPropertyOf :end_date ;
-                   rdfs:domain :AEON_0000001 ;
-                   rdfs:range xsd:dateTime ;
-                   rdfs:label "previous end date"@en ;
-                   :SMW_datatype "Date" ;
-                   :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:previous_end_date rdf:type owl:DatatypeProperty ;
+                       rdfs:subPropertyOf aeon:end_date ;
+                       rdfs:domain aeon:AEON_0000001 ;
+                       rdfs:range xsd:dateTime ;
+                       rdfs:label "previous end date"@en ;
+                       aeon:SMW_datatype "Date" ;
+                       aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#previous_start_date
-:previous_start_date rdf:type owl:DatatypeProperty ;
-                     rdfs:subPropertyOf :start_date ;
-                     rdfs:domain :AEON_0000001 ;
-                     rdfs:range xsd:dateTimeStamp ;
-                     rdfs:label "previous start date"@en ;
-                     :SMW_datatype "Date" ;
-                     :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:previous_start_date rdf:type owl:DatatypeProperty ;
+                         rdfs:subPropertyOf aeon:start_date ;
+                         rdfs:domain aeon:AEON_0000001 ;
+                         rdfs:range xsd:dateTimeStamp ;
+                         rdfs:label "previous start date"@en ;
+                         aeon:SMW_datatype "Date" ;
+                         aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#proceedings_site_count
-:proceedings_site_count rdf:type owl:DatatypeProperty ;
-                        rdfs:subPropertyOf :metric ;
-                        rdfs:domain :AEON_0000001 ;
-                        rdfs:label "proceeding cite count"@en ;
-                        :SMW_datatype "Number" ;
-                        :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:proceedings_site_count rdf:type owl:DatatypeProperty ;
+                            rdfs:subPropertyOf aeon:metric ;
+                            rdfs:domain aeon:AEON_0000001 ;
+                            rdfs:label "proceeding cite count"@en ;
+                            aeon:SMW_datatype "Number" ;
+                            aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#process_acronym
-:process_acronym rdf:type owl:DatatypeProperty ;
-                 rdfs:subPropertyOf :name ;
-                 rdfs:range xsd:string ;
-                 <http://purl.obolibrary.org/obo/IAO_0000112> "\"DILS 2019\" is the official acronym of the academic event \"13th International Conference on Data Integration in Life Science\""@en ;
-                 <http://purl.obolibrary.org/obo/IAO_0000115> "The literal value of the official acronym of an aeon:process, that is either an academic event or event series."@en ;
-                 rdfs:label "acronym"@en ;
-                 :AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P1813\", \"label\": \"short_nameLabel\"}, \"gnd\": {\"uri\": \"https://d-nb.info/standards/elementset/gnd#abbreviatedNameForTheConferenceOrEvent\", \"label\": \"Abbreviated name for the conference or event\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Property:Acronym\", \"label\": \"Acronym\"}, \"crossref\": {\"api_proceedings_endpoint_uri\": \"https://api.crossref.org/types/proceedings/works?select=event\", \"json_api_key\": {\"event\": \"acronym\"}}}"^^xsd:string ;
-                 :SMW_datatype "Text" ;
-                 :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" ;
-                 :WikidataLabel "short_nameLabel" ;
-                 :WikidataURI "https://www.wikidata.org/wiki/Property:P1813" .
+aeon:process_acronym rdf:type owl:DatatypeProperty ;
+                     rdfs:subPropertyOf aeon:name ;
+                     rdfs:range xsd:string ;
+                     obo:IAO_0000112 "\"DILS 2019\" is the official acronym of the academic event \"13th International Conference on Data Integration in Life Science\""@en ;
+                     obo:IAO_0000115 "The literal value of the official acronym of an aeon:process, that is either an academic event or event series."@en ;
+                     rdfs:label "acronym"@en ;
+                     aeon:AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P1813\", \"label\": \"short_nameLabel\"}, \"gnd\": {\"uri\": \"https://d-nb.info/standards/elementset/gnd#abbreviatedNameForTheConferenceOrEvent\", \"label\": \"Abbreviated name for the conference or event\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Property:Acronym\", \"label\": \"Acronym\"}, \"crossref\": {\"api_proceedings_endpoint_uri\": \"https://api.crossref.org/types/proceedings/works?select=event\", \"json_api_key\": {\"event\": \"acronym\"}}}"^^xsd:string ;
+                     aeon:SMW_datatype "Text" ;
+                     aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" ;
+                     aeon:WikidataLabel "short_nameLabel" ;
+                     aeon:WikidataURI "https://www.wikidata.org/wiki/Property:P1813" .
 
 
 ###  https://github.com/tibonto/aeon#process_alternative_name
-:process_alternative_name rdf:type owl:DatatypeProperty ;
-                          rdfs:subPropertyOf :name ;
-                          rdfs:range xsd:string ;
-                          rdfs:comment "The Literal value of an alternative name of an aeon:process, that is either an academic event or event series."@en ;
-                          rdfs:label "alternative name"@en ;
-                          :AEON_0000026 "{\"gnd\": {\"uri\": \"https://d-nb.info/standards/elementset/gnd#variantNameForTheConferenceOrEvent\", \"label\": \"Variant name for the conference or event\"}, \"crossref\": {\"api_proceedings_endpoint_uri\": \"https://api.crossref.org/types/proceedings/works?select=title\", \"json_api_key\": \"title\"}}"^^xsd:string ;
-                          :SMW_datatype "Text" ;
-                          :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:process_alternative_name rdf:type owl:DatatypeProperty ;
+                              rdfs:subPropertyOf aeon:name ;
+                              rdfs:range xsd:string ;
+                              rdfs:comment "The Literal value of an alternative name of an aeon:process, that is either an academic event or event series."@en ;
+                              rdfs:label "alternative name"@en ;
+                              aeon:AEON_0000026 "{\"gnd\": {\"uri\": \"https://d-nb.info/standards/elementset/gnd#variantNameForTheConferenceOrEvent\", \"label\": \"Variant name for the conference or event\"}, \"crossref\": {\"api_proceedings_endpoint_uri\": \"https://api.crossref.org/types/proceedings/works?select=title\", \"json_api_key\": \"title\"}}"^^xsd:string ;
+                              aeon:SMW_datatype "Text" ;
+                              aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#process_former_name
-:process_former_name rdf:type owl:DatatypeProperty ;
-                     rdfs:subPropertyOf :name ;
-                     rdfs:range xsd:string ;
-                     rdfs:comment "The Literal value of the former official name of an aeon:process, that is either an academic event or event series."@en ;
-                     rdfs:label "former name"@en ;
-                     :SMW_datatype "Text" ;
-                     :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:process_former_name rdf:type owl:DatatypeProperty ;
+                         rdfs:subPropertyOf aeon:name ;
+                         rdfs:range xsd:string ;
+                         rdfs:comment "The Literal value of the former official name of an aeon:process, that is either an academic event or event series."@en ;
+                         rdfs:label "former name"@en ;
+                         aeon:SMW_datatype "Text" ;
+                         aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#process_translated_name
-:process_translated_name rdf:type owl:DatatypeProperty ;
-                         rdfs:subPropertyOf :name ;
-                         rdfs:range xsd:string ;
-                         <http://purl.obolibrary.org/obo/IAO_0000115> "The literal value of the translation of the official name (title) of an aeon:process, that is either an academic event or event series."@en ;
-                         rdfs:label "translated name"@en ;
-                         :SMW_datatype "Text" ;
-                         :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:process_translated_name rdf:type owl:DatatypeProperty ;
+                             rdfs:subPropertyOf aeon:name ;
+                             rdfs:range xsd:string ;
+                             obo:IAO_0000115 "The literal value of the translation of the official name (title) of an aeon:process, that is either an academic event or event series."@en ;
+                             rdfs:label "translated name"@en ;
+                             aeon:SMW_datatype "Text" ;
+                             aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#process_website
-:process_website rdf:type owl:DatatypeProperty ;
-                 rdfs:subPropertyOf owl:topDataProperty ;
-                 rdfs:domain <http://purl.obolibrary.org/obo/OBI_0000011> ;
-                 rdfs:range xsd:anyURI ;
-                 rdfs:label "process website"@en ;
-                 :AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P856\", \"label\": \"official_website\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Property:Homepage\", \"label\": \"Homepage\"}}"^^xsd:string ;
-                 :SMW_datatype "URL" ;
-                 :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" ;
-                 :WikidataLabel "official_website" ;
-                 :WikidataURI "https://www.wikidata.org/wiki/Property:P856" .
+aeon:process_website rdf:type owl:DatatypeProperty ;
+                     rdfs:subPropertyOf owl:topDataProperty ;
+                     rdfs:domain obo:OBI_0000011 ;
+                     rdfs:range xsd:anyURI ;
+                     rdfs:label "process website"@en ;
+                     aeon:AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P856\", \"label\": \"official_website\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Property:Homepage\", \"label\": \"Homepage\"}}"^^xsd:string ;
+                     aeon:SMW_datatype "URL" ;
+                     aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" ;
+                     aeon:WikidataLabel "official_website" ;
+                     aeon:WikidataURI "https://www.wikidata.org/wiki/Property:P856" .
 
 
 ###  https://github.com/tibonto/aeon#series_cite_count
-:series_cite_count rdf:type owl:DatatypeProperty ;
-                   rdfs:subPropertyOf :metric ;
-                   rdfs:domain :AEON_0000002 ;
-                   rdfs:label "series cite count"@en ;
-                   :SMW_datatype "Number" ;
-                   :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:series_cite_count rdf:type owl:DatatypeProperty ;
+                       rdfs:subPropertyOf aeon:metric ;
+                       rdfs:domain aeon:AEON_0000002 ;
+                       rdfs:label "series cite count"@en ;
+                       aeon:SMW_datatype "Number" ;
+                       aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#sponsor_type
-:sponsor_type rdf:type owl:DatatypeProperty ;
-              rdfs:subPropertyOf owl:topDataProperty ;
-              rdfs:domain :AEON_0000015 ;
-              rdfs:range xsd:string ;
-              rdfs:label "sponsor type"@en ;
-              :SMW_datatype "Text" ;
-              :SMW_import_info """Controlled vocabulary in [[MediaWiki:Smw _allows_list_Sponsor_type]] 
+aeon:sponsor_type rdf:type owl:DatatypeProperty ;
+                  rdfs:subPropertyOf owl:topDataProperty ;
+                  rdfs:domain aeon:AEON_0000015 ;
+                  rdfs:range xsd:string ;
+                  rdfs:label "sponsor type"@en ;
+                  aeon:SMW_datatype "Text" ;
+                  aeon:SMW_import_info """Controlled vocabulary in [[MediaWiki:Smw _allows_list_Sponsor_type]] 
 
 [[Category:AEON]] [[Category:Imported vocabulary]]""" .
 
 
 ###  https://github.com/tibonto/aeon#start_date
-:start_date rdf:type owl:DatatypeProperty ;
-            rdfs:subPropertyOf :duration ;
-            rdfs:domain :AEON_0000001 ;
-            rdfs:range xsd:dateTime ;
-            rdfs:label "start date"@en ;
-            :AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P580\", \"label\": \"start_time\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Property:Start_date\", \"label\": \"Start_date\"},\"crossref\": {\"api_proceedings_endpoint_uri\": \"https://api.crossref.org/types/proceedings/works?select=event\", \"json_api_key\": {\"event\": \"start\"}}}"^^xsd:string ;
-            :SMW_datatype "Date" ;
-            :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" ;
-            :WikidataLabel "start_time" ;
-            :WikidataURI "https://www.wikidata.org/wiki/Property:P580" .
+aeon:start_date rdf:type owl:DatatypeProperty ;
+                rdfs:subPropertyOf aeon:duration ;
+                rdfs:domain aeon:AEON_0000001 ;
+                rdfs:range xsd:dateTime ;
+                rdfs:label "start date"@en ;
+                aeon:AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P580\", \"label\": \"start_time\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Property:Start_date\", \"label\": \"Start_date\"},\"crossref\": {\"api_proceedings_endpoint_uri\": \"https://api.crossref.org/types/proceedings/works?select=event\", \"json_api_key\": {\"event\": \"start\"}}}"^^xsd:string ;
+                aeon:SMW_datatype "Date" ;
+                aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" ;
+                aeon:WikidataLabel "start_time" ;
+                aeon:WikidataURI "https://www.wikidata.org/wiki/Property:P580" .
 
 
 ###  https://github.com/tibonto/aeon#state
-:state rdf:type owl:DatatypeProperty ;
-       rdfs:subPropertyOf :location ;
-       rdfs:domain :AEON_0000024 ;
-       rdfs:label "state"@en ;
-       :SMW_datatype "Text" ;
-       :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:state rdf:type owl:DatatypeProperty ;
+           rdfs:subPropertyOf aeon:location ;
+           rdfs:domain aeon:AEON_0000024 ;
+           rdfs:label "state"@en ;
+           aeon:SMW_datatype "Text" ;
+           aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#submission_deadline
-:submission_deadline rdf:type owl:DatatypeProperty ;
-                     rdfs:subPropertyOf :deadline ;
-                     rdfs:domain :AEON_0000001 ;
-                     rdfs:range xsd:dateTimeStamp ;
-                     rdfs:label "submission deadline"@en ;
-                     :SMW_datatype "Date" ;
-                     :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:submission_deadline rdf:type owl:DatatypeProperty ;
+                         rdfs:subPropertyOf aeon:deadline ;
+                         rdfs:domain aeon:AEON_0000001 ;
+                         rdfs:range xsd:dateTimeStamp ;
+                         rdfs:label "submission deadline"@en ;
+                         aeon:SMW_datatype "Date" ;
+                         aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#submitted_papers
-:submitted_papers rdf:type owl:DatatypeProperty ;
-                  rdfs:subPropertyOf :metric ;
-                  rdfs:domain :AEON_0000001 ;
-                  rdfs:label "submitted papers"@en ;
-                  :SMW_datatype "Number" ;
-                  :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:submitted_papers rdf:type owl:DatatypeProperty ;
+                      rdfs:subPropertyOf aeon:metric ;
+                      rdfs:domain aeon:AEON_0000001 ;
+                      rdfs:label "submitted papers"@en ;
+                      aeon:SMW_datatype "Number" ;
+                      aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#summary
-:summary rdf:type owl:DatatypeProperty ;
-         rdfs:subPropertyOf owl:topDataProperty ;
-         rdfs:label "summary"@en ;
-         :SMW_datatype "Text" ;
-         :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:summary rdf:type owl:DatatypeProperty ;
+             rdfs:subPropertyOf owl:topDataProperty ;
+             rdfs:label "summary"@en ;
+             aeon:SMW_datatype "Text" ;
+             aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#summary_licence
-:summary_licence rdf:type owl:DatatypeProperty ;
-                 rdfs:subPropertyOf :summary ;
-                 rdfs:label "summary licence"@en ;
-                 :SMW_datatype "Text" ;
-                 :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:summary_licence rdf:type owl:DatatypeProperty ;
+                     rdfs:subPropertyOf aeon:summary ;
+                     rdfs:label "summary licence"@en ;
+                     aeon:SMW_datatype "Text" ;
+                     aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#tutorial_deadline
-:tutorial_deadline rdf:type owl:DatatypeProperty ;
-                   rdfs:subPropertyOf :deadline ;
-                   rdfs:domain :AEON_0000001 ;
-                   rdfs:range xsd:dateTimeStamp ;
-                   rdfs:label "tutorial deadline"@en ;
-                   :SMW_datatype "Date" ;
-                   :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:tutorial_deadline rdf:type owl:DatatypeProperty ;
+                       rdfs:subPropertyOf aeon:deadline ;
+                       rdfs:domain aeon:AEON_0000001 ;
+                       rdfs:range xsd:dateTimeStamp ;
+                       rdfs:label "tutorial deadline"@en ;
+                       aeon:SMW_datatype "Date" ;
+                       aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#venue
-:venue rdf:type owl:DatatypeProperty ;
-       rdfs:subPropertyOf :location ;
-       rdfs:domain :AEON_0000025 ;
-       rdfs:label "venue"@en ;
-       :SMW_datatype "Text" ;
-       :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:venue rdf:type owl:DatatypeProperty ;
+           rdfs:subPropertyOf aeon:location ;
+           rdfs:domain aeon:AEON_0000025 ;
+           rdfs:label "venue"@en ;
+           aeon:SMW_datatype "Text" ;
+           aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#venue_URL
-:venue_URL rdf:type owl:DatatypeProperty ;
-           rdfs:subPropertyOf :venue ;
-           rdfs:domain :AEON_0000025 ;
-           rdfs:range xsd:anyURI ;
-           rdfs:label "venue website"@en ;
-           :SMW_datatype "URL" ;
-           :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:venue_URL rdf:type owl:DatatypeProperty ;
+               rdfs:subPropertyOf aeon:venue ;
+               rdfs:domain aeon:AEON_0000025 ;
+               rdfs:range xsd:anyURI ;
+               rdfs:label "venue website"@en ;
+               aeon:SMW_datatype "URL" ;
+               aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#workshop_deadline
-:workshop_deadline rdf:type owl:DatatypeProperty ;
-                   rdfs:subPropertyOf :deadline ;
-                   rdfs:domain :AEON_0000001 ;
-                   rdfs:range xsd:dateTimeStamp ;
-                   rdfs:label "workshop deadline"@en ;
-                   :SMW_datatype "Date" ;
-                   :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:workshop_deadline rdf:type owl:DatatypeProperty ;
+                       rdfs:subPropertyOf aeon:deadline ;
+                       rdfs:domain aeon:AEON_0000001 ;
+                       rdfs:range xsd:dateTimeStamp ;
+                       rdfs:label "workshop deadline"@en ;
+                       aeon:SMW_datatype "Date" ;
+                       aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 #################################################################
@@ -1994,742 +2000,742 @@ cancled → withdrawn"""@en ;
 #################################################################
 
 ###  http://purl.obolibrary.org/obo/BFO_0000001
-<http://purl.obolibrary.org/obo/BFO_0000001> rdf:type owl:Class ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000112> "Julius Caesar"@en ,
-                                                                                          "Verdi’s Requiem"@en ,
-                                                                                          "the Second World War"@en ,
-                                                                                          "your body mass index"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000116> "BFO 2 Reference: In all areas of empirical inquiry we encounter general terms of two sorts. First are general terms which refer to universals or types:animaltuberculosissurgical procedurediseaseSecond, are general terms used to refer to groups of entities which instantiate a given universal but do not correspond to the extension of any subuniversal of that universal because there is nothing intrinsic to the entities in question by virtue of which they – and only they – are counted as belonging to the given group. Examples are: animal purchased by the Emperortuberculosis diagnosed on a Wednesdaysurgical procedure performed on a patient from Stockholmperson identified as candidate for clinical trial #2056-555person who is signatory of Form 656-PPVpainting by Leonardo da VinciSuch terms, which represent what are called ‘specializations’ in [81"@en ,
-                                                                                          "Entity doesn't have a closure axiom because the subclasses don't necessarily exhaust all possibilites. For example Werner Ceusters 'portions of reality' include 4 sorts, entities (as BFO construes them), universals, configurations, and relations. It is an open question as to whether entities as construed in BFO will at some point also include these other portions of reality. See, for example, 'How to track absolutely everything' at http://www.referent-tracking.com/_RTU/papers/CeustersICbookRevised.pdf"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000600> "An entity is anything that exists or has existed or will exist. (axiom label in BFO2 Reference: [001-001])"@en ;
-                                             rdfs:comment "per discussion with Barry Smith" ;
-                                             rdfs:isDefinedBy <http://purl.obolibrary.org/obo/bfo.owl> ;
-                                             rdfs:label "entity"@en ;
-                                             rdfs:seeAlso <http://www.referent-tracking.com/_RTU/papers/CeustersICbookRevised.pdf> .
+obo:BFO_0000001 rdf:type owl:Class ;
+                obo:IAO_0000112 "Julius Caesar"@en ,
+                                "Verdi’s Requiem"@en ,
+                                "the Second World War"@en ,
+                                "your body mass index"@en ;
+                obo:IAO_0000116 "BFO 2 Reference: In all areas of empirical inquiry we encounter general terms of two sorts. First are general terms which refer to universals or types:animaltuberculosissurgical procedurediseaseSecond, are general terms used to refer to groups of entities which instantiate a given universal but do not correspond to the extension of any subuniversal of that universal because there is nothing intrinsic to the entities in question by virtue of which they – and only they – are counted as belonging to the given group. Examples are: animal purchased by the Emperortuberculosis diagnosed on a Wednesdaysurgical procedure performed on a patient from Stockholmperson identified as candidate for clinical trial #2056-555person who is signatory of Form 656-PPVpainting by Leonardo da VinciSuch terms, which represent what are called ‘specializations’ in [81"@en ,
+                                "Entity doesn't have a closure axiom because the subclasses don't necessarily exhaust all possibilites. For example Werner Ceusters 'portions of reality' include 4 sorts, entities (as BFO construes them), universals, configurations, and relations. It is an open question as to whether entities as construed in BFO will at some point also include these other portions of reality. See, for example, 'How to track absolutely everything' at http://www.referent-tracking.com/_RTU/papers/CeustersICbookRevised.pdf"@en ;
+                obo:IAO_0000412 "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
+                obo:IAO_0000600 "An entity is anything that exists or has existed or will exist. (axiom label in BFO2 Reference: [001-001])"@en ;
+                rdfs:comment "per discussion with Barry Smith" ;
+                rdfs:isDefinedBy obo:bfo.owl ;
+                rdfs:label "entity"@en ;
+                rdfs:seeAlso <http://www.referent-tracking.com/_RTU/papers/CeustersICbookRevised.pdf> .
 
 
 ###  http://purl.obolibrary.org/obo/BFO_0000002
-<http://purl.obolibrary.org/obo/BFO_0000002> rdf:type owl:Class ;
-                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/BFO_0000001> ;
-                                             owl:disjointWith <http://purl.obolibrary.org/obo/BFO_0000003> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000116> "BFO 2 Reference: Continuant entities are entities which can be sliced to yield parts only along the spatial dimension, yielding for example the parts of your table which we call its legs, its top, its nails. ‘My desk stretches from the window to the door. It has spatial parts, and can be sliced (in space) in two. With respect to time, however, a thing is a continuant.’ [60, p. 240"@en ,
-                                                                                          "Continuant doesn't have a closure axiom because the subclasses don't necessarily exhaust all possibilites. For example, in an expansion involving bringing in some of Ceuster's other portions of reality, questions are raised as to whether universals are continuants"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000600> "A continuant is an entity that persists, endures, or continues to exist through time while maintaining its identity. (axiom label in BFO2 Reference: [008-002])"@en ;
-                                             rdfs:isDefinedBy <http://purl.obolibrary.org/obo/bfo.owl> ;
-                                             rdfs:label "continuant"@en .
+obo:BFO_0000002 rdf:type owl:Class ;
+                rdfs:subClassOf obo:BFO_0000001 ;
+                owl:disjointWith obo:BFO_0000003 ;
+                obo:IAO_0000116 "BFO 2 Reference: Continuant entities are entities which can be sliced to yield parts only along the spatial dimension, yielding for example the parts of your table which we call its legs, its top, its nails. ‘My desk stretches from the window to the door. It has spatial parts, and can be sliced (in space) in two. With respect to time, however, a thing is a continuant.’ [60, p. 240"@en ,
+                                "Continuant doesn't have a closure axiom because the subclasses don't necessarily exhaust all possibilites. For example, in an expansion involving bringing in some of Ceuster's other portions of reality, questions are raised as to whether universals are continuants"@en ;
+                obo:IAO_0000412 "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
+                obo:IAO_0000600 "A continuant is an entity that persists, endures, or continues to exist through time while maintaining its identity. (axiom label in BFO2 Reference: [008-002])"@en ;
+                rdfs:isDefinedBy obo:bfo.owl ;
+                rdfs:label "continuant"@en .
 
 
 ###  http://purl.obolibrary.org/obo/BFO_0000003
-<http://purl.obolibrary.org/obo/BFO_0000003> rdf:type owl:Class ;
-                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/BFO_0000001> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000116> "BFO 2 Reference: every occurrent that is not a temporal or spatiotemporal region is s-dependent on some independent continuant that is not a spatial region"@en ,
-                                                                                          "BFO 2 Reference: s-dependence obtains between every process and its participants in the sense that, as a matter of necessity, this process could not have existed unless these or those participants existed also. A process may have a succession of participants at different phases of its unfolding. Thus there may be different players on the field at different times during the course of a football game; but the process which is the entire game s-depends_on all of these players nonetheless. Some temporal parts of this process will s-depend_on on only some of the players."@en ,
-                                                                                          "Occurrent doesn't have a closure axiom because the subclasses don't necessarily exhaust all possibilites. An example would be the sum of a process and the process boundary of another process."@en ,
-                                                                                          "Simons uses different terminology for relations of occurrents to regions: Denote the spatio-temporal location of a given occurrent e by 'spn[e]' and call this region its span. We may say an occurrent is at its span, in any larger region, and covers any smaller region. Now suppose we have fixed a frame of reference so that we can speak not merely of spatio-temporal but also of spatial regions (places) and temporal regions (times). The spread of an occurrent, (relative to a frame of reference) is the space it exactly occupies, and its spell is likewise the time it exactly occupies. We write 'spr[e]' and `spl[e]' respectively for the spread and spell of e, omitting mention of the frame." ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000600> "An occurrent is an entity that unfolds itself in time or it is the instantaneous boundary of such an entity (for example a beginning or an ending) or it is a temporal or spatiotemporal region which such an entity occupies_temporal_region or occupies_spatiotemporal_region. (axiom label in BFO2 Reference: [077-002])"@en ;
-                                             rdfs:comment "per discussion with Barry Smith" ;
-                                             rdfs:isDefinedBy <http://purl.obolibrary.org/obo/bfo.owl> ;
-                                             rdfs:label "occurrent"@en .
+obo:BFO_0000003 rdf:type owl:Class ;
+                rdfs:subClassOf obo:BFO_0000001 ;
+                obo:IAO_0000116 "BFO 2 Reference: every occurrent that is not a temporal or spatiotemporal region is s-dependent on some independent continuant that is not a spatial region"@en ,
+                                "BFO 2 Reference: s-dependence obtains between every process and its participants in the sense that, as a matter of necessity, this process could not have existed unless these or those participants existed also. A process may have a succession of participants at different phases of its unfolding. Thus there may be different players on the field at different times during the course of a football game; but the process which is the entire game s-depends_on all of these players nonetheless. Some temporal parts of this process will s-depend_on on only some of the players."@en ,
+                                "Occurrent doesn't have a closure axiom because the subclasses don't necessarily exhaust all possibilites. An example would be the sum of a process and the process boundary of another process."@en ,
+                                "Simons uses different terminology for relations of occurrents to regions: Denote the spatio-temporal location of a given occurrent e by 'spn[e]' and call this region its span. We may say an occurrent is at its span, in any larger region, and covers any smaller region. Now suppose we have fixed a frame of reference so that we can speak not merely of spatio-temporal but also of spatial regions (places) and temporal regions (times). The spread of an occurrent, (relative to a frame of reference) is the space it exactly occupies, and its spell is likewise the time it exactly occupies. We write 'spr[e]' and `spl[e]' respectively for the spread and spell of e, omitting mention of the frame." ;
+                obo:IAO_0000412 "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
+                obo:IAO_0000600 "An occurrent is an entity that unfolds itself in time or it is the instantaneous boundary of such an entity (for example a beginning or an ending) or it is a temporal or spatiotemporal region which such an entity occupies_temporal_region or occupies_spatiotemporal_region. (axiom label in BFO2 Reference: [077-002])"@en ;
+                rdfs:comment "per discussion with Barry Smith" ;
+                rdfs:isDefinedBy obo:bfo.owl ;
+                rdfs:label "occurrent"@en .
 
 
 ###  http://purl.obolibrary.org/obo/BFO_0000004
-<http://purl.obolibrary.org/obo/BFO_0000004> rdf:type owl:Class ;
-                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/BFO_0000002> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000112> "a chair"@en ,
-                                                                                          "a heart"@en ,
-                                                                                          "a leg"@en ,
-                                                                                          "a molecule"@en ,
-                                                                                          "a spatial region"@en ,
-                                                                                          "an atom"@en ,
-                                                                                          "an orchestra."@en ,
-                                                                                          "an organism"@en ,
-                                                                                          "the bottom right portion of a human torso"@en ,
-                                                                                          "the interior of your mouth"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000115> "b is an independent continuant = Def. b is a continuant which is such that there is no c and no t such that b s-depends_on c at t. (axiom label in BFO2 Reference: [017-002])"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
-                                             rdfs:isDefinedBy <http://purl.obolibrary.org/obo/bfo.owl> ;
-                                             rdfs:label "independent continuant"@en .
+obo:BFO_0000004 rdf:type owl:Class ;
+                rdfs:subClassOf obo:BFO_0000002 ;
+                obo:IAO_0000112 "a chair"@en ,
+                                "a heart"@en ,
+                                "a leg"@en ,
+                                "a molecule"@en ,
+                                "a spatial region"@en ,
+                                "an atom"@en ,
+                                "an orchestra."@en ,
+                                "an organism"@en ,
+                                "the bottom right portion of a human torso"@en ,
+                                "the interior of your mouth"@en ;
+                obo:IAO_0000115 "b is an independent continuant = Def. b is a continuant which is such that there is no c and no t such that b s-depends_on c at t. (axiom label in BFO2 Reference: [017-002])"@en ;
+                obo:IAO_0000412 "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
+                rdfs:isDefinedBy obo:bfo.owl ;
+                rdfs:label "independent continuant"@en .
 
 
 ###  http://purl.obolibrary.org/obo/BFO_0000006
-<http://purl.obolibrary.org/obo/BFO_0000006> rdf:type owl:Class ;
-                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/BFO_0000141> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000116> "BFO 2 Reference: Spatial regions do not participate in processes."@en ,
-                                                                                          "Spatial region doesn't have a closure axiom because the subclasses don't exhaust all possibilites. An example would be the union of a spatial point and a spatial line that doesn't overlap the point, or two spatial lines that intersect at a single point. In both cases the resultant spatial region is neither 0-dimensional, 1-dimensional, 2-dimensional, or 3-dimensional."@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000600> "A spatial region is a continuant entity that is a continuant_part_of spaceR as defined relative to some frame R. (axiom label in BFO2 Reference: [035-001])"@en ;
-                                             rdfs:comment "per discussion with Barry Smith" ;
-                                             rdfs:isDefinedBy <http://purl.obolibrary.org/obo/bfo.owl> ;
-                                             rdfs:label "spatial region"@en .
+obo:BFO_0000006 rdf:type owl:Class ;
+                rdfs:subClassOf obo:BFO_0000141 ;
+                obo:IAO_0000116 "BFO 2 Reference: Spatial regions do not participate in processes."@en ,
+                                "Spatial region doesn't have a closure axiom because the subclasses don't exhaust all possibilites. An example would be the union of a spatial point and a spatial line that doesn't overlap the point, or two spatial lines that intersect at a single point. In both cases the resultant spatial region is neither 0-dimensional, 1-dimensional, 2-dimensional, or 3-dimensional."@en ;
+                obo:IAO_0000412 "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
+                obo:IAO_0000600 "A spatial region is a continuant entity that is a continuant_part_of spaceR as defined relative to some frame R. (axiom label in BFO2 Reference: [035-001])"@en ;
+                rdfs:comment "per discussion with Barry Smith" ;
+                rdfs:isDefinedBy obo:bfo.owl ;
+                rdfs:label "spatial region"@en .
 
 
 ###  http://purl.obolibrary.org/obo/BFO_0000008
-<http://purl.obolibrary.org/obo/BFO_0000008> rdf:type owl:Class ;
-                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/BFO_0000003> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000116> "Temporal region doesn't have a closure axiom because the subclasses don't exhaust all possibilites. An example would be the mereological sum of a temporal instant and a temporal interval that doesn't overlap the instant. In this case the resultant temporal region is neither 0-dimensional nor 1-dimensional"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000600> "A temporal region is an occurrent entity that is part of time as defined relative to some reference frame. (axiom label in BFO2 Reference: [100-001])"@en ;
-                                             rdfs:comment "per discussion with Barry Smith" ;
-                                             rdfs:isDefinedBy <http://purl.obolibrary.org/obo/bfo.owl> ;
-                                             rdfs:label "temporal region"@en .
+obo:BFO_0000008 rdf:type owl:Class ;
+                rdfs:subClassOf obo:BFO_0000003 ;
+                obo:IAO_0000116 "Temporal region doesn't have a closure axiom because the subclasses don't exhaust all possibilites. An example would be the mereological sum of a temporal instant and a temporal interval that doesn't overlap the instant. In this case the resultant temporal region is neither 0-dimensional nor 1-dimensional"@en ;
+                obo:IAO_0000412 "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
+                obo:IAO_0000600 "A temporal region is an occurrent entity that is part of time as defined relative to some reference frame. (axiom label in BFO2 Reference: [100-001])"@en ;
+                rdfs:comment "per discussion with Barry Smith" ;
+                rdfs:isDefinedBy obo:bfo.owl ;
+                rdfs:label "temporal region"@en .
 
 
 ###  http://purl.obolibrary.org/obo/BFO_0000011
-<http://purl.obolibrary.org/obo/BFO_0000011> rdf:type owl:Class ;
-                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/BFO_0000003> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000112> "the spatiotemporal region occupied by a human life"@en ,
-                                                                                          "the spatiotemporal region occupied by a process of cellular meiosis."@en ,
-                                                                                          "the spatiotemporal region occupied by the development of a cancer tumor"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000600> "A spatiotemporal region is an occurrent entity that is part of spacetime. (axiom label in BFO2 Reference: [095-001])"@en ;
-                                             rdfs:isDefinedBy <http://purl.obolibrary.org/obo/bfo.owl> ;
-                                             rdfs:label "spatiotemporal region"@en .
+obo:BFO_0000011 rdf:type owl:Class ;
+                rdfs:subClassOf obo:BFO_0000003 ;
+                obo:IAO_0000112 "the spatiotemporal region occupied by a human life"@en ,
+                                "the spatiotemporal region occupied by a process of cellular meiosis."@en ,
+                                "the spatiotemporal region occupied by the development of a cancer tumor"@en ;
+                obo:IAO_0000412 "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
+                obo:IAO_0000600 "A spatiotemporal region is an occurrent entity that is part of spacetime. (axiom label in BFO2 Reference: [095-001])"@en ;
+                rdfs:isDefinedBy obo:bfo.owl ;
+                rdfs:label "spatiotemporal region"@en .
 
 
 ###  http://purl.obolibrary.org/obo/BFO_0000015
-<http://purl.obolibrary.org/obo/BFO_0000015> rdf:type owl:Class ;
-                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/BFO_0000003> ,
-                                                             [ rdf:type owl:Restriction ;
-                                                               owl:onProperty <http://purl.obolibrary.org/obo/RO_0002012> ;
-                                                               owl:allValuesFrom <http://purl.obolibrary.org/obo/BFO_0000015>
-                                                             ] ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000112> "a process of cell-division, \\ a beating of the heart"@en ,
-                                                                                          "a process of meiosis"@en ,
-                                                                                          "a process of sleeping"@en ,
-                                                                                          "the course of a disease"@en ,
-                                                                                          "the flight of a bird"@en ,
-                                                                                          "the life of an organism"@en ,
-                                                                                          "your process of aging."@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000115> "p is a process = Def. p is an occurrent that has temporal proper parts and for some time t, p s-depends_on some material entity at t. (axiom label in BFO2 Reference: [083-003])"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000116> "BFO 2 Reference: The realm of occurrents is less pervasively marked by the presence of natural units than is the case in the realm of independent continuants. Thus there is here no counterpart of ‘object’. In BFO 1.0 ‘process’ served as such a counterpart. In BFO 2.0 ‘process’ is, rather, the occurrent counterpart of ‘material entity’. Those natural – as contrasted with engineered, which here means: deliberately executed – units which do exist in the realm of occurrents are typically either parasitic on the existence of natural units on the continuant side, or they are fiat in nature. Thus we can count lives; we can count football games; we can count chemical reactions performed in experiments or in chemical manufacturing. We cannot count the processes taking place, for instance, in an episode of insect mating behavior.Even where natural units are identifiable, for example cycles in a cyclical process such as the beating of a heart or an organism’s sleep/wake cycle, the processes in question form a sequence with no discontinuities (temporal gaps) of the sort that we find for instance where billiard balls or zebrafish or planets are separated by clear spatial gaps. Lives of organisms are process units, but they too unfold in a continuous series from other, prior processes such as fertilization, and they unfold in turn in continuous series of post-life processes such as post-mortem decay. Clear examples of boundaries of processes are almost always of the fiat sort (midnight, a time of death as declared in an operating theater or on a death certificate, the initiation of a state of war)"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
-                                             rdfs:isDefinedBy <http://purl.obolibrary.org/obo/bfo.owl> ;
-                                             rdfs:label "process"@en .
+obo:BFO_0000015 rdf:type owl:Class ;
+                rdfs:subClassOf obo:BFO_0000003 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:RO_0002012 ;
+                                  owl:allValuesFrom obo:BFO_0000015
+                                ] ;
+                obo:IAO_0000112 "a process of cell-division, \\ a beating of the heart"@en ,
+                                "a process of meiosis"@en ,
+                                "a process of sleeping"@en ,
+                                "the course of a disease"@en ,
+                                "the flight of a bird"@en ,
+                                "the life of an organism"@en ,
+                                "your process of aging."@en ;
+                obo:IAO_0000115 "p is a process = Def. p is an occurrent that has temporal proper parts and for some time t, p s-depends_on some material entity at t. (axiom label in BFO2 Reference: [083-003])"@en ;
+                obo:IAO_0000116 "BFO 2 Reference: The realm of occurrents is less pervasively marked by the presence of natural units than is the case in the realm of independent continuants. Thus there is here no counterpart of ‘object’. In BFO 1.0 ‘process’ served as such a counterpart. In BFO 2.0 ‘process’ is, rather, the occurrent counterpart of ‘material entity’. Those natural – as contrasted with engineered, which here means: deliberately executed – units which do exist in the realm of occurrents are typically either parasitic on the existence of natural units on the continuant side, or they are fiat in nature. Thus we can count lives; we can count football games; we can count chemical reactions performed in experiments or in chemical manufacturing. We cannot count the processes taking place, for instance, in an episode of insect mating behavior.Even where natural units are identifiable, for example cycles in a cyclical process such as the beating of a heart or an organism’s sleep/wake cycle, the processes in question form a sequence with no discontinuities (temporal gaps) of the sort that we find for instance where billiard balls or zebrafish or planets are separated by clear spatial gaps. Lives of organisms are process units, but they too unfold in a continuous series from other, prior processes such as fertilization, and they unfold in turn in continuous series of post-life processes such as post-mortem decay. Clear examples of boundaries of processes are almost always of the fiat sort (midnight, a time of death as declared in an operating theater or on a death certificate, the initiation of a state of war)"@en ;
+                obo:IAO_0000412 "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
+                rdfs:isDefinedBy obo:bfo.owl ;
+                rdfs:label "process"@en .
 
 
 ###  http://purl.obolibrary.org/obo/BFO_0000016
-<http://purl.obolibrary.org/obo/BFO_0000016> rdf:type owl:Class ;
-                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/BFO_0000017> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000112> "an atom of element X has the disposition to decay to an atom of element Y"@en ,
-                                                                                          "certain people have a predisposition to colon cancer"@en ,
-                                                                                          "children are innately disposed to categorize objects in certain ways."@en ,
-                                                                                          "the cell wall is disposed to filter chemicals in endocytosis and exocytosis"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000116> "BFO 2 Reference: Dispositions exist along a strength continuum. Weaker forms of disposition are realized in only a fraction of triggering cases. These forms occur in a significant number of cases of a similar type."@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000600> "b is a disposition means: b is a realizable entity & b’s bearer is some material entity & b is such that if it ceases to exist, then its bearer is physically changed, & b’s realization occurs when and because this bearer is in some special physical circumstances, & this realization occurs in virtue of the bearer’s physical make-up. (axiom label in BFO2 Reference: [062-002])"@en ;
-                                             rdfs:isDefinedBy <http://purl.obolibrary.org/obo/bfo.owl> ;
-                                             rdfs:label "disposition"@en .
+obo:BFO_0000016 rdf:type owl:Class ;
+                rdfs:subClassOf obo:BFO_0000017 ;
+                obo:IAO_0000112 "an atom of element X has the disposition to decay to an atom of element Y"@en ,
+                                "certain people have a predisposition to colon cancer"@en ,
+                                "children are innately disposed to categorize objects in certain ways."@en ,
+                                "the cell wall is disposed to filter chemicals in endocytosis and exocytosis"@en ;
+                obo:IAO_0000116 "BFO 2 Reference: Dispositions exist along a strength continuum. Weaker forms of disposition are realized in only a fraction of triggering cases. These forms occur in a significant number of cases of a similar type."@en ;
+                obo:IAO_0000412 "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
+                obo:IAO_0000600 "b is a disposition means: b is a realizable entity & b’s bearer is some material entity & b is such that if it ceases to exist, then its bearer is physically changed, & b’s realization occurs when and because this bearer is in some special physical circumstances, & this realization occurs in virtue of the bearer’s physical make-up. (axiom label in BFO2 Reference: [062-002])"@en ;
+                rdfs:isDefinedBy obo:bfo.owl ;
+                rdfs:label "disposition"@en .
 
 
 ###  http://purl.obolibrary.org/obo/BFO_0000017
-<http://purl.obolibrary.org/obo/BFO_0000017> rdf:type owl:Class ;
-                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/BFO_0000020> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000112> "the disposition of this piece of metal to conduct electricity."@en ,
-                                                                                          "the disposition of your blood to coagulate"@en ,
-                                                                                          "the function of your reproductive organs"@en ,
-                                                                                          "the role of being a doctor"@en ,
-                                                                                          "the role of this boundary to delineate where Utah and Colorado meet"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000600> "To say that b is a realizable entity is to say that b is a specifically dependent continuant that inheres in some independent continuant which is not a spatial region and is of a type instances of which are realized in processes of a correlated type. (axiom label in BFO2 Reference: [058-002])"@en ;
-                                             rdfs:isDefinedBy <http://purl.obolibrary.org/obo/bfo.owl> ;
-                                             rdfs:label "realizable entity"@en .
+obo:BFO_0000017 rdf:type owl:Class ;
+                rdfs:subClassOf obo:BFO_0000020 ;
+                obo:IAO_0000112 "the disposition of this piece of metal to conduct electricity."@en ,
+                                "the disposition of your blood to coagulate"@en ,
+                                "the function of your reproductive organs"@en ,
+                                "the role of being a doctor"@en ,
+                                "the role of this boundary to delineate where Utah and Colorado meet"@en ;
+                obo:IAO_0000412 "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
+                obo:IAO_0000600 "To say that b is a realizable entity is to say that b is a specifically dependent continuant that inheres in some independent continuant which is not a spatial region and is of a type instances of which are realized in processes of a correlated type. (axiom label in BFO2 Reference: [058-002])"@en ;
+                rdfs:isDefinedBy obo:bfo.owl ;
+                rdfs:label "realizable entity"@en .
 
 
 ###  http://purl.obolibrary.org/obo/BFO_0000020
-<http://purl.obolibrary.org/obo/BFO_0000020> rdf:type owl:Class ;
-                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/BFO_0000002> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000112> "Reciprocal specifically dependent continuants: the function of this key to open this lock and the mutually dependent disposition of this lock: to be opened by this key"@en ,
-                                                                                          "of one-sided specifically dependent continuants: the mass of this tomato"@en ,
-                                                                                          "of relational dependent continuants (multiple bearers): John’s love for Mary, the ownership relation between John and this statue, the relation of authority between John and his subordinates."@en ,
-                                                                                          "the disposition of this fish to decay"@en ,
-                                                                                          "the function of this heart: to pump blood"@en ,
-                                                                                          "the mutual dependence of proton donors and acceptors in chemical reactions [79"@en ,
-                                                                                          "the mutual dependence of the role predator and the role prey as played by two organisms in a given interaction"@en ,
-                                                                                          "the pink color of a medium rare piece of grilled filet mignon at its center"@en ,
-                                                                                          "the role of being a doctor"@en ,
-                                                                                          "the shape of this hole."@en ,
-                                                                                          "the smell of this portion of mozzarella"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000115> "b is a specifically dependent continuant = Def. b is a continuant & there is some independent continuant c which is not a spatial region and which is such that b s-depends_on c at every time t during the course of b’s existence. (axiom label in BFO2 Reference: [050-003])"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000116> "Specifically dependent continuant doesn't have a closure axiom because the subclasses don't necessarily exhaust all possibilites. We're not sure what else will develop here, but for example there are questions such as what are promises, obligation, etc."@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
-                                             rdfs:comment "per discussion with Barry Smith" ;
-                                             rdfs:isDefinedBy <http://purl.obolibrary.org/obo/bfo.owl> ;
-                                             rdfs:label "specifically dependent continuant"@en .
+obo:BFO_0000020 rdf:type owl:Class ;
+                rdfs:subClassOf obo:BFO_0000002 ;
+                obo:IAO_0000112 "Reciprocal specifically dependent continuants: the function of this key to open this lock and the mutually dependent disposition of this lock: to be opened by this key"@en ,
+                                "of one-sided specifically dependent continuants: the mass of this tomato"@en ,
+                                "of relational dependent continuants (multiple bearers): John’s love for Mary, the ownership relation between John and this statue, the relation of authority between John and his subordinates."@en ,
+                                "the disposition of this fish to decay"@en ,
+                                "the function of this heart: to pump blood"@en ,
+                                "the mutual dependence of proton donors and acceptors in chemical reactions [79"@en ,
+                                "the mutual dependence of the role predator and the role prey as played by two organisms in a given interaction"@en ,
+                                "the pink color of a medium rare piece of grilled filet mignon at its center"@en ,
+                                "the role of being a doctor"@en ,
+                                "the shape of this hole."@en ,
+                                "the smell of this portion of mozzarella"@en ;
+                obo:IAO_0000115 "b is a specifically dependent continuant = Def. b is a continuant & there is some independent continuant c which is not a spatial region and which is such that b s-depends_on c at every time t during the course of b’s existence. (axiom label in BFO2 Reference: [050-003])"@en ;
+                obo:IAO_0000116 "Specifically dependent continuant doesn't have a closure axiom because the subclasses don't necessarily exhaust all possibilites. We're not sure what else will develop here, but for example there are questions such as what are promises, obligation, etc."@en ;
+                obo:IAO_0000412 "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
+                rdfs:comment "per discussion with Barry Smith" ;
+                rdfs:isDefinedBy obo:bfo.owl ;
+                rdfs:label "specifically dependent continuant"@en .
 
 
 ###  http://purl.obolibrary.org/obo/BFO_0000023
-<http://purl.obolibrary.org/obo/BFO_0000023> rdf:type owl:Class ;
-                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/BFO_0000017> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000112> "John’s role of husband to Mary is dependent on Mary’s role of wife to John, and both are dependent on the object aggregate comprising John and Mary as member parts joined together through the relational quality of being married."@en ,
-                                                                                          "the priest role"@en ,
-                                                                                          "the role of a boundary to demarcate two neighboring administrative territories"@en ,
-                                                                                          "the role of a building in serving as a military target"@en ,
-                                                                                          "the role of a stone in marking a property boundary"@en ,
-                                                                                          "the role of subject in a clinical trial"@en ,
-                                                                                          "the student role"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000116> "BFO 2 Reference: One major family of examples of non-rigid universals involves roles, and ontologies developed for corresponding administrative purposes may consist entirely of representatives of entities of this sort. Thus ‘professor’, defined as follows,b instance_of professor at t =Def. there is some c, c instance_of professor role & c inheres_in b at t.denotes a non-rigid universal and so also do ‘nurse’, ‘student’, ‘colonel’, ‘taxpayer’, and so forth. (These terms are all, in the jargon of philosophy, phase sortals.) By using role terms in definitions, we can create a BFO conformant treatment of such entities drawing on the fact that, while an instance of professor may be simultaneously an instance of trade union member, no instance of the type professor role is also (at any time) an instance of the type trade union member role (any more than any instance of the type color is at any time an instance of the type length).If an ontology of employment positions should be defined in terms of roles following the above pattern, this enables the ontology to do justice to the fact that individuals instantiate the corresponding universals –  professor, sergeant, nurse – only during certain phases in their lives."@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000600> "b is a role means: b is a realizable entity & b exists because there is some single bearer that is in some special physical, social, or institutional set of circumstances in which this bearer does not have to be& b is not such that, if it ceases to exist, then the physical make-up of the bearer is thereby changed. (axiom label in BFO2 Reference: [061-001])"@en ;
-                                             rdfs:isDefinedBy <http://purl.obolibrary.org/obo/bfo.owl> ;
-                                             rdfs:label "role"@en .
+obo:BFO_0000023 rdf:type owl:Class ;
+                rdfs:subClassOf obo:BFO_0000017 ;
+                obo:IAO_0000112 "John’s role of husband to Mary is dependent on Mary’s role of wife to John, and both are dependent on the object aggregate comprising John and Mary as member parts joined together through the relational quality of being married."@en ,
+                                "the priest role"@en ,
+                                "the role of a boundary to demarcate two neighboring administrative territories"@en ,
+                                "the role of a building in serving as a military target"@en ,
+                                "the role of a stone in marking a property boundary"@en ,
+                                "the role of subject in a clinical trial"@en ,
+                                "the student role"@en ;
+                obo:IAO_0000116 "BFO 2 Reference: One major family of examples of non-rigid universals involves roles, and ontologies developed for corresponding administrative purposes may consist entirely of representatives of entities of this sort. Thus ‘professor’, defined as follows,b instance_of professor at t =Def. there is some c, c instance_of professor role & c inheres_in b at t.denotes a non-rigid universal and so also do ‘nurse’, ‘student’, ‘colonel’, ‘taxpayer’, and so forth. (These terms are all, in the jargon of philosophy, phase sortals.) By using role terms in definitions, we can create a BFO conformant treatment of such entities drawing on the fact that, while an instance of professor may be simultaneously an instance of trade union member, no instance of the type professor role is also (at any time) an instance of the type trade union member role (any more than any instance of the type color is at any time an instance of the type length).If an ontology of employment positions should be defined in terms of roles following the above pattern, this enables the ontology to do justice to the fact that individuals instantiate the corresponding universals –  professor, sergeant, nurse – only during certain phases in their lives."@en ;
+                obo:IAO_0000412 "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
+                obo:IAO_0000600 "b is a role means: b is a realizable entity & b exists because there is some single bearer that is in some special physical, social, or institutional set of circumstances in which this bearer does not have to be& b is not such that, if it ceases to exist, then the physical make-up of the bearer is thereby changed. (axiom label in BFO2 Reference: [061-001])"@en ;
+                rdfs:isDefinedBy obo:bfo.owl ;
+                rdfs:label "role"@en .
 
 
 ###  http://purl.obolibrary.org/obo/BFO_0000027
-<http://purl.obolibrary.org/obo/BFO_0000027> rdf:type owl:Class ;
-                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/BFO_0000040> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000112> "a collection of cells in a blood biobank."@en ,
-                                                                                          "a swarm of bees is an aggregate of members who are linked together through natural bonds"@en ,
-                                                                                          "a symphony orchestra"@en ,
-                                                                                          "an organization is an aggregate whose member parts have roles of specific types (for example in a jazz band, a chess club, a football team)"@en ,
-                                                                                          "defined by fiat: the aggregate of members of an organization"@en ,
-                                                                                          "defined through physical attachment: the aggregate of atoms in a lump of granite"@en ,
-                                                                                          "defined through physical containment: the aggregate of molecules of carbon dioxide in a sealed container"@en ,
-                                                                                          "defined via attributive delimitations such as: the patients in this hospital"@en ,
-                                                                                          "the aggregate of bearings in a constant velocity axle joint"@en ,
-                                                                                          "the aggregate of blood cells in your body"@en ,
-                                                                                          "the nitrogen atoms in the atmosphere"@en ,
-                                                                                          "the restaurants in Palo Alto"@en ,
-                                                                                          "your collection of Meissen ceramic plates."@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000116> "An entity a is an object aggregate if and only if there is a mutually exhaustive and pairwise disjoint partition of a into objects " ,
-                                                                                          "BFO 2 Reference: object aggregates may gain and lose parts while remaining numerically identical (one and the same individual) over time. This holds both for aggregates whose membership is determined naturally (the aggregate of cells in your body) and aggregates determined by fiat (a baseball team, a congressional committee)."@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000119> "ISBN:978-3-938793-98-5pp124-158#Thomas Bittner and Barry Smith, 'A Theory of Granular Partitions', in K. Munn and B. Smith (eds.), Applied Ontology: An Introduction, Frankfurt/Lancaster: ontos, 2008, 125-158." ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000600> "b is an object aggregate means: b is a material entity consisting exactly of a plurality of objects as member_parts at all times at which b exists. (axiom label in BFO2 Reference: [025-004])"@en ;
-                                             rdfs:isDefinedBy <http://purl.obolibrary.org/obo/bfo.owl> ;
-                                             rdfs:label "object aggregate"@en .
+obo:BFO_0000027 rdf:type owl:Class ;
+                rdfs:subClassOf obo:BFO_0000040 ;
+                obo:IAO_0000112 "a collection of cells in a blood biobank."@en ,
+                                "a swarm of bees is an aggregate of members who are linked together through natural bonds"@en ,
+                                "a symphony orchestra"@en ,
+                                "an organization is an aggregate whose member parts have roles of specific types (for example in a jazz band, a chess club, a football team)"@en ,
+                                "defined by fiat: the aggregate of members of an organization"@en ,
+                                "defined through physical attachment: the aggregate of atoms in a lump of granite"@en ,
+                                "defined through physical containment: the aggregate of molecules of carbon dioxide in a sealed container"@en ,
+                                "defined via attributive delimitations such as: the patients in this hospital"@en ,
+                                "the aggregate of bearings in a constant velocity axle joint"@en ,
+                                "the aggregate of blood cells in your body"@en ,
+                                "the nitrogen atoms in the atmosphere"@en ,
+                                "the restaurants in Palo Alto"@en ,
+                                "your collection of Meissen ceramic plates."@en ;
+                obo:IAO_0000116 "An entity a is an object aggregate if and only if there is a mutually exhaustive and pairwise disjoint partition of a into objects " ,
+                                "BFO 2 Reference: object aggregates may gain and lose parts while remaining numerically identical (one and the same individual) over time. This holds both for aggregates whose membership is determined naturally (the aggregate of cells in your body) and aggregates determined by fiat (a baseball team, a congressional committee)."@en ;
+                obo:IAO_0000119 "ISBN:978-3-938793-98-5pp124-158#Thomas Bittner and Barry Smith, 'A Theory of Granular Partitions', in K. Munn and B. Smith (eds.), Applied Ontology: An Introduction, Frankfurt/Lancaster: ontos, 2008, 125-158." ;
+                obo:IAO_0000412 "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
+                obo:IAO_0000600 "b is an object aggregate means: b is a material entity consisting exactly of a plurality of objects as member_parts at all times at which b exists. (axiom label in BFO2 Reference: [025-004])"@en ;
+                rdfs:isDefinedBy obo:bfo.owl ;
+                rdfs:label "object aggregate"@en .
 
 
 ###  http://purl.obolibrary.org/obo/BFO_0000029
-<http://purl.obolibrary.org/obo/BFO_0000029> rdf:type owl:Class ;
-                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/BFO_0000141> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000112> "Manhattan Canyon)"@en ,
-                                                                                          "a hole in the interior of a portion of cheese"@en ,
-                                                                                          "a rabbit hole"@en ,
-                                                                                          "an air traffic control region defined in the airspace above an airport"@en ,
-                                                                                          "the Grand Canyon"@en ,
-                                                                                          "the Piazza San Marco"@en ,
-                                                                                          "the cockpit of an aircraft"@en ,
-                                                                                          "the hold of a ship"@en ,
-                                                                                          "the interior of a kangaroo pouch"@en ,
-                                                                                          "the interior of the trunk of your car"@en ,
-                                                                                          "the interior of your bedroom"@en ,
-                                                                                          "the interior of your office"@en ,
-                                                                                          "the interior of your refrigerator"@en ,
-                                                                                          "the lumen of your gut"@en ,
-                                                                                          "your left nostril (a fiat part – the opening – of your left nasal cavity)"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000600> "b is a site means: b is a three-dimensional immaterial entity that is (partially or wholly) bounded by a material entity or it is a three-dimensional immaterial part thereof. (axiom label in BFO2 Reference: [034-002])"@en ;
-                                             rdfs:isDefinedBy <http://purl.obolibrary.org/obo/bfo.owl> ;
-                                             rdfs:label "site"@en .
+obo:BFO_0000029 rdf:type owl:Class ;
+                rdfs:subClassOf obo:BFO_0000141 ;
+                obo:IAO_0000112 "Manhattan Canyon)"@en ,
+                                "a hole in the interior of a portion of cheese"@en ,
+                                "a rabbit hole"@en ,
+                                "an air traffic control region defined in the airspace above an airport"@en ,
+                                "the Grand Canyon"@en ,
+                                "the Piazza San Marco"@en ,
+                                "the cockpit of an aircraft"@en ,
+                                "the hold of a ship"@en ,
+                                "the interior of a kangaroo pouch"@en ,
+                                "the interior of the trunk of your car"@en ,
+                                "the interior of your bedroom"@en ,
+                                "the interior of your office"@en ,
+                                "the interior of your refrigerator"@en ,
+                                "the lumen of your gut"@en ,
+                                "your left nostril (a fiat part – the opening – of your left nasal cavity)"@en ;
+                obo:IAO_0000412 "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
+                obo:IAO_0000600 "b is a site means: b is a three-dimensional immaterial entity that is (partially or wholly) bounded by a material entity or it is a three-dimensional immaterial part thereof. (axiom label in BFO2 Reference: [034-002])"@en ;
+                rdfs:isDefinedBy obo:bfo.owl ;
+                rdfs:label "site"@en .
 
 
 ###  http://purl.obolibrary.org/obo/BFO_0000030
-<http://purl.obolibrary.org/obo/BFO_0000030> rdf:type owl:Class ;
-                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/BFO_0000040> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000112> "atom"@en ,
-                                                                                          "cell"@en ,
-                                                                                          "cells and organisms"@en ,
-                                                                                          "engineered artifacts"@en ,
-                                                                                          "grain of sand"@en ,
-                                                                                          "molecule"@en ,
-                                                                                          "organelle"@en ,
-                                                                                          "organism"@en ,
-                                                                                          "planet"@en ,
-                                                                                          "solid portions of matter"@en ,
-                                                                                          "star"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000116> "BFO 2 Reference: BFO rests on the presupposition that at multiple micro-, meso- and macroscopic scales reality exhibits certain stable, spatially separated or separable material units, combined or combinable into aggregates of various sorts (for example organisms into what are called ‘populations’). Such units play a central role in almost all domains of natural science from particle physics to cosmology. Many scientific laws govern the units in question, employing general terms (such as ‘molecule’ or ‘planet’) referring to the types and subtypes of units, and also to the types and subtypes of the processes through which such units develop and interact. The division of reality into such natural units is at the heart of biological science, as also is the fact that these units may form higher-level units (as cells form multicellular organisms) and that they may also form aggregates of units, for example as cells form portions of tissue and organs form families, herds, breeds, species, and so on. At the same time, the division of certain portions of reality into engineered units (manufactured artifacts) is the basis of modern industrial technology, which rests on the distributed mass production of engineered parts through division of labor and on their assembly into larger, compound units such as cars and laptops. The division of portions of reality into units is one starting point for the phenomenon of counting."@en ,
-                                                                                          "BFO 2 Reference: Each object is such that there are entities of which we can assert unproblematically that they lie in its interior, and other entities of which we can assert unproblematically that they lie in its exterior. This may not be so for entities lying at or near the boundary between the interior and exterior. This means that two objects – for example the two cells depicted in Figure 3 – may be such that there are material entities crossing their boundaries which belong determinately to neither cell. Something similar obtains in certain cases of conjoined twins (see below)."@en ,
-                                                                                          "BFO 2 Reference: To say that b is causally unified means: b is a material entity which is such that its material parts are tied together in such a way that, in environments typical for entities of the type in question,if c, a continuant part of b that is in the interior of b at t, is larger than a certain threshold size (which will be determined differently from case to case, depending on factors such as porosity of external cover) and is moved in space to be at t at a location on the exterior of the spatial region that had been occupied by b at t, then either b’s other parts will be moved in coordinated fashion or b will be damaged (be affected, for example, by breakage or tearing) in the interval between t and t.causal changes in one part of b can have consequences for other parts of b without the mediation of any entity that lies on the exterior of b. Material entities with no proper material parts would satisfy these conditions trivially. Candidate examples of types of causal unity for material entities of more complex sorts are as follows (this is not intended to be an exhaustive list):CU1: Causal unity via physical coveringHere the parts in the interior of the unified entity are combined together causally through a common membrane or other physical covering\\. The latter points outwards toward and may serve a protective function in relation to what lies on the exterior of the entity [13, 47"@en ,
-                                                                                          "BFO 2 Reference: an object is a maximal causally unified material entity"@en ,
-                                                                                          "BFO 2 Reference: ‘objects’ are sometimes referred to as ‘grains’ [74"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000600> "b is an object means: b is a material entity which manifests causal unity of one or other of the types CUn listed above & is of a type (a material universal) instances of which are maximal relative to this criterion of causal unity. (axiom label in BFO2 Reference: [024-001])"@en ;
-                                             rdfs:isDefinedBy <http://purl.obolibrary.org/obo/bfo.owl> ;
-                                             rdfs:label "object"@en .
+obo:BFO_0000030 rdf:type owl:Class ;
+                rdfs:subClassOf obo:BFO_0000040 ;
+                obo:IAO_0000112 "atom"@en ,
+                                "cell"@en ,
+                                "cells and organisms"@en ,
+                                "engineered artifacts"@en ,
+                                "grain of sand"@en ,
+                                "molecule"@en ,
+                                "organelle"@en ,
+                                "organism"@en ,
+                                "planet"@en ,
+                                "solid portions of matter"@en ,
+                                "star"@en ;
+                obo:IAO_0000116 "BFO 2 Reference: BFO rests on the presupposition that at multiple micro-, meso- and macroscopic scales reality exhibits certain stable, spatially separated or separable material units, combined or combinable into aggregates of various sorts (for example organisms into what are called ‘populations’). Such units play a central role in almost all domains of natural science from particle physics to cosmology. Many scientific laws govern the units in question, employing general terms (such as ‘molecule’ or ‘planet’) referring to the types and subtypes of units, and also to the types and subtypes of the processes through which such units develop and interact. The division of reality into such natural units is at the heart of biological science, as also is the fact that these units may form higher-level units (as cells form multicellular organisms) and that they may also form aggregates of units, for example as cells form portions of tissue and organs form families, herds, breeds, species, and so on. At the same time, the division of certain portions of reality into engineered units (manufactured artifacts) is the basis of modern industrial technology, which rests on the distributed mass production of engineered parts through division of labor and on their assembly into larger, compound units such as cars and laptops. The division of portions of reality into units is one starting point for the phenomenon of counting."@en ,
+                                "BFO 2 Reference: Each object is such that there are entities of which we can assert unproblematically that they lie in its interior, and other entities of which we can assert unproblematically that they lie in its exterior. This may not be so for entities lying at or near the boundary between the interior and exterior. This means that two objects – for example the two cells depicted in Figure 3 – may be such that there are material entities crossing their boundaries which belong determinately to neither cell. Something similar obtains in certain cases of conjoined twins (see below)."@en ,
+                                "BFO 2 Reference: To say that b is causally unified means: b is a material entity which is such that its material parts are tied together in such a way that, in environments typical for entities of the type in question,if c, a continuant part of b that is in the interior of b at t, is larger than a certain threshold size (which will be determined differently from case to case, depending on factors such as porosity of external cover) and is moved in space to be at t at a location on the exterior of the spatial region that had been occupied by b at t, then either b’s other parts will be moved in coordinated fashion or b will be damaged (be affected, for example, by breakage or tearing) in the interval between t and t.causal changes in one part of b can have consequences for other parts of b without the mediation of any entity that lies on the exterior of b. Material entities with no proper material parts would satisfy these conditions trivially. Candidate examples of types of causal unity for material entities of more complex sorts are as follows (this is not intended to be an exhaustive list):CU1: Causal unity via physical coveringHere the parts in the interior of the unified entity are combined together causally through a common membrane or other physical covering\\. The latter points outwards toward and may serve a protective function in relation to what lies on the exterior of the entity [13, 47"@en ,
+                                "BFO 2 Reference: an object is a maximal causally unified material entity"@en ,
+                                "BFO 2 Reference: ‘objects’ are sometimes referred to as ‘grains’ [74"@en ;
+                obo:IAO_0000412 "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
+                obo:IAO_0000600 "b is an object means: b is a material entity which manifests causal unity of one or other of the types CUn listed above & is of a type (a material universal) instances of which are maximal relative to this criterion of causal unity. (axiom label in BFO2 Reference: [024-001])"@en ;
+                rdfs:isDefinedBy obo:bfo.owl ;
+                rdfs:label "object"@en .
 
 
 ###  http://purl.obolibrary.org/obo/BFO_0000031
-<http://purl.obolibrary.org/obo/BFO_0000031> rdf:type owl:Class ;
-                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/BFO_0000002> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000112> "The entries in your database are patterns instantiated as quality instances in your hard drive. The database itself is an aggregate of such patterns. When you create the database you create a particular instance of the generically dependent continuant type database. Each entry in the database is an instance of the generically dependent continuant type IAO: information content entity."@en ,
-                                                                                          "the pdf file on your laptop, the pdf file that is a copy thereof on my laptop"@en ,
-                                                                                          "the sequence of this protein molecule; the sequence that is a copy thereof in that protein molecule."@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000115> "b is a generically dependent continuant = Def. b is a continuant that g-depends_on one or more other entities. (axiom label in BFO2 Reference: [074-001])"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
-                                             rdfs:isDefinedBy <http://purl.obolibrary.org/obo/bfo.owl> ;
-                                             rdfs:label "generically dependent continuant"@en .
+obo:BFO_0000031 rdf:type owl:Class ;
+                rdfs:subClassOf obo:BFO_0000002 ;
+                obo:IAO_0000112 "The entries in your database are patterns instantiated as quality instances in your hard drive. The database itself is an aggregate of such patterns. When you create the database you create a particular instance of the generically dependent continuant type database. Each entry in the database is an instance of the generically dependent continuant type IAO: information content entity."@en ,
+                                "the pdf file on your laptop, the pdf file that is a copy thereof on my laptop"@en ,
+                                "the sequence of this protein molecule; the sequence that is a copy thereof in that protein molecule."@en ;
+                obo:IAO_0000115 "b is a generically dependent continuant = Def. b is a continuant that g-depends_on one or more other entities. (axiom label in BFO2 Reference: [074-001])"@en ;
+                obo:IAO_0000412 "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
+                rdfs:isDefinedBy obo:bfo.owl ;
+                rdfs:label "generically dependent continuant"@en .
 
 
 ###  http://purl.obolibrary.org/obo/BFO_0000034
-<http://purl.obolibrary.org/obo/BFO_0000034> rdf:type owl:Class ;
-                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/BFO_0000016> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000112> "the function of a hammer to drive in nails"@en ,
-                                                                                          "the function of a heart pacemaker to regulate the beating of a heart through electricity"@en ,
-                                                                                          "the function of amylase in saliva to break down starch into sugar"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000116> "BFO 2 Reference: In the past, we have distinguished two varieties of function, artifactual function and biological function. These are not asserted subtypes of BFO:function however, since the same function – for example: to pump, to transport – can exist both in artifacts and in biological entities. The asserted subtypes of function that would be needed in order to yield a separate monoheirarchy are not artifactual function, biological function, etc., but rather transporting function, pumping function, etc."@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000600> "A function is a disposition that exists in virtue of the bearer’s physical make-up and this physical make-up is something the bearer possesses because it came into being, either through evolution (in the case of natural biological entities) or through intentional design (in the case of artifacts), in order to realize processes of a certain sort. (axiom label in BFO2 Reference: [064-001])"@en ;
-                                             rdfs:isDefinedBy <http://purl.obolibrary.org/obo/bfo.owl> ;
-                                             rdfs:label "function"@en .
+obo:BFO_0000034 rdf:type owl:Class ;
+                rdfs:subClassOf obo:BFO_0000016 ;
+                obo:IAO_0000112 "the function of a hammer to drive in nails"@en ,
+                                "the function of a heart pacemaker to regulate the beating of a heart through electricity"@en ,
+                                "the function of amylase in saliva to break down starch into sugar"@en ;
+                obo:IAO_0000116 "BFO 2 Reference: In the past, we have distinguished two varieties of function, artifactual function and biological function. These are not asserted subtypes of BFO:function however, since the same function – for example: to pump, to transport – can exist both in artifacts and in biological entities. The asserted subtypes of function that would be needed in order to yield a separate monoheirarchy are not artifactual function, biological function, etc., but rather transporting function, pumping function, etc."@en ;
+                obo:IAO_0000412 "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
+                obo:IAO_0000600 "A function is a disposition that exists in virtue of the bearer’s physical make-up and this physical make-up is something the bearer possesses because it came into being, either through evolution (in the case of natural biological entities) or through intentional design (in the case of artifacts), in order to realize processes of a certain sort. (axiom label in BFO2 Reference: [064-001])"@en ;
+                rdfs:isDefinedBy obo:bfo.owl ;
+                rdfs:label "function"@en .
 
 
 ###  http://purl.obolibrary.org/obo/BFO_0000035
-<http://purl.obolibrary.org/obo/BFO_0000035> rdf:type owl:Class ;
-                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/BFO_0000003> ,
-                                                             [ rdf:type owl:Restriction ;
-                                                               owl:onProperty <http://purl.obolibrary.org/obo/RO_0002012> ;
-                                                               owl:allValuesFrom [ rdf:type owl:Class ;
-                                                                                   owl:unionOf ( <http://purl.obolibrary.org/obo/BFO_0000015>
-                                                                                                 <http://purl.obolibrary.org/obo/BFO_0000035>
-                                                                                               )
-                                                                                 ]
-                                                             ] ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000112> "the boundary between the 2nd and 3rd year of your life."@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000115> "p is a process boundary =Def. p is a temporal part of a process & p has no proper temporal parts. (axiom label in BFO2 Reference: [084-001])"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
-                                             rdfs:isDefinedBy <http://purl.obolibrary.org/obo/bfo.owl> ;
-                                             rdfs:label "process boundary"@en .
+obo:BFO_0000035 rdf:type owl:Class ;
+                rdfs:subClassOf obo:BFO_0000003 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:RO_0002012 ;
+                                  owl:allValuesFrom [ rdf:type owl:Class ;
+                                                      owl:unionOf ( obo:BFO_0000015
+                                                                    obo:BFO_0000035
+                                                                  )
+                                                    ]
+                                ] ;
+                obo:IAO_0000112 "the boundary between the 2nd and 3rd year of your life."@en ;
+                obo:IAO_0000115 "p is a process boundary =Def. p is a temporal part of a process & p has no proper temporal parts. (axiom label in BFO2 Reference: [084-001])"@en ;
+                obo:IAO_0000412 "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
+                rdfs:isDefinedBy obo:bfo.owl ;
+                rdfs:label "process boundary"@en .
 
 
 ###  http://purl.obolibrary.org/obo/BFO_0000038
-<http://purl.obolibrary.org/obo/BFO_0000038> rdf:type owl:Class ;
-                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/BFO_0000008> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000112> "the temporal region during which a process occurs."@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000116> "BFO 2 Reference: A temporal interval is a special kind of one-dimensional temporal region, namely one that is self-connected (is without gaps or breaks)."@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000600> "A one-dimensional temporal region is a temporal region that is extended. (axiom label in BFO2 Reference: [103-001])"@en ;
-                                             rdfs:isDefinedBy <http://purl.obolibrary.org/obo/bfo.owl> ;
-                                             rdfs:label "one-dimensional temporal region"@en .
+obo:BFO_0000038 rdf:type owl:Class ;
+                rdfs:subClassOf obo:BFO_0000008 ;
+                obo:IAO_0000112 "the temporal region during which a process occurs."@en ;
+                obo:IAO_0000116 "BFO 2 Reference: A temporal interval is a special kind of one-dimensional temporal region, namely one that is self-connected (is without gaps or breaks)."@en ;
+                obo:IAO_0000412 "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
+                obo:IAO_0000600 "A one-dimensional temporal region is a temporal region that is extended. (axiom label in BFO2 Reference: [103-001])"@en ;
+                rdfs:isDefinedBy obo:bfo.owl ;
+                rdfs:label "one-dimensional temporal region"@en .
 
 
 ###  http://purl.obolibrary.org/obo/BFO_0000040
-<http://purl.obolibrary.org/obo/BFO_0000040> rdf:type owl:Class ;
-                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/BFO_0000004> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000112> "a flame"@en ,
-                                                                                          "a forest fire"@en ,
-                                                                                          "a human being"@en ,
-                                                                                          "a hurricane"@en ,
-                                                                                          "a photon"@en ,
-                                                                                          "a puff of smoke"@en ,
-                                                                                          "a sea wave"@en ,
-                                                                                          "a tornado"@en ,
-                                                                                          "an aggregate of human beings."@en ,
-                                                                                          "an energy wave"@en ,
-                                                                                          "an epidemic"@en ,
-                                                                                          "the undetached arm of a human being"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000116> "BFO 2 Reference: Material entities (continuants) can preserve their identity even while gaining and losing material parts. Continuants are contrasted with occurrents, which unfold themselves in successive temporal parts or phases [60"@en ,
-                                                                                          "BFO 2 Reference: Object, Fiat Object Part and Object Aggregate are not intended to be exhaustive of Material Entity. Users are invited to propose new subcategories of Material Entity."@en ,
-                                                                                          "BFO 2 Reference: ‘Matter’ is intended to encompass both mass and energy (we will address the ontological treatment of portions of energy in a later version of BFO). A portion of matter is anything that includes elementary particles among its proper or improper parts: quarks and leptons, including electrons, as the smallest particles thus far discovered; baryons (including protons and neutrons) at a higher level of granularity; atoms and molecules at still higher levels, forming the cells, organs, organisms and other material entities studied by biologists, the portions of rock studied by geologists, the fossils studied by paleontologists, and so on.Material entities are three-dimensional entities (entities extended in three spatial dimensions), as contrasted with the processes in which they participate, which are four-dimensional entities (entities extended also along the dimension of time).According to the FMA, material entities may have immaterial entities as parts – including the entities identified below as sites; for example the interior (or ‘lumen’) of your small intestine is a part of your body. BFO 2.0 embodies a decision to follow the FMA here."@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000600> "A material entity is an independent continuant that has some portion of matter as proper or improper continuant part. (axiom label in BFO2 Reference: [019-002])"@en ;
-                                             rdfs:isDefinedBy <http://purl.obolibrary.org/obo/bfo.owl> ;
-                                             rdfs:label "material entity"@en .
+obo:BFO_0000040 rdf:type owl:Class ;
+                rdfs:subClassOf obo:BFO_0000004 ;
+                obo:IAO_0000112 "a flame"@en ,
+                                "a forest fire"@en ,
+                                "a human being"@en ,
+                                "a hurricane"@en ,
+                                "a photon"@en ,
+                                "a puff of smoke"@en ,
+                                "a sea wave"@en ,
+                                "a tornado"@en ,
+                                "an aggregate of human beings."@en ,
+                                "an energy wave"@en ,
+                                "an epidemic"@en ,
+                                "the undetached arm of a human being"@en ;
+                obo:IAO_0000116 "BFO 2 Reference: Material entities (continuants) can preserve their identity even while gaining and losing material parts. Continuants are contrasted with occurrents, which unfold themselves in successive temporal parts or phases [60"@en ,
+                                "BFO 2 Reference: Object, Fiat Object Part and Object Aggregate are not intended to be exhaustive of Material Entity. Users are invited to propose new subcategories of Material Entity."@en ,
+                                "BFO 2 Reference: ‘Matter’ is intended to encompass both mass and energy (we will address the ontological treatment of portions of energy in a later version of BFO). A portion of matter is anything that includes elementary particles among its proper or improper parts: quarks and leptons, including electrons, as the smallest particles thus far discovered; baryons (including protons and neutrons) at a higher level of granularity; atoms and molecules at still higher levels, forming the cells, organs, organisms and other material entities studied by biologists, the portions of rock studied by geologists, the fossils studied by paleontologists, and so on.Material entities are three-dimensional entities (entities extended in three spatial dimensions), as contrasted with the processes in which they participate, which are four-dimensional entities (entities extended also along the dimension of time).According to the FMA, material entities may have immaterial entities as parts – including the entities identified below as sites; for example the interior (or ‘lumen’) of your small intestine is a part of your body. BFO 2.0 embodies a decision to follow the FMA here."@en ;
+                obo:IAO_0000412 "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
+                obo:IAO_0000600 "A material entity is an independent continuant that has some portion of matter as proper or improper continuant part. (axiom label in BFO2 Reference: [019-002])"@en ;
+                rdfs:isDefinedBy obo:bfo.owl ;
+                rdfs:label "material entity"@en .
 
 
 ###  http://purl.obolibrary.org/obo/BFO_0000141
-<http://purl.obolibrary.org/obo/BFO_0000141> rdf:type owl:Class ;
-                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/BFO_0000004> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000116> "BFO 2 Reference: Immaterial entities are divided into two subgroups:boundaries and sites, which bound, or are demarcated in relation, to material entities, and which can thus change location, shape and size and as their material hosts move or change shape or size (for example: your nasal passage; the hold of a ship; the boundary of Wales (which moves with the rotation of the Earth) [38, 7, 10"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
-                                             rdfs:isDefinedBy <http://purl.obolibrary.org/obo/bfo.owl> ;
-                                             rdfs:label "immaterial entity"@en .
+obo:BFO_0000141 rdf:type owl:Class ;
+                rdfs:subClassOf obo:BFO_0000004 ;
+                obo:IAO_0000116 "BFO 2 Reference: Immaterial entities are divided into two subgroups:boundaries and sites, which bound, or are demarcated in relation, to material entities, and which can thus change location, shape and size and as their material hosts move or change shape or size (for example: your nasal passage; the hold of a ship; the boundary of Wales (which moves with the rotation of the Earth) [38, 7, 10"@en ;
+                obo:IAO_0000412 "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
+                rdfs:isDefinedBy obo:bfo.owl ;
+                rdfs:label "immaterial entity"@en .
 
 
 ###  http://purl.obolibrary.org/obo/BFO_0000148
-<http://purl.obolibrary.org/obo/BFO_0000148> rdf:type owl:Class ;
-                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/BFO_0000008> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000112> "a temporal region that is occupied by a process boundary"@en ,
-                                                                                          "right now"@en ,
-                                                                                          "the moment at which a child is born"@en ,
-                                                                                          "the moment at which a finger is detached in an industrial accident"@en ,
-                                                                                          "the moment of death."@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000118> "temporal instant."@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000600> "A zero-dimensional temporal region is a temporal region that is without extent. (axiom label in BFO2 Reference: [102-001])"@en ;
-                                             rdfs:isDefinedBy <http://purl.obolibrary.org/obo/bfo.owl> ;
-                                             rdfs:label "zero-dimensional temporal region"@en .
+obo:BFO_0000148 rdf:type owl:Class ;
+                rdfs:subClassOf obo:BFO_0000008 ;
+                obo:IAO_0000112 "a temporal region that is occupied by a process boundary"@en ,
+                                "right now"@en ,
+                                "the moment at which a child is born"@en ,
+                                "the moment at which a finger is detached in an industrial accident"@en ,
+                                "the moment of death."@en ;
+                obo:IAO_0000118 "temporal instant."@en ;
+                obo:IAO_0000412 "http://purl.obolibrary.org/obo/bfo/2019-08-26/bfo.owl"^^xsd:string ;
+                obo:IAO_0000600 "A zero-dimensional temporal region is a temporal region that is without extent. (axiom label in BFO2 Reference: [102-001])"@en ;
+                rdfs:isDefinedBy obo:bfo.owl ;
+                rdfs:label "zero-dimensional temporal region"@en .
 
 
 ###  http://purl.obolibrary.org/obo/GAZ_00000448
-<http://purl.obolibrary.org/obo/GAZ_00000448> rdf:type owl:Class ;
-                                              rdfs:subClassOf <http://purl.obolibrary.org/obo/BFO_0000029> ;
-                                              rdfs:label "geographic location"@en ;
-                                              :SMW_datatype "Category" ;
-                                              :SMW_import_info "[[Category:GAZ]] [[Category:Imported vocabulary]]" .
+obo:GAZ_00000448 rdf:type owl:Class ;
+                 rdfs:subClassOf obo:BFO_0000029 ;
+                 rdfs:label "geographic location"@en ;
+                 aeon:SMW_datatype "Category" ;
+                 aeon:SMW_import_info "[[Category:GAZ]] [[Category:Imported vocabulary]]" .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000027
-<http://purl.obolibrary.org/obo/IAO_0000027> rdf:type owl:Class ;
-                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/IAO_0000030> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000111> "data item"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000112> "Data items include counts of things, analyte concentrations, and statistical summaries."@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000125> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000115> "An information content entity that is intended to be a truthful statement about something (modulo, e.g., measurement precision or other systematic errors) and is constructed/acquired by a method which reliably tends to produce (approximately) truthful statements."@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000116> "2/2/2009 Alan and Bjoern discussing FACS run output data. This is a data item because it is about the cell population. Each element records an event and is typically further composed a set of measurment data items that record the fluorescent intensity stimulated by one of the lasers."@en ,
-                                                                                          "2009-03-16: data item deliberatly ambiguous: we merged data set and datum to be one entity, not knowing how to define singular versus plural. So data item is more general than datum."@en ,
-                                                                                          "2009-03-16: removed datum as alternative term as datum specifically refers to singular form, and is thus not an exact synonym."@en ,
-                                                                                          "2014-03-31: See discussion at http://odontomachus.wordpress.com/2014/03/30/aboutness-objects-propositions/" ,
-                                                                                          """JAR: datum     -- well, this will be very tricky to define, but maybe some 
+obo:IAO_0000027 rdf:type owl:Class ;
+                rdfs:subClassOf obo:IAO_0000030 ;
+                obo:IAO_0000111 "data item"@en ;
+                obo:IAO_0000112 "Data items include counts of things, analyte concentrations, and statistical summaries."@en ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 "An information content entity that is intended to be a truthful statement about something (modulo, e.g., measurement precision or other systematic errors) and is constructed/acquired by a method which reliably tends to produce (approximately) truthful statements."@en ;
+                obo:IAO_0000116 "2/2/2009 Alan and Bjoern discussing FACS run output data. This is a data item because it is about the cell population. Each element records an event and is typically further composed a set of measurment data items that record the fluorescent intensity stimulated by one of the lasers."@en ,
+                                "2009-03-16: data item deliberatly ambiguous: we merged data set and datum to be one entity, not knowing how to define singular versus plural. So data item is more general than datum."@en ,
+                                "2009-03-16: removed datum as alternative term as datum specifically refers to singular form, and is thus not an exact synonym."@en ,
+                                "2014-03-31: See discussion at http://odontomachus.wordpress.com/2014/03/30/aboutness-objects-propositions/" ,
+                                """JAR: datum     -- well, this will be very tricky to define, but maybe some 
 information-like stuff that might be put into a computer and that is 
 meant, by someone, to denote and/or to be interpreted by some 
 process... I would include lists, tables, sentences... I think I might 
 defer to Barry, or to Brian Cantwell Smith
 
 JAR: A data item is an approximately justified approximately true approximate belief"""@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Alan Ruttenberg"@en ,
-                                                                                          "PERSON: Chris Stoeckert"@en ,
-                                                                                          "PERSON: Jonathan Rees"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000118> "data"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/iao/2020-12-09/iao.owl"^^xsd:string ;
-                                             rdfs:label "data item"@en .
+                obo:IAO_0000117 "PERSON: Alan Ruttenberg"@en ,
+                                "PERSON: Chris Stoeckert"@en ,
+                                "PERSON: Jonathan Rees"@en ;
+                obo:IAO_0000118 "data"@en ;
+                obo:IAO_0000412 "http://purl.obolibrary.org/obo/iao/2020-12-09/iao.owl"^^xsd:string ;
+                rdfs:label "data item"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000028
-<http://purl.obolibrary.org/obo/IAO_0000028> rdf:type owl:Class ;
-                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/IAO_0000030> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000111> "symbol"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000112> "a serial number such as \"12324X\""@en ,
-                                                                                          "a stop sign"@en ,
-                                                                                          "a written proper name such as \"OBI\""@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000125> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000115> "An information content entity that is a mark(s) or character(s) used as a conventional representation of another entity."@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000116> "20091104, MC: this needs work and will most probably change"@en ,
-                                                                                          "2014-03-31: We would like to have a deeper analysis of 'mark' and 'sign' in the future (see https://github.com/information-artifact-ontology/IAO/issues/154)."@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: James A. Overton"@en ,
-                                                                                          "PERSON: Jonathan Rees"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000119> "based on Oxford English Dictionary"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/iao/2020-12-09/iao.owl"^^xsd:string ;
-                                             rdfs:label "symbol"@en .
+obo:IAO_0000028 rdf:type owl:Class ;
+                rdfs:subClassOf obo:IAO_0000030 ;
+                obo:IAO_0000111 "symbol"@en ;
+                obo:IAO_0000112 "a serial number such as \"12324X\""@en ,
+                                "a stop sign"@en ,
+                                "a written proper name such as \"OBI\""@en ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 "An information content entity that is a mark(s) or character(s) used as a conventional representation of another entity."@en ;
+                obo:IAO_0000116 "20091104, MC: this needs work and will most probably change"@en ,
+                                "2014-03-31: We would like to have a deeper analysis of 'mark' and 'sign' in the future (see https://github.com/information-artifact-ontology/IAO/issues/154)."@en ;
+                obo:IAO_0000117 "PERSON: James A. Overton"@en ,
+                                "PERSON: Jonathan Rees"@en ;
+                obo:IAO_0000119 "based on Oxford English Dictionary"@en ;
+                obo:IAO_0000412 "http://purl.obolibrary.org/obo/iao/2020-12-09/iao.owl"^^xsd:string ;
+                rdfs:label "symbol"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000030
-<http://purl.obolibrary.org/obo/IAO_0000030> rdf:type owl:Class ;
-                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/BFO_0000031> ,
-                                                             [ rdf:type owl:Restriction ;
-                                                               owl:onProperty <http://purl.obolibrary.org/obo/IAO_0000136> ;
-                                                               owl:someValuesFrom <http://purl.obolibrary.org/obo/BFO_0000001>
-                                                             ] ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000111> "information content entity"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000112> "Examples of information content entites include journal articles, data, graphical layouts, and graphs."@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000122> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000115> "A generically dependent continuant that is about some thing."@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000116> "2014-03-10: The use of \"thing\" is intended to be general enough to include universals and configurations (see https://groups.google.com/d/msg/information-ontology/GBxvYZCk1oc/-L6B5fSBBTQJ)."@en ,
-                                                                                          """information_content_entity 'is_encoded_in' some digital_entity in obi before split (040907). information_content_entity 'is_encoded_in' some physical_document in obi before split (040907).
+obo:IAO_0000030 rdf:type owl:Class ;
+                rdfs:subClassOf obo:BFO_0000031 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:IAO_0000136 ;
+                                  owl:someValuesFrom obo:BFO_0000001
+                                ] ;
+                obo:IAO_0000111 "information content entity"@en ;
+                obo:IAO_0000112 "Examples of information content entites include journal articles, data, graphical layouts, and graphs."@en ;
+                obo:IAO_0000114 obo:IAO_0000122 ;
+                obo:IAO_0000115 "A generically dependent continuant that is about some thing."@en ;
+                obo:IAO_0000116 "2014-03-10: The use of \"thing\" is intended to be general enough to include universals and configurations (see https://groups.google.com/d/msg/information-ontology/GBxvYZCk1oc/-L6B5fSBBTQJ)."@en ,
+                                """information_content_entity 'is_encoded_in' some digital_entity in obi before split (040907). information_content_entity 'is_encoded_in' some physical_document in obi before split (040907).
 
 Previous. An information content entity is a non-realizable information entity that 'is encoded in' some digital or physical entity."""@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Chris Stoeckert"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000119> "OBI_0000142"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/iao/2020-12-09/iao.owl"^^xsd:string ;
-                                             rdfs:label "information content entity"@en .
+                obo:IAO_0000117 "PERSON: Chris Stoeckert"@en ;
+                obo:IAO_0000119 "OBI_0000142"@en ;
+                obo:IAO_0000412 "http://purl.obolibrary.org/obo/iao/2020-12-09/iao.owl"^^xsd:string ;
+                rdfs:label "information content entity"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000078
-<http://purl.obolibrary.org/obo/IAO_0000078> rdf:type owl:Class ;
-                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/IAO_0000102> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000111> "curation status specification"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000125> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000115> "The curation status of the term. The allowed values come from an enumerated list of predefined terms. See the specification of these instances for more detailed definitions of each enumerated value."@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000116> "Better to represent curation as a process with parts and then relate labels to that process (in IAO meeting)"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON:Bill Bug"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000119> "GROUP:OBI:<http://purl.obolibrary.org/obo/obi>"@en ,
-                                                                                          "OBI_0000266"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/iao/2020-12-09/iao.owl"^^xsd:string ;
-                                             rdfs:label "curation status specification"@en .
+obo:IAO_0000078 rdf:type owl:Class ;
+                rdfs:subClassOf obo:IAO_0000102 ;
+                obo:IAO_0000111 "curation status specification"@en ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 "The curation status of the term. The allowed values come from an enumerated list of predefined terms. See the specification of these instances for more detailed definitions of each enumerated value."@en ;
+                obo:IAO_0000116 "Better to represent curation as a process with parts and then relate labels to that process (in IAO meeting)"@en ;
+                obo:IAO_0000117 "PERSON:Bill Bug"@en ;
+                obo:IAO_0000119 "GROUP:OBI:<http://purl.obolibrary.org/obo/obi>"@en ,
+                                "OBI_0000266"@en ;
+                obo:IAO_0000412 "http://purl.obolibrary.org/obo/iao/2020-12-09/iao.owl"^^xsd:string ;
+                rdfs:label "curation status specification"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000100
-<http://purl.obolibrary.org/obo/IAO_0000100> rdf:type owl:Class ;
-                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/IAO_0000027> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000111> "data set"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000112> "Intensity values in a CEL file or from multiple CEL files comprise a data set (as opposed to the CEL files themselves)."@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000125> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000115> "A data item that is an aggregate of other data items of the same type that have something in common. Averages and distributions can be determined for data sets."@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000116> "2009/10/23 Alan Ruttenberg. The intention is that this term represent collections of like data. So this isn't for, e.g. the whole contents of a cel file, which includes parameters, metadata etc. This is more like java arrays of a certain rather specific type"@en ,
-                                                                                          "2014-05-05: Data sets are aggregates and thus must include two or more data items. We have chosen not to add logical axioms to make this restriction." ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000117> "person:Allyson Lister"@en ,
-                                                                                          "person:Chris Stoeckert"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000119> "OBI_0000042"@en ,
-                                                                                          "group:OBI"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/iao/2020-12-09/iao.owl"^^xsd:string ;
-                                             rdfs:label "data set"@en .
+obo:IAO_0000100 rdf:type owl:Class ;
+                rdfs:subClassOf obo:IAO_0000027 ;
+                obo:IAO_0000111 "data set"@en ;
+                obo:IAO_0000112 "Intensity values in a CEL file or from multiple CEL files comprise a data set (as opposed to the CEL files themselves)."@en ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 "A data item that is an aggregate of other data items of the same type that have something in common. Averages and distributions can be determined for data sets."@en ;
+                obo:IAO_0000116 "2009/10/23 Alan Ruttenberg. The intention is that this term represent collections of like data. So this isn't for, e.g. the whole contents of a cel file, which includes parameters, metadata etc. This is more like java arrays of a certain rather specific type"@en ,
+                                "2014-05-05: Data sets are aggregates and thus must include two or more data items. We have chosen not to add logical axioms to make this restriction." ;
+                obo:IAO_0000117 "person:Allyson Lister"@en ,
+                                "person:Chris Stoeckert"@en ;
+                obo:IAO_0000119 "OBI_0000042"@en ,
+                                "group:OBI"@en ;
+                obo:IAO_0000412 "http://purl.obolibrary.org/obo/iao/2020-12-09/iao.owl"^^xsd:string ;
+                rdfs:label "data set"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000102
-<http://purl.obolibrary.org/obo/IAO_0000102> rdf:type owl:Class ;
-                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/IAO_0000027> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000111> "data about an ontology part"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000115> "Data about an ontology part is a data item about a part of an ontology, for example a term"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000117> "Person:Alan Ruttenberg"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/iao/2020-12-09/iao.owl"^^xsd:string ;
-                                             rdfs:label "data about an ontology part"@en .
+obo:IAO_0000102 rdf:type owl:Class ;
+                rdfs:subClassOf obo:IAO_0000027 ;
+                obo:IAO_0000111 "data about an ontology part"@en ;
+                obo:IAO_0000115 "Data about an ontology part is a data item about a part of an ontology, for example a term"@en ;
+                obo:IAO_0000117 "Person:Alan Ruttenberg"@en ;
+                obo:IAO_0000412 "http://purl.obolibrary.org/obo/iao/2020-12-09/iao.owl"^^xsd:string ;
+                rdfs:label "data about an ontology part"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000225
-<http://purl.obolibrary.org/obo/IAO_0000225> rdf:type owl:Class ;
-                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/IAO_0000102> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000111> "obsolescence reason specification"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000125> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000115> "The reason for which a term has been deprecated. The allowed values come from an enumerated list of predefined terms. See the specification of these instances for more detailed definitions of each enumerated value."@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000116> "The creation of this class has been inspired in part by Werner Ceusters' paper, Applying evolutionary terminology auditing to the Gene Ontology."@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Alan Ruttenberg"@en ,
-                                                                                          "PERSON: Melanie Courtot"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/iao/2020-12-09/iao.owl"^^xsd:string ;
-                                             rdfs:label "obsolescence reason specification"@en .
+obo:IAO_0000225 rdf:type owl:Class ;
+                rdfs:subClassOf obo:IAO_0000102 ;
+                obo:IAO_0000111 "obsolescence reason specification"@en ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 "The reason for which a term has been deprecated. The allowed values come from an enumerated list of predefined terms. See the specification of these instances for more detailed definitions of each enumerated value."@en ;
+                obo:IAO_0000116 "The creation of this class has been inspired in part by Werner Ceusters' paper, Applying evolutionary terminology auditing to the Gene Ontology."@en ;
+                obo:IAO_0000117 "PERSON: Alan Ruttenberg"@en ,
+                                "PERSON: Melanie Courtot"@en ;
+                obo:IAO_0000412 "http://purl.obolibrary.org/obo/iao/2020-12-09/iao.owl"^^xsd:string ;
+                rdfs:label "obsolescence reason specification"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000310
-<http://purl.obolibrary.org/obo/IAO_0000310> rdf:type owl:Class ;
-                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/IAO_0000030> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000111> "document"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000112> "A journal article, patent application, laboratory notebook, or a book"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000120> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000115> "A collection of information content entities intended to be understood together as a whole"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Lawrence Hunter"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/iao/2020-12-09/iao.owl"^^xsd:string ;
-                                             rdfs:label "document"@en .
+obo:IAO_0000310 rdf:type owl:Class ;
+                rdfs:subClassOf obo:IAO_0000030 ;
+                obo:IAO_0000111 "document"@en ;
+                obo:IAO_0000112 "A journal article, patent application, laboratory notebook, or a book"@en ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "A collection of information content entities intended to be understood together as a whole"@en ;
+                obo:IAO_0000117 "PERSON: Lawrence Hunter"@en ;
+                obo:IAO_0000412 "http://purl.obolibrary.org/obo/iao/2020-12-09/iao.owl"^^xsd:string ;
+                rdfs:label "document"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000577
-<http://purl.obolibrary.org/obo/IAO_0000577> rdf:type owl:Class ;
-                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/IAO_0000028> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000112> "The sentence \"The article has Pubmed ID 12345.\" contains a CRID that has two parts: one part is the CRID symbol, which is '12345'; the other part denotes the CRID registry, which is Pubmed."@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000120> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000115> "A symbol that is part of a CRID and that is sufficient to look up a record from the CRID's registry."@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Alan Ruttenberg"@en ,
-                                                                                          "PERSON: Bill Hogan"@en ,
-                                                                                          "PERSON: Bjoern Peters"@en ,
-                                                                                          "PERSON: Melanie Courtot"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000118> "CRID symbol" ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000119> "Original proposal from Bjoern, discussions at IAO calls"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/iao/2020-12-09/iao.owl"^^xsd:string ;
-                                             rdfs:label "centrally registered identifier symbol"@en .
+obo:IAO_0000577 rdf:type owl:Class ;
+                rdfs:subClassOf obo:IAO_0000028 ;
+                obo:IAO_0000112 "The sentence \"The article has Pubmed ID 12345.\" contains a CRID that has two parts: one part is the CRID symbol, which is '12345'; the other part denotes the CRID registry, which is Pubmed."@en ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "A symbol that is part of a CRID and that is sufficient to look up a record from the CRID's registry."@en ;
+                obo:IAO_0000117 "PERSON: Alan Ruttenberg"@en ,
+                                "PERSON: Bill Hogan"@en ,
+                                "PERSON: Bjoern Peters"@en ,
+                                "PERSON: Melanie Courtot"@en ;
+                obo:IAO_0000118 "CRID symbol" ;
+                obo:IAO_0000119 "Original proposal from Bjoern, discussions at IAO calls"@en ;
+                obo:IAO_0000412 "http://purl.obolibrary.org/obo/iao/2020-12-09/iao.owl"^^xsd:string ;
+                rdfs:label "centrally registered identifier symbol"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000578
-<http://purl.obolibrary.org/obo/IAO_0000578> rdf:type owl:Class ;
-                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/IAO_0020000> ,
-                                                             [ rdf:type owl:Restriction ;
-                                                               owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000051> ;
-                                                               owl:someValuesFrom <http://purl.obolibrary.org/obo/IAO_0000577>
-                                                             ] ,
-                                                             [ rdf:type owl:Restriction ;
-                                                               owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000051> ;
-                                                               owl:someValuesFrom [ rdf:type owl:Restriction ;
-                                                                                    owl:onProperty <http://purl.obolibrary.org/obo/IAO_0000219> ;
-                                                                                    owl:someValuesFrom <http://purl.obolibrary.org/obo/IAO_0000579>
-                                                                                  ]
-                                                             ] ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000112> "The sentence \"The article has Pubmed ID 12345.\" contains a CRID that has two parts: one part is the CRID symbol, which is '12345'; the other part denotes the CRID registry, which is Pubmed."@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000120> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000115> "An information content entity that consists of a CRID symbol and additional information about the CRID registry to which it belongs."@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000116> "2014-05-05: In defining this term we take no position on what the CRID denotes. In particular do not assume it denotes a *record* in the CRID registry (since the registry might not have 'records')."@en ,
-                                                                                          "Alan, IAO call 20101124: potentially the CRID denotes the instance it was associated with during creation."@en ,
-                                                                                          "Note, IAO call 20101124: URIs are not always CRID, as not centrally registered. We acknowledge that CRID is a subset of a larger identifier class, but this subset fulfills our current needs. OBI PURLs are CRID as they are registered with OCLC. UPCs (Universal Product Codes from AC Nielsen)are not CRID as they are not centrally registered."@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Alan Ruttenberg"@en ,
-                                                                                          "PERSON: Bill Hogan"@en ,
-                                                                                          "PERSON: Bjoern Peters"@en ,
-                                                                                          "PERSON: Melanie Courtot"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000118> "CRID" ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000119> "Original proposal from Bjoern, discussions at IAO calls"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/iao/2020-12-09/iao.owl"^^xsd:string ;
-                                             rdfs:label "centrally registered identifier"@en .
+obo:IAO_0000578 rdf:type owl:Class ;
+                rdfs:subClassOf obo:IAO_0020000 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000051 ;
+                                  owl:someValuesFrom obo:IAO_0000577
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000051 ;
+                                  owl:someValuesFrom [ rdf:type owl:Restriction ;
+                                                       owl:onProperty obo:IAO_0000219 ;
+                                                       owl:someValuesFrom obo:IAO_0000579
+                                                     ]
+                                ] ;
+                obo:IAO_0000112 "The sentence \"The article has Pubmed ID 12345.\" contains a CRID that has two parts: one part is the CRID symbol, which is '12345'; the other part denotes the CRID registry, which is Pubmed."@en ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "An information content entity that consists of a CRID symbol and additional information about the CRID registry to which it belongs."@en ;
+                obo:IAO_0000116 "2014-05-05: In defining this term we take no position on what the CRID denotes. In particular do not assume it denotes a *record* in the CRID registry (since the registry might not have 'records')."@en ,
+                                "Alan, IAO call 20101124: potentially the CRID denotes the instance it was associated with during creation."@en ,
+                                "Note, IAO call 20101124: URIs are not always CRID, as not centrally registered. We acknowledge that CRID is a subset of a larger identifier class, but this subset fulfills our current needs. OBI PURLs are CRID as they are registered with OCLC. UPCs (Universal Product Codes from AC Nielsen)are not CRID as they are not centrally registered."@en ;
+                obo:IAO_0000117 "PERSON: Alan Ruttenberg"@en ,
+                                "PERSON: Bill Hogan"@en ,
+                                "PERSON: Bjoern Peters"@en ,
+                                "PERSON: Melanie Courtot"@en ;
+                obo:IAO_0000118 "CRID" ;
+                obo:IAO_0000119 "Original proposal from Bjoern, discussions at IAO calls"@en ;
+                obo:IAO_0000412 "http://purl.obolibrary.org/obo/iao/2020-12-09/iao.owl"^^xsd:string ;
+                rdfs:label "centrally registered identifier"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000579
-<http://purl.obolibrary.org/obo/IAO_0000579> rdf:type owl:Class ;
-                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/IAO_0000100> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000112> "PubMed is a CRID registry. It has a dataset of PubMed identifiers associated with journal articles. "@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000120> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000115> "A CRID registry is a dataset of CRID records, each consisting of a CRID symbol and additional information which was recorded in the dataset through a assigning a centrally registered identifier process."@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Alan Ruttenberg"@en ,
-                                                                                          "PERSON: Bill Hogan"@en ,
-                                                                                          "PERSON: Bjoern Peters"@en ,
-                                                                                          "PERSON: Melanie Courtot"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000118> "CRID registry" ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000119> "Original proposal from Bjoern, discussions at IAO calls"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/iao/2020-12-09/iao.owl"^^xsd:string ;
-                                             rdfs:label "centrally registered identifier registry"@en .
+obo:IAO_0000579 rdf:type owl:Class ;
+                rdfs:subClassOf obo:IAO_0000100 ;
+                obo:IAO_0000112 "PubMed is a CRID registry. It has a dataset of PubMed identifiers associated with journal articles. "@en ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "A CRID registry is a dataset of CRID records, each consisting of a CRID symbol and additional information which was recorded in the dataset through a assigning a centrally registered identifier process."@en ;
+                obo:IAO_0000117 "PERSON: Alan Ruttenberg"@en ,
+                                "PERSON: Bill Hogan"@en ,
+                                "PERSON: Bjoern Peters"@en ,
+                                "PERSON: Melanie Courtot"@en ;
+                obo:IAO_0000118 "CRID registry" ;
+                obo:IAO_0000119 "Original proposal from Bjoern, discussions at IAO calls"@en ;
+                obo:IAO_0000412 "http://purl.obolibrary.org/obo/iao/2020-12-09/iao.owl"^^xsd:string ;
+                rdfs:label "centrally registered identifier registry"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0020000
-<http://purl.obolibrary.org/obo/IAO_0020000> rdf:type owl:Class ;
-                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/IAO_0000030> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000111> "identifier"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000115> "An identifier is an information content entity that is the outcome of a dubbing process and is used to refer to one instance of entity shared by a group of people to refer to that individual entity."@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/iao/2020-12-09/iao.owl"^^xsd:string ;
-                                             rdfs:label "identifier"@en .
+obo:IAO_0020000 rdf:type owl:Class ;
+                rdfs:subClassOf obo:IAO_0000030 ;
+                obo:IAO_0000111 "identifier"@en ;
+                obo:IAO_0000115 "An identifier is an information content entity that is the outcome of a dubbing process and is used to refer to one instance of entity shared by a group of people to refer to that individual entity."@en ;
+                obo:IAO_0000412 "http://purl.obolibrary.org/obo/iao/2020-12-09/iao.owl"^^xsd:string ;
+                rdfs:label "identifier"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0020015
-<http://purl.obolibrary.org/obo/IAO_0020015> rdf:type owl:Class ;
-                                             owl:equivalentClass [ owl:intersectionOf ( <http://purl.obolibrary.org/obo/IAO_0020000>
-                                                                                        [ rdf:type owl:Restriction ;
-                                                                                          owl:onProperty <http://purl.obolibrary.org/obo/IAO_0000219> ;
-                                                                                          owl:allValuesFrom <http://purl.obolibrary.org/obo/NCBITaxon_9606>
-                                                                                        ]
-                                                                                      ) ;
-                                                                   rdf:type owl:Class
-                                                                 ] ;
-                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/IAO_0020000> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000115> "A personal name is a proper name identifying an individual person."@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000117> "Mathias Brochhausen" ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000119> "http://en.wikipedia.org/wiki/Personal_name" ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/iao/pno/release/2020-04-18/pno.owl"^^xsd:string ;
-                                             rdfs:comment "Personal names \"today usually comprises a given name bestowed at birth or at a young age plus a surname. It is nearly universal for a human to have a name; except in rare cases, for example feral children growing up in isolation, or infants orphaned by natural disaster for whom no written record survives.[citation needed] The Convention on the Rights of the Child specifies that a child has the right from birth to a name. Certain isolated tribes, such as the Machiguenga of the Amazon, also lack personal names.\" (http://en.wikipedia.org/wiki/Personal_name)"@en ,
-                                                          "Sep 29, 2016: The comment that including the wikipedia definition of personal name is not to be interpreted in a way that restricts this class to only contain strings of letters. A numerical or alphanumerical identifier that denotes a human is being is a personal name, too. (MB)"@en ;
-                                             rdfs:label "personal name"@en .
+obo:IAO_0020015 rdf:type owl:Class ;
+                owl:equivalentClass [ owl:intersectionOf ( obo:IAO_0020000
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty obo:IAO_0000219 ;
+                                                             owl:allValuesFrom obo:NCBITaxon_9606
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf obo:IAO_0020000 ;
+                obo:IAO_0000115 "A personal name is a proper name identifying an individual person."@en ;
+                obo:IAO_0000117 "Mathias Brochhausen" ;
+                obo:IAO_0000119 "http://en.wikipedia.org/wiki/Personal_name" ;
+                obo:IAO_0000412 "http://purl.obolibrary.org/obo/iao/pno/release/2020-04-18/pno.owl"^^xsd:string ;
+                rdfs:comment "Personal names \"today usually comprises a given name bestowed at birth or at a young age plus a surname. It is nearly universal for a human to have a name; except in rare cases, for example feral children growing up in isolation, or infants orphaned by natural disaster for whom no written record survives.[citation needed] The Convention on the Rights of the Child specifies that a child has the right from birth to a name. Certain isolated tribes, such as the Machiguenga of the Amazon, also lack personal names.\" (http://en.wikipedia.org/wiki/Personal_name)"@en ,
+                             "Sep 29, 2016: The comment that including the wikipedia definition of personal name is not to be interpreted in a way that restricts this class to only contain strings of letters. A numerical or alphanumerical identifier that denotes a human is being is a personal name, too. (MB)"@en ;
+                rdfs:label "personal name"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0022000
-<http://purl.obolibrary.org/obo/IAO_0022000> rdf:type owl:Class ;
-                                             owl:equivalentClass :AEON_0000034 ;
-                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/IAO_0020000> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000111> "http://purl.obolibrary.org/obo/IAO_0000122"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000112> "postal codes are assigned by each country"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000115> "An identifier issued by more than one authority"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Michael Conlon"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/iao/ido/release/2021-02-19/ido.owl"^^xsd:string ;
-                                             rdfs:label "distributed identifier"@en .
+obo:IAO_0022000 rdf:type owl:Class ;
+                owl:equivalentClass aeon:AEON_0000034 ;
+                rdfs:subClassOf obo:IAO_0020000 ;
+                obo:IAO_0000111 "http://purl.obolibrary.org/obo/IAO_0000122"@en ;
+                obo:IAO_0000112 "postal codes are assigned by each country"@en ;
+                obo:IAO_0000115 "An identifier issued by more than one authority"@en ;
+                obo:IAO_0000117 "PERSON: Michael Conlon"@en ;
+                obo:IAO_0000412 "http://purl.obolibrary.org/obo/iao/ido/release/2021-02-19/ido.owl"^^xsd:string ;
+                rdfs:label "distributed identifier"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0022014
-<http://purl.obolibrary.org/obo/IAO_0022014> rdf:type owl:Class ;
-                                             owl:equivalentClass :AEON_0000018 ;
-                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/IAO_0000578> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000111> "ISNI"@en ,
-                                                                                          "http://purl.obolibrary.org/obo/IAO_0000123"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000115> "An identifier for persons and organizations which may be assigned by matching algorithms based on records provided by publishers"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000116> "spell out"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Michael Conlon"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000119> "https://isni.org/page/what-is-isni/"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/iao/ido/release/2021-02-19/ido.owl"^^xsd:string ;
-                                             rdfs:label "international standard name identifier"@en .
+obo:IAO_0022014 rdf:type owl:Class ;
+                owl:equivalentClass aeon:AEON_0000018 ;
+                rdfs:subClassOf obo:IAO_0000578 ;
+                obo:IAO_0000111 "ISNI"@en ,
+                                "http://purl.obolibrary.org/obo/IAO_0000123"@en ;
+                obo:IAO_0000115 "An identifier for persons and organizations which may be assigned by matching algorithms based on records provided by publishers"@en ;
+                obo:IAO_0000116 "spell out"@en ;
+                obo:IAO_0000117 "PERSON: Michael Conlon"@en ;
+                obo:IAO_0000119 "https://isni.org/page/what-is-isni/"@en ;
+                obo:IAO_0000412 "http://purl.obolibrary.org/obo/iao/ido/release/2021-02-19/ido.owl"^^xsd:string ;
+                rdfs:label "international standard name identifier"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0022019
-<http://purl.obolibrary.org/obo/IAO_0022019> rdf:type owl:Class ;
-                                             owl:equivalentClass :AEON_0000019 ;
-                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/IAO_0000578> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000111> "ORCID ID"@en ,
-                                                                                          "http://purl.obolibrary.org/obo/IAO_0000123"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000115> "Open Researcher and Contributor ID is an alphanumeric code (ORCID iD) to uniquely identify authors and contributors of scholarly communication"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Michael Conlon"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/wiki/ORCID"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/iao/ido/release/2021-02-19/ido.owl"^^xsd:string ;
-                                             rdfs:label "open researcher and contributor identifier"@en .
+obo:IAO_0022019 rdf:type owl:Class ;
+                owl:equivalentClass aeon:AEON_0000019 ;
+                rdfs:subClassOf obo:IAO_0000578 ;
+                obo:IAO_0000111 "ORCID ID"@en ,
+                                "http://purl.obolibrary.org/obo/IAO_0000123"@en ;
+                obo:IAO_0000115 "Open Researcher and Contributor ID is an alphanumeric code (ORCID iD) to uniquely identify authors and contributors of scholarly communication"@en ;
+                obo:IAO_0000117 "PERSON: Michael Conlon"@en ;
+                obo:IAO_0000119 "https://en.wikipedia.org/wiki/ORCID"@en ;
+                obo:IAO_0000412 "http://purl.obolibrary.org/obo/iao/ido/release/2021-02-19/ido.owl"^^xsd:string ;
+                rdfs:label "open researcher and contributor identifier"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0022022
-<http://purl.obolibrary.org/obo/IAO_0022022> rdf:type owl:Class ;
-                                             owl:equivalentClass :AEON_0000020 ;
-                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/IAO_0000578> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000111> "ROR ID"@en ,
-                                                                                          "http://purl.obolibrary.org/obo/IAO_0000123"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000115> "An identifier assigned by ROR to research organizations in the world"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Michael Conlon"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000119> "http://ror.org"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/iao/ido/release/2021-02-19/ido.owl"^^xsd:string ;
-                                             rdfs:label "research organization registry identifier"@en .
+obo:IAO_0022022 rdf:type owl:Class ;
+                owl:equivalentClass aeon:AEON_0000020 ;
+                rdfs:subClassOf obo:IAO_0000578 ;
+                obo:IAO_0000111 "ROR ID"@en ,
+                                "http://purl.obolibrary.org/obo/IAO_0000123"@en ;
+                obo:IAO_0000115 "An identifier assigned by ROR to research organizations in the world"@en ;
+                obo:IAO_0000117 "PERSON: Michael Conlon"@en ;
+                obo:IAO_0000119 "http://ror.org"@en ;
+                obo:IAO_0000412 "http://purl.obolibrary.org/obo/iao/ido/release/2021-02-19/ido.owl"^^xsd:string ;
+                rdfs:label "research organization registry identifier"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0022027
-<http://purl.obolibrary.org/obo/IAO_0022027> rdf:type owl:Class ;
-                                             owl:equivalentClass :AEON_0000021 ;
-                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/IAO_0000578> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000111> "QID"@en ,
-                                                                                          "http://purl.obolibrary.org/obo/IAO_0000123"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000115> "QID (or Q number) is the unique identifier of a data item on Wikidata, comprising the letter \"Q\" followed by one or more digits."@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Michael Conlon"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000119> "https://www.wikidata.org/wiki/Q43649390"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/iao/ido/release/2021-02-19/ido.owl"^^xsd:string ;
-                                             rdfs:label "wikidata q number"@en .
+obo:IAO_0022027 rdf:type owl:Class ;
+                owl:equivalentClass aeon:AEON_0000021 ;
+                rdfs:subClassOf obo:IAO_0000578 ;
+                obo:IAO_0000111 "QID"@en ,
+                                "http://purl.obolibrary.org/obo/IAO_0000123"@en ;
+                obo:IAO_0000115 "QID (or Q number) is the unique identifier of a data item on Wikidata, comprising the letter \"Q\" followed by one or more digits."@en ;
+                obo:IAO_0000117 "PERSON: Michael Conlon"@en ;
+                obo:IAO_0000119 "https://www.wikidata.org/wiki/Q43649390"@en ;
+                obo:IAO_0000412 "http://purl.obolibrary.org/obo/iao/ido/release/2021-02-19/ido.owl"^^xsd:string ;
+                rdfs:label "wikidata q number"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0022034
-<http://purl.obolibrary.org/obo/IAO_0022034> rdf:type owl:Class ;
-                                             owl:equivalentClass :AEON_0000003 ;
-                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/IAO_0020000> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000111> "http://purl.obolibrary.org/obo/IAO_0000123"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000115> "An identifier assigned to an ice by a repository in which it is held"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Michael Conlon"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/iao/ido/release/2021-02-19/ido.owl"^^xsd:string ;
-                                             rdfs:label "local information content entity identifier"@en .
+obo:IAO_0022034 rdf:type owl:Class ;
+                owl:equivalentClass aeon:AEON_0000003 ;
+                rdfs:subClassOf obo:IAO_0020000 ;
+                obo:IAO_0000111 "http://purl.obolibrary.org/obo/IAO_0000123"@en ;
+                obo:IAO_0000115 "An identifier assigned to an ice by a repository in which it is held"@en ;
+                obo:IAO_0000117 "PERSON: Michael Conlon"@en ;
+                obo:IAO_0000412 "http://purl.obolibrary.org/obo/iao/ido/release/2021-02-19/ido.owl"^^xsd:string ;
+                rdfs:label "local information content entity identifier"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0022041
-<http://purl.obolibrary.org/obo/IAO_0022041> rdf:type owl:Class ;
-                                             owl:equivalentClass :AEON_0000016 ;
-                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/IAO_0020000> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000111> "DOI"@en ,
-                                                                                          "http://purl.obolibrary.org/obo/IAO_0000123"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000115> "A digital object identifier (DOI) is a persistent identifier or handle used to identify objects uniquely, standardized by the International Organization for Standardization (ISO)."@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Michael Conlon"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000119> "https://en.wikipedia.org/wiki/Digital_object_identifier"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/iao/ido/release/2021-02-19/ido.owl"^^xsd:string ;
-                                             rdfs:label "digital object identifier"@en .
+obo:IAO_0022041 rdf:type owl:Class ;
+                owl:equivalentClass aeon:AEON_0000016 ;
+                rdfs:subClassOf obo:IAO_0020000 ;
+                obo:IAO_0000111 "DOI"@en ,
+                                "http://purl.obolibrary.org/obo/IAO_0000123"@en ;
+                obo:IAO_0000115 "A digital object identifier (DOI) is a persistent identifier or handle used to identify objects uniquely, standardized by the International Organization for Standardization (ISO)."@en ;
+                obo:IAO_0000117 "PERSON: Michael Conlon"@en ;
+                obo:IAO_0000119 "https://en.wikipedia.org/wiki/Digital_object_identifier"@en ;
+                obo:IAO_0000412 "http://purl.obolibrary.org/obo/iao/ido/release/2021-02-19/ido.owl"^^xsd:string ;
+                rdfs:label "digital object identifier"@en .
 
 
 ###  http://purl.obolibrary.org/obo/ICO_0000048
-<http://purl.obolibrary.org/obo/ICO_0000048> rdf:type owl:Class ;
-                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/OBI_0000245> ;
-                                             owl:disjointWith <http://purl.obolibrary.org/obo/ICO_0000049> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000115> "An organization that is operated without the principal goal of making a financial profit."@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000117> "Yongqun He"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/2020-08-27/ico.owl"^^xsd:string ;
-                                             rdfs:label "nonprofit organization"@en ;
-                                             :SMW_datatype "Category" ;
-                                             :SMW_import_info "[[Category:ICO]] [[Category:Imported vocabulary]]" .
+obo:ICO_0000048 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000245 ;
+                owl:disjointWith obo:ICO_0000049 ;
+                obo:IAO_0000115 "An organization that is operated without the principal goal of making a financial profit."@en ;
+                obo:IAO_0000117 "Yongqun He"@en ;
+                obo:IAO_0000412 "http://purl.obolibrary.org/obo/2020-08-27/ico.owl"^^xsd:string ;
+                rdfs:label "nonprofit organization"@en ;
+                aeon:SMW_datatype "Category" ;
+                aeon:SMW_import_info "[[Category:ICO]] [[Category:Imported vocabulary]]" .
 
 
 ###  http://purl.obolibrary.org/obo/ICO_0000049
-<http://purl.obolibrary.org/obo/ICO_0000049> rdf:type owl:Class ;
-                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/OBI_0000245> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000115> "An organization which has the principle goal of earning financial profit."@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000117> "Yongqun He"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/2020-08-27/ico.owl"^^xsd:string ;
-                                             rdfs:label "profit organization"@en ;
-                                             :SMW_datatype "Category" ;
-                                             :SMW_import_info "[[Category:ICO]] [[Category:Imported vocabulary]]" .
+obo:ICO_0000049 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000245 ;
+                obo:IAO_0000115 "An organization which has the principle goal of earning financial profit."@en ;
+                obo:IAO_0000117 "Yongqun He"@en ;
+                obo:IAO_0000412 "http://purl.obolibrary.org/obo/2020-08-27/ico.owl"^^xsd:string ;
+                rdfs:label "profit organization"@en ;
+                aeon:SMW_datatype "Category" ;
+                aeon:SMW_import_info "[[Category:ICO]] [[Category:Imported vocabulary]]" .
 
 
 ###  http://purl.obolibrary.org/obo/NCBITaxon_9606
-<http://purl.obolibrary.org/obo/NCBITaxon_9606> rdf:type owl:Class ;
-                                                rdfs:subClassOf <http://purl.obolibrary.org/obo/OBI_0100026> ,
-                                                                [ rdf:type owl:Restriction ;
-                                                                  owl:onProperty <http://purl.obolibrary.org/obo/IAO_0000235> ;
-                                                                  owl:someValuesFrom <http://purl.obolibrary.org/obo/IAO_0020015>
-                                                                ] ,
-                                                                [ rdf:type owl:Restriction ;
-                                                                  owl:onProperty <http://purl.obolibrary.org/obo/IAO_0000235> ;
-                                                                  owl:someValuesFrom :AEON_0000019
-                                                                ] ;
-                                                <http://purl.obolibrary.org/obo/IAO_0000111> "Homo sapiens"^^xsd:string ;
-                                                <http://purl.obolibrary.org/obo/IAO_0000118> "human"^^xsd:string ,
-                                                                                             "human being"^^xsd:string ,
-                                                                                             "man"^^xsd:string ;
-                                                <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/obi/2020-12-16/obi.owl"^^xsd:string ;
-                                                rdfs:label "Homo sapiens"^^xsd:string ;
-                                                :SMW_datatype "Category" ;
-                                                :SMW_import_info "[[Category:NCBITaxon]] [[Category:Imported vocabulary]]" .
+obo:NCBITaxon_9606 rdf:type owl:Class ;
+                   rdfs:subClassOf obo:OBI_0100026 ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty obo:IAO_0000235 ;
+                                     owl:someValuesFrom obo:IAO_0020015
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty obo:IAO_0000235 ;
+                                     owl:someValuesFrom aeon:AEON_0000019
+                                   ] ;
+                   obo:IAO_0000111 "Homo sapiens"^^xsd:string ;
+                   obo:IAO_0000118 "human"^^xsd:string ,
+                                   "human being"^^xsd:string ,
+                                   "man"^^xsd:string ;
+                   obo:IAO_0000412 "http://purl.obolibrary.org/obo/obi/2020-12-16/obi.owl"^^xsd:string ;
+                   rdfs:label "Homo sapiens"^^xsd:string ;
+                   aeon:SMW_datatype "Category" ;
+                   aeon:SMW_import_info "[[Category:NCBITaxon]] [[Category:Imported vocabulary]]" .
 
 
 ###  http://purl.obolibrary.org/obo/OBI_0000011
-<http://purl.obolibrary.org/obo/OBI_0000011> rdf:type owl:Class ;
-                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/BFO_0000015> ;
-                                             rdfs:label "planned process"@en .
+obo:OBI_0000011 rdf:type owl:Class ;
+                rdfs:subClassOf obo:BFO_0000015 ;
+                rdfs:label "planned process"@en .
 
 
 ###  http://purl.obolibrary.org/obo/OBI_0000245
-<http://purl.obolibrary.org/obo/OBI_0000245> rdf:type owl:Class ;
-                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/BFO_0000027> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000111> "organization"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000112> "PMID: 16353909.AAPS J. 2005 Sep 22;7(2):E274-80. Review. The joint food and agriculture organization of the United Nations/World Health Organization Expert Committee on Food Additives and its role in the evaluation of the safety of veterinary drug residues in foods."@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000122> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000115> "An entity that can bear roles, has members, and has a set of organization rules. Members of organizations are either organizations themselves or individual people. Members can bear specific organization member roles that are determined in the organization rules. The organization rules also determine how decisions are made on behalf of the organization by the organization members."@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000116> """BP: The definition summarizes long email discussions on the OBI developer, roles, biomaterial and denrie branches. It leaves open if an organization is a material entity or a dependent continuant, as no consensus was reached on that.  The current placement as material is therefore temporary, in order to move forward with development. Here is the entire email summary, on which the definition is based:
+obo:OBI_0000245 rdf:type owl:Class ;
+                rdfs:subClassOf obo:BFO_0000027 ;
+                obo:IAO_0000111 "organization"@en ;
+                obo:IAO_0000112 "PMID: 16353909.AAPS J. 2005 Sep 22;7(2):E274-80. Review. The joint food and agriculture organization of the United Nations/World Health Organization Expert Committee on Food Additives and its role in the evaluation of the safety of veterinary drug residues in foods."@en ;
+                obo:IAO_0000114 obo:IAO_0000122 ;
+                obo:IAO_0000115 "An entity that can bear roles, has members, and has a set of organization rules. Members of organizations are either organizations themselves or individual people. Members can bear specific organization member roles that are determined in the organization rules. The organization rules also determine how decisions are made on behalf of the organization by the organization members."@en ;
+                obo:IAO_0000116 """BP: The definition summarizes long email discussions on the OBI developer, roles, biomaterial and denrie branches. It leaves open if an organization is a material entity or a dependent continuant, as no consensus was reached on that.  The current placement as material is therefore temporary, in order to move forward with development. Here is the entire email summary, on which the definition is based:
 
 1) there are organization_member_roles (president, treasurer, branch
 editor), with individual persons as bearers
@@ -2756,338 +2762,338 @@ This leads to my proposal: We define organization through the statements 1 -
 current place in the is_a hierarchy (material entity) or move it up to
 'continuant'. We leave further clarifications to BFO, and close this issue
 for now."""@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Alan Ruttenberg"^^xsd:string ,
-                                                                                          "PERSON: Bjoern Peters"^^xsd:string ,
-                                                                                          "PERSON: Philippe Rocca-Serra"^^xsd:string ,
-                                                                                          "PERSON: Susanna Sansone"^^xsd:string ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000119> "GROUP: OBI"^^xsd:string ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000412> "http://purl.obolibrary.org/obo/obi/2020-12-16/obi.owl"^^xsd:string ;
-                                             rdfs:label "organization"@en ;
-                                             :SMW_datatype "Category" ;
-                                             :SMW_import_info "[[Category:OBI]] [[Category:Imported vocabulary]]" .
+                obo:IAO_0000117 "PERSON: Alan Ruttenberg"^^xsd:string ,
+                                "PERSON: Bjoern Peters"^^xsd:string ,
+                                "PERSON: Philippe Rocca-Serra"^^xsd:string ,
+                                "PERSON: Susanna Sansone"^^xsd:string ;
+                obo:IAO_0000119 "GROUP: OBI"^^xsd:string ;
+                obo:IAO_0000412 "http://purl.obolibrary.org/obo/obi/2020-12-16/obi.owl"^^xsd:string ;
+                rdfs:label "organization"@en ;
+                aeon:SMW_datatype "Category" ;
+                aeon:SMW_import_info "[[Category:OBI]] [[Category:Imported vocabulary]]" .
 
 
 ###  http://purl.obolibrary.org/obo/OBI_0100026
-<http://purl.obolibrary.org/obo/OBI_0100026> rdf:type owl:Class ;
-                                             rdfs:subClassOf <http://purl.obolibrary.org/obo/BFO_0000030> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000111> "organizational term"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000112> "fungus; plant; virus; animal"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000114> "organizational term"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000116> "10/21/09: This is a placeholder term, that should ideally be imported from the NCBI taxonomy, but the high level hierarchy there does not suit our needs (includes plasmids and 'other organisms')"@en ,
-                                                                                          "13-02-2009: OBI doesn't take position as to when an organism starts or ends being an organism - e.g. sperm, foetus. This issue is outside the scope of OBI."@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000119> "WEB: http://en.wikipedia.org/wiki/Organism"@en ;
-                                             rdfs:label "organism"@en .
+obo:OBI_0100026 rdf:type owl:Class ;
+                rdfs:subClassOf obo:BFO_0000030 ;
+                obo:IAO_0000111 "organizational term"@en ;
+                obo:IAO_0000112 "fungus; plant; virus; animal"@en ;
+                obo:IAO_0000114 "organizational term"@en ;
+                obo:IAO_0000116 "10/21/09: This is a placeholder term, that should ideally be imported from the NCBI taxonomy, but the high level hierarchy there does not suit our needs (includes plasmids and 'other organisms')"@en ,
+                                "13-02-2009: OBI doesn't take position as to when an organism starts or ends being an organism - e.g. sperm, foetus. This issue is outside the scope of OBI."@en ;
+                obo:IAO_0000119 "WEB: http://en.wikipedia.org/wiki/Organism"@en ;
+                rdfs:label "organism"@en .
 
 
 ###  http://www.w3.org/2004/02/skos/core#Concept
-<http://www.w3.org/2004/02/skos/core#Concept> rdf:type owl:Class ;
-                                              <http://purl.obolibrary.org/obo/IAO_0000115> """A SKOS concept can be viewed as an idea or notion; a unit of thought. However, what constitutes a unit of thought is subjective, and this definition is meant to be suggestive, rather than restrictive.
+skos:Concept rdf:type owl:Class ;
+             obo:IAO_0000115 """A SKOS concept can be viewed as an idea or notion; a unit of thought. However, what constitutes a unit of thought is subjective, and this definition is meant to be suggestive, rather than restrictive.
 
 The notion of a SKOS concept is useful when describing the conceptual or intellectual structure of a knowledge organization system, and when referring to specific ideas or meanings established within a KOS.
 
 Note that, because SKOS is designed to be a vehicle for representing semi-formal KOS, such as thesauri and classification schemes, a certain amount of flexibility has been built in to the formal definition of this class.
 
 See the [SKOS-PRIMER] for more examples of identifying and describing SKOS concepts."""@en ;
-                                              <http://purl.obolibrary.org/obo/IAO_0000412> "https://www.w3.org/2009/08/skos-reference/skos.html#Concept" ;
-                                              rdfs:label "Concept" ;
-                                              :SMW_datatype "Category" ;
-                                              :SMW_import_info "[[Category:SKOS]] [[Category:Imported vocabulary]]" .
+             obo:IAO_0000412 "https://www.w3.org/2009/08/skos-reference/skos.html#Concept" ;
+             rdfs:label "Concept" ;
+             aeon:SMW_datatype "Category" ;
+             aeon:SMW_import_info "[[Category:SKOS]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000001
-:AEON_0000001 rdf:type owl:Class ;
-              rdfs:subClassOf <http://purl.obolibrary.org/obo/OBI_0000011> ,
-                              [ rdf:type owl:Restriction ;
-                                owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000055> ;
-                                owl:someValuesFrom :AEON_0000005
-                              ] ,
-                              [ rdf:type owl:Restriction ;
-                                owl:onProperty :AEON_0000084 ;
-                                owl:someValuesFrom :AEON_0000002
-                              ] ;
-              owl:disjointWith :AEON_0000002 ;
-              <http://purl.obolibrary.org/obo/IAO_0000112> "The 19th International Semantic Web Conference (ISWC2020) is an academic  event."@en ;
-              <http://purl.obolibrary.org/obo/IAO_0000115> "An academic event is an organized gathering for researchers (not necessarily academics) to present and discuss their work."@en ;
-              rdfs:comment """TODO:
+aeon:AEON_0000001 rdf:type owl:Class ;
+                  rdfs:subClassOf obo:OBI_0000011 ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty obo:BFO_0000055 ;
+                                    owl:someValuesFrom aeon:AEON_0000005
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty aeon:AEON_0000084 ;
+                                    owl:someValuesFrom aeon:AEON_0000002
+                                  ] ;
+                  owl:disjointWith aeon:AEON_0000002 ;
+                  obo:IAO_0000112 "The 19th International Semantic Web Conference (ISWC2020) is an academic  event."@en ;
+                  obo:IAO_0000115 "An academic event is an organized gathering for researchers (not necessarily academics) to present and discuss their work."@en ;
+                  rdfs:comment """TODO:
 * It needs to be discussed, if we need the \"process boundary\" class to describe the start and end of an academic event or event series.
 * It needs to be discussed, if we need the \"temporal region\" and \"spatiotemporal region\"  classes to describe the duration and manifestation in spacetime of an academic event or event series."""@en ;
-              rdfs:label "academic event"@en ;
-              :AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Q1656682\", \"label\": \"eventLabel\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Category:Event\", \"label\": \"Event\"}, \"gnd\": {\"uri\": \"https://d-nb.info/standards/elementset/gnd#ConferenceOrEvent\", \"label\": \"Conference or Event\"}}"^^xsd:string ;
-              :SMW_datatype "Category" ;
-              :SMW_import_info """
+                  rdfs:label "academic event"@en ;
+                  aeon:AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Q1656682\", \"label\": \"eventLabel\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Category:Event\", \"label\": \"Event\"}, \"gnd\": {\"uri\": \"https://d-nb.info/standards/elementset/gnd#ConferenceOrEvent\", \"label\": \"Conference or Event\"}}"^^xsd:string ;
+                  aeon:SMW_datatype "Category" ;
+                  aeon:SMW_import_info """
            [[Category:AEON]] [[Category:Imported vocabulary]]""" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000002
-:AEON_0000002 rdf:type owl:Class ;
-              rdfs:subClassOf <http://purl.obolibrary.org/obo/OBI_0000011> ,
-                              [ rdf:type owl:Restriction ;
-                                owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000055> ;
-                                owl:someValuesFrom :AEON_0000005
-                              ] ;
-              <http://purl.obolibrary.org/obo/IAO_0000112> "International Semantic Web Conference (ISWC) series" ;
-              rdfs:label "academic event series" ;
-              :AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Q15900647\", \"label\": \"conference_seriesLabel\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Category:Event_series\", \"label\": \"Event_series\"}, \"gnd\": {\"uri\": \"https://d-nb.info/standards/elementset/gnd#SeriesOfConferenceOrEvent\", \"label\": \"Series of conference or event\"}}"^^xsd:string ;
-              :SMW_datatype "Category" ;
-              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:AEON_0000002 rdf:type owl:Class ;
+                  rdfs:subClassOf obo:OBI_0000011 ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty obo:BFO_0000055 ;
+                                    owl:someValuesFrom aeon:AEON_0000005
+                                  ] ;
+                  obo:IAO_0000112 "International Semantic Web Conference (ISWC) series" ;
+                  rdfs:label "academic event series" ;
+                  aeon:AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Q15900647\", \"label\": \"conference_seriesLabel\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Category:Event_series\", \"label\": \"Event_series\"}, \"gnd\": {\"uri\": \"https://d-nb.info/standards/elementset/gnd#SeriesOfConferenceOrEvent\", \"label\": \"Series of conference or event\"}}"^^xsd:string ;
+                  aeon:SMW_datatype "Category" ;
+                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000003
-:AEON_0000003 rdf:type owl:Class ;
-              rdfs:subClassOf <http://purl.obolibrary.org/obo/IAO_0020000> ;
-              <http://purl.obolibrary.org/obo/IAO_0000116> "The alternative term \"ConfIDent_ID\" is used here, as the ontology is being developed by the ConfIDent project (https://projects.tib.eu/en/confident/) to be used in its service. Thus the internal identifier is called \"ConfIDent ID\". You will probably want to change that in your implementation."@en ;
-              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"@en ;
-              <http://purl.obolibrary.org/obo/IAO_0000118> "ConfIDent ID"@en ;
-              rdfs:label "internal identifier"@en ;
-              <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> <http://purl.obolibrary.org/obo/IAO_0000423> ;
-              :SMW_datatype "Category" ;
-              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:AEON_0000003 rdf:type owl:Class ;
+                  rdfs:subClassOf obo:IAO_0020000 ;
+                  obo:IAO_0000116 "The alternative term \"ConfIDent_ID\" is used here, as the ontology is being developed by the ConfIDent project (https://projects.tib.eu/en/confident/) to be used in its service. Thus the internal identifier is called \"ConfIDent ID\". You will probably want to change that in your implementation."@en ;
+                  obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
+                  obo:IAO_0000118 "ConfIDent ID"@en ;
+                  rdfs:label "internal identifier"@en ;
+                  ns:term_status obo:IAO_0000423 ;
+                  aeon:SMW_datatype "Category" ;
+                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000004
-:AEON_0000004 rdf:type owl:Class ;
-              rdfs:subClassOf <http://www.w3.org/2004/02/skos/core#Concept> ;
-              <http://purl.obolibrary.org/obo/IAO_0000115> "An event type is a skos:Concept that is being used to distinguish between the different academic event formats."@en ;
-              <http://purl.obolibrary.org/obo/IAO_0000116> "As the used definitions of the various academic event types can vary strongly between different communities and societies, we chose to model the type of an event as a SKOS concept instead of adding subclasses to the \"academic event\" class. The most commonly used event types are provided in AEON as named instances of this class."@en ;
-              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert" ;
-              rdfs:label "event type"@en ;
-              :SMW_datatype "Category" ;
-              :SMW_import_info "The individuals/instances of this class make up the allowed value list in [[MediaWiki:Smw_allows_list_has_event_type]]. [[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:AEON_0000004 rdf:type owl:Class ;
+                  rdfs:subClassOf skos:Concept ;
+                  obo:IAO_0000115 "An event type is a skos:Concept that is being used to distinguish between the different academic event formats."@en ;
+                  obo:IAO_0000116 "As the used definitions of the various academic event types can vary strongly between different communities and societies, we chose to model the type of an event as a SKOS concept instead of adding subclasses to the \"academic event\" class. The most commonly used event types are provided in AEON as named instances of this class."@en ;
+                  obo:IAO_0000117 "PERSON: Philip Strömert" ;
+                  rdfs:label "event type"@en ;
+                  aeon:SMW_datatype "Category" ;
+                  aeon:SMW_import_info "The individuals/instances of this class make up the allowed value list in [[MediaWiki:Smw_allows_list_has_event_type]]. [[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000005
-:AEON_0000005 rdf:type owl:Class ;
-              owl:equivalentClass [ rdf:type owl:Restriction ;
-                                    owl:onProperty <http://purl.obolibrary.org/obo/RO_0000081> ;
-                                    owl:someValuesFrom [ rdf:type owl:Restriction ;
-                                                         owl:onProperty :contibutes_to ;
-                                                         owl:someValuesFrom <http://purl.obolibrary.org/obo/OBI_0000011>
-                                                       ]
+aeon:AEON_0000005 rdf:type owl:Class ;
+                  owl:equivalentClass [ rdf:type owl:Restriction ;
+                                        owl:onProperty obo:RO_0000081 ;
+                                        owl:someValuesFrom [ rdf:type owl:Restriction ;
+                                                             owl:onProperty aeon:contibutes_to ;
+                                                             owl:someValuesFrom obo:OBI_0000011
+                                                           ]
+                                      ] ;
+                  rdfs:subClassOf obo:BFO_0000023 ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty obo:BFO_0000054 ;
+                                    owl:someValuesFrom obo:OBI_0000011
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty obo:BFO_0000054 ;
+                                    owl:someValuesFrom aeon:AEON_0000001
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty obo:BFO_0000054 ;
+                                    owl:someValuesFrom aeon:AEON_0000002
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty obo:RO_0000081 ;
+                                    owl:someValuesFrom aeon:contributor
                                   ] ;
-              rdfs:subClassOf <http://purl.obolibrary.org/obo/BFO_0000023> ,
-                              [ rdf:type owl:Restriction ;
-                                owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000054> ;
-                                owl:someValuesFrom <http://purl.obolibrary.org/obo/OBI_0000011>
-                              ] ,
-                              [ rdf:type owl:Restriction ;
-                                owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000054> ;
-                                owl:someValuesFrom :AEON_0000001
-                              ] ,
-                              [ rdf:type owl:Restriction ;
-                                owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000054> ;
-                                owl:someValuesFrom :AEON_0000002
-                              ] ,
-                              [ rdf:type owl:Restriction ;
-                                owl:onProperty <http://purl.obolibrary.org/obo/RO_0000081> ;
-                                owl:someValuesFrom :contributor
-                              ] ;
-              <http://purl.obolibrary.org/obo/IAO_0000115> "The contributor role inheres in a person or organization that participates in a planned process by somehow contributing to it."@en ;
-              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert" ;
-              <http://purl.org/dc/elements/1.1/date> "2020-09-28T12:51:02Z"^^xsd:dateTime ;
-              rdfs:label "contributor role"@en ;
-              :SMW_datatype "Category" ;
-              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+                  obo:IAO_0000115 "The contributor role inheres in a person or organization that participates in a planned process by somehow contributing to it."@en ;
+                  obo:IAO_0000117 "PERSON: Philip Strömert" ;
+                  <http://purl.org/dc/elements/1.1/date> "2020-09-28T12:51:02Z"^^xsd:dateTime ;
+                  rdfs:label "contributor role"@en ;
+                  aeon:SMW_datatype "Category" ;
+                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000006
-:AEON_0000006 rdf:type owl:Class ;
-              owl:equivalentClass [ rdf:type owl:Restriction ;
-                                    owl:onProperty <http://purl.obolibrary.org/obo/RO_0000081> ;
-                                    owl:someValuesFrom [ rdf:type owl:Restriction ;
-                                                         owl:onProperty :organizes ;
-                                                         owl:someValuesFrom <http://purl.obolibrary.org/obo/OBI_0000011>
-                                                       ]
-                                  ] ;
-              rdfs:subClassOf :AEON_0000005 ;
-              <http://purl.obolibrary.org/obo/IAO_0000115> "The organizer role inheres in a person or organization that contributes to a planned process by planning and managing its realization."@en ;
-              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"@en ;
-              rdfs:label "organizer role"@en ;
-              :SMW_datatype "Category" ;
-              :SMW_import_info """[[partOfSubobject::Template:Subobject Organizer]]
+aeon:AEON_0000006 rdf:type owl:Class ;
+                  owl:equivalentClass [ rdf:type owl:Restriction ;
+                                        owl:onProperty obo:RO_0000081 ;
+                                        owl:someValuesFrom [ rdf:type owl:Restriction ;
+                                                             owl:onProperty aeon:organizes ;
+                                                             owl:someValuesFrom obo:OBI_0000011
+                                                           ]
+                                      ] ;
+                  rdfs:subClassOf aeon:AEON_0000005 ;
+                  obo:IAO_0000115 "The organizer role inheres in a person or organization that contributes to a planned process by planning and managing its realization."@en ;
+                  obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
+                  rdfs:label "organizer role"@en ;
+                  aeon:SMW_datatype "Category" ;
+                  aeon:SMW_import_info """[[partOfSubobject::Template:Subobject Organizer]]
 
 [[Category:AEON]] [[Category:Imported vocabulary]]""" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000007
-:AEON_0000007 rdf:type owl:Class ;
-              owl:equivalentClass [ rdf:type owl:Restriction ;
-                                    owl:onProperty <http://purl.obolibrary.org/obo/RO_0000081> ;
-                                    owl:someValuesFrom [ rdf:type owl:Restriction ;
-                                                         owl:onProperty :committee_member_in ;
-                                                         owl:someValuesFrom <http://purl.obolibrary.org/obo/OBI_0000011>
-                                                       ]
-                                  ] ;
-              rdfs:subClassOf :AEON_0000006 ;
-              owl:disjointWith :AEON_0000009 ;
-              <http://purl.obolibrary.org/obo/IAO_0000115> "The 'committee member role' inheres in a person who contributes to a planned process by somehow realizing the function of the committe he is a member of."@en ;
-              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"@en ;
-              rdfs:label "event committee member role"@en ;
-              :SMW_datatype "Category" ;
-              :SMW_import_info """[[partOfSubobject::Template:Subobject Committee]]
+aeon:AEON_0000007 rdf:type owl:Class ;
+                  owl:equivalentClass [ rdf:type owl:Restriction ;
+                                        owl:onProperty obo:RO_0000081 ;
+                                        owl:someValuesFrom [ rdf:type owl:Restriction ;
+                                                             owl:onProperty aeon:committee_member_in ;
+                                                             owl:someValuesFrom obo:OBI_0000011
+                                                           ]
+                                      ] ;
+                  rdfs:subClassOf aeon:AEON_0000006 ;
+                  owl:disjointWith aeon:AEON_0000009 ;
+                  obo:IAO_0000115 "The 'committee member role' inheres in a person who contributes to a planned process by somehow realizing the function of the committe he is a member of."@en ;
+                  obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
+                  rdfs:label "event committee member role"@en ;
+                  aeon:SMW_datatype "Category" ;
+                  aeon:SMW_import_info """[[partOfSubobject::Template:Subobject Committee]]
 
 [[Category:AEON]] [[Category:Imported vocabulary]]""" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000008
-:AEON_0000008 rdf:type owl:Class ;
-              owl:equivalentClass [ rdf:type owl:Restriction ;
-                                    owl:onProperty <http://purl.obolibrary.org/obo/RO_0000081> ;
-                                    owl:someValuesFrom [ rdf:type owl:Restriction ;
-                                                         owl:onProperty :committee_chair_in ;
-                                                         owl:someValuesFrom <http://purl.obolibrary.org/obo/OBI_0000011>
-                                                       ]
-                                  ] ;
-              rdfs:subClassOf :AEON_0000007 ;
-              <http://purl.obolibrary.org/obo/IAO_0000115> "The 'committee chair role' inheres in a person who contributes to a planned process by somehow realizing the function of the committee he is a chair of."@en ;
-              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"@en ;
-              rdfs:label "event committee chair role"@en ;
-              :SMW_datatype "Category" ;
-              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:AEON_0000008 rdf:type owl:Class ;
+                  owl:equivalentClass [ rdf:type owl:Restriction ;
+                                        owl:onProperty obo:RO_0000081 ;
+                                        owl:someValuesFrom [ rdf:type owl:Restriction ;
+                                                             owl:onProperty aeon:committee_chair_in ;
+                                                             owl:someValuesFrom obo:OBI_0000011
+                                                           ]
+                                      ] ;
+                  rdfs:subClassOf aeon:AEON_0000007 ;
+                  obo:IAO_0000115 "The 'committee chair role' inheres in a person who contributes to a planned process by somehow realizing the function of the committee he is a chair of."@en ;
+                  obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
+                  rdfs:label "event committee chair role"@en ;
+                  aeon:SMW_datatype "Category" ;
+                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000009
-:AEON_0000009 rdf:type owl:Class ;
-              owl:equivalentClass [ rdf:type owl:Restriction ;
-                                    owl:onProperty <http://purl.obolibrary.org/obo/RO_0000081> ;
-                                    owl:someValuesFrom [ rdf:type owl:Restriction ;
-                                                         owl:onProperty :contact_person_of ;
-                                                         owl:someValuesFrom <http://purl.obolibrary.org/obo/OBI_0000011>
-                                                       ]
-                                  ] ;
-              rdfs:subClassOf :AEON_0000006 ;
-              <http://purl.obolibrary.org/obo/IAO_0000115> "The contact person role inheres in a person that contributes to a planned process by functioning as the addressee of the planned process who answers general inquiries and redirects more complex inqueries to a more appropriate addressee."@en ;
-              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"@en ;
-              rdfs:label "contact person role"@en ;
-              :SMW_datatype "Category" ;
-              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:AEON_0000009 rdf:type owl:Class ;
+                  owl:equivalentClass [ rdf:type owl:Restriction ;
+                                        owl:onProperty obo:RO_0000081 ;
+                                        owl:someValuesFrom [ rdf:type owl:Restriction ;
+                                                             owl:onProperty aeon:contact_person_of ;
+                                                             owl:someValuesFrom obo:OBI_0000011
+                                                           ]
+                                      ] ;
+                  rdfs:subClassOf aeon:AEON_0000006 ;
+                  obo:IAO_0000115 "The contact person role inheres in a person that contributes to a planned process by functioning as the addressee of the planned process who answers general inquiries and redirects more complex inqueries to a more appropriate addressee."@en ;
+                  obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
+                  rdfs:label "contact person role"@en ;
+                  aeon:SMW_datatype "Category" ;
+                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000010
-:AEON_0000010 rdf:type owl:Class ;
-              owl:equivalentClass [ rdf:type owl:Restriction ;
-                                    owl:onProperty <http://purl.obolibrary.org/obo/RO_0000081> ;
-                                    owl:someValuesFrom [ rdf:type owl:Restriction ;
-                                                         owl:onProperty :attends_at ;
-                                                         owl:someValuesFrom <http://purl.obolibrary.org/obo/OBI_0000011>
-                                                       ]
-                                  ] ;
-              rdfs:subClassOf :AEON_0000005 ;
-              <http://purl.obolibrary.org/obo/IAO_0000115> "The attendee role inheres in a person that contributes to a planned process by attending it."@en ;
-              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"@en ;
-              rdfs:label "attendee role"@en ;
-              :SMW_datatype "Category" ;
-              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:AEON_0000010 rdf:type owl:Class ;
+                  owl:equivalentClass [ rdf:type owl:Restriction ;
+                                        owl:onProperty obo:RO_0000081 ;
+                                        owl:someValuesFrom [ rdf:type owl:Restriction ;
+                                                             owl:onProperty aeon:attends_at ;
+                                                             owl:someValuesFrom obo:OBI_0000011
+                                                           ]
+                                      ] ;
+                  rdfs:subClassOf aeon:AEON_0000005 ;
+                  obo:IAO_0000115 "The attendee role inheres in a person that contributes to a planned process by attending it."@en ;
+                  obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
+                  rdfs:label "attendee role"@en ;
+                  aeon:SMW_datatype "Category" ;
+                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000011
-:AEON_0000011 rdf:type owl:Class ;
-              owl:equivalentClass [ rdf:type owl:Restriction ;
-                                    owl:onProperty <http://purl.obolibrary.org/obo/RO_0000081> ;
-                                    owl:someValuesFrom [ rdf:type owl:Restriction ;
-                                                         owl:onProperty :moderates_at ;
-                                                         owl:someValuesFrom <http://purl.obolibrary.org/obo/OBI_0000011>
-                                                       ]
-                                  ] ;
-              rdfs:subClassOf :AEON_0000005 ;
-              <http://purl.obolibrary.org/obo/IAO_0000115> "The moderating role inheres in a person that contributes to a planned process by facilitating the communication."@en ;
-              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"@en ;
-              rdfs:label "moderator role"@en ;
-              :SMW_datatype "Category" ;
-              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:AEON_0000011 rdf:type owl:Class ;
+                  owl:equivalentClass [ rdf:type owl:Restriction ;
+                                        owl:onProperty obo:RO_0000081 ;
+                                        owl:someValuesFrom [ rdf:type owl:Restriction ;
+                                                             owl:onProperty aeon:moderates_at ;
+                                                             owl:someValuesFrom obo:OBI_0000011
+                                                           ]
+                                      ] ;
+                  rdfs:subClassOf aeon:AEON_0000005 ;
+                  obo:IAO_0000115 "The moderating role inheres in a person that contributes to a planned process by facilitating the communication."@en ;
+                  obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
+                  rdfs:label "moderator role"@en ;
+                  aeon:SMW_datatype "Category" ;
+                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000012
-:AEON_0000012 rdf:type owl:Class ;
-              owl:equivalentClass [ rdf:type owl:Restriction ;
-                                    owl:onProperty <http://purl.obolibrary.org/obo/RO_0000081> ;
-                                    owl:someValuesFrom [ rdf:type owl:Restriction ;
-                                                         owl:onProperty :reviews_at ;
-                                                         owl:someValuesFrom <http://purl.obolibrary.org/obo/OBI_0000011>
-                                                       ]
-                                  ] ;
-              rdfs:subClassOf :AEON_0000005 ;
-              <http://purl.obolibrary.org/obo/IAO_0000115> "Evaluation of scientific, academic, or professional work, such as manuscripts or grants by others working in the same field."@en ,
-                                                           "The reviewer role inheres in a person that contributes to a planned process by reviewing something of interest in a planned process."@en ;
-              <http://purl.obolibrary.org/obo/IAO_0000116> "ToDo: use CRO IRI http://purl.obolibrary.org/obo/CRO_0000101"@en ;
-              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"@en ;
-              <http://purl.obolibrary.org/obo/IAO_0000118> "manuscript review role"@en ;
-              rdfs:label "reviewer role"@en ;
-              :SMW_datatype "Category" ;
-              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:AEON_0000012 rdf:type owl:Class ;
+                  owl:equivalentClass [ rdf:type owl:Restriction ;
+                                        owl:onProperty obo:RO_0000081 ;
+                                        owl:someValuesFrom [ rdf:type owl:Restriction ;
+                                                             owl:onProperty aeon:reviews_at ;
+                                                             owl:someValuesFrom obo:OBI_0000011
+                                                           ]
+                                      ] ;
+                  rdfs:subClassOf aeon:AEON_0000005 ;
+                  obo:IAO_0000115 "Evaluation of scientific, academic, or professional work, such as manuscripts or grants by others working in the same field."@en ,
+                                  "The reviewer role inheres in a person that contributes to a planned process by reviewing something of interest in a planned process."@en ;
+                  obo:IAO_0000116 "ToDo: use CRO IRI http://purl.obolibrary.org/obo/CRO_0000101"@en ;
+                  obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
+                  obo:IAO_0000118 "manuscript review role"@en ;
+                  rdfs:label "reviewer role"@en ;
+                  aeon:SMW_datatype "Category" ;
+                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000013
-:AEON_0000013 rdf:type owl:Class ;
-              owl:equivalentClass [ rdf:type owl:Restriction ;
-                                    owl:onProperty <http://purl.obolibrary.org/obo/RO_0000081> ;
-                                    owl:someValuesFrom [ rdf:type owl:Restriction ;
-                                                         owl:onProperty :speaks_at ;
-                                                         owl:someValuesFrom <http://purl.obolibrary.org/obo/OBI_0000011>
-                                                       ]
-                                  ] ;
-              rdfs:subClassOf :AEON_0000005 ;
-              <http://purl.obolibrary.org/obo/IAO_0000115> "The presenter role inheres in a person that contributes to a planned process by presenting something of interest at a planned process."@en ;
-              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"@en ;
-              <http://purl.obolibrary.org/obo/IAO_0000118> "invited speaker role"@en ;
-              <http://purl.obolibrary.org/obo/IAO_0006011> "http://purl.obolibrary.org/obo/CRO_0000100"^^xsd:anyURI ;
-              rdfs:label "presenter role"@en ;
-              :SMW_datatype "Category" ;
-              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:AEON_0000013 rdf:type owl:Class ;
+                  owl:equivalentClass [ rdf:type owl:Restriction ;
+                                        owl:onProperty obo:RO_0000081 ;
+                                        owl:someValuesFrom [ rdf:type owl:Restriction ;
+                                                             owl:onProperty aeon:speaks_at ;
+                                                             owl:someValuesFrom obo:OBI_0000011
+                                                           ]
+                                      ] ;
+                  rdfs:subClassOf aeon:AEON_0000005 ;
+                  obo:IAO_0000115 "The presenter role inheres in a person that contributes to a planned process by presenting something of interest at a planned process."@en ;
+                  obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
+                  obo:IAO_0000118 "invited speaker role"@en ;
+                  obo:IAO_0006011 "http://purl.obolibrary.org/obo/CRO_0000100"^^xsd:anyURI ;
+                  rdfs:label "presenter role"@en ;
+                  aeon:SMW_datatype "Category" ;
+                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000014
-:AEON_0000014 rdf:type owl:Class ;
-              owl:equivalentClass [ rdf:type owl:Restriction ;
-                                    owl:onProperty <http://purl.obolibrary.org/obo/RO_0000081> ;
-                                    owl:someValuesFrom [ rdf:type owl:Restriction ;
-                                                         owl:onProperty :holds_keynote_at ;
-                                                         owl:someValuesFrom <http://purl.obolibrary.org/obo/OBI_0000011>
-                                                       ]
-                                  ] ;
-              rdfs:subClassOf :AEON_0000013 ;
-              <http://purl.obolibrary.org/obo/IAO_0000115> "The keynote speaker role inheres in a person that contributes to a planned process by holding a keynote speech at a planned process."@en ;
-              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"@en ;
-              rdfs:label "keynote speaker role"@en ;
-              :SMW_datatype "Category" ;
-              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:AEON_0000014 rdf:type owl:Class ;
+                  owl:equivalentClass [ rdf:type owl:Restriction ;
+                                        owl:onProperty obo:RO_0000081 ;
+                                        owl:someValuesFrom [ rdf:type owl:Restriction ;
+                                                             owl:onProperty aeon:holds_keynote_at ;
+                                                             owl:someValuesFrom obo:OBI_0000011
+                                                           ]
+                                      ] ;
+                  rdfs:subClassOf aeon:AEON_0000013 ;
+                  obo:IAO_0000115 "The keynote speaker role inheres in a person that contributes to a planned process by holding a keynote speech at a planned process."@en ;
+                  obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
+                  rdfs:label "keynote speaker role"@en ;
+                  aeon:SMW_datatype "Category" ;
+                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000015
-:AEON_0000015 rdf:type owl:Class ;
-              owl:equivalentClass [ rdf:type owl:Restriction ;
-                                    owl:onProperty <http://purl.obolibrary.org/obo/RO_0000081> ;
-                                    owl:someValuesFrom [ rdf:type owl:Restriction ;
-                                                         owl:onProperty :sponsors ;
-                                                         owl:someValuesFrom <http://purl.obolibrary.org/obo/OBI_0000011>
-                                                       ]
-                                  ] ;
-              rdfs:subClassOf :AEON_0000005 ;
-              <http://purl.obolibrary.org/obo/IAO_0000115> "The sponsor role inheres in a person or organization that contributes to a planned process by providing the financial or material ressources needed to realize a planned process."@en ;
-              <http://purl.obolibrary.org/obo/IAO_0000116> "PS 2-9-2020: For me there is still the open question on how to best model the different sponsor types (e.g. gold, silver, bronze...). As the possible sponsor types can have various schemes, it seems best to have named individuals of the aeon:Sponsor class at the moment." ;
-              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"@en ;
-              rdfs:label "sponsor role"@en ;
-              :SMW_datatype "Category" ;
-              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:AEON_0000015 rdf:type owl:Class ;
+                  owl:equivalentClass [ rdf:type owl:Restriction ;
+                                        owl:onProperty obo:RO_0000081 ;
+                                        owl:someValuesFrom [ rdf:type owl:Restriction ;
+                                                             owl:onProperty aeon:sponsors ;
+                                                             owl:someValuesFrom obo:OBI_0000011
+                                                           ]
+                                      ] ;
+                  rdfs:subClassOf aeon:AEON_0000005 ;
+                  obo:IAO_0000115 "The sponsor role inheres in a person or organization that contributes to a planned process by providing the financial or material ressources needed to realize a planned process."@en ;
+                  obo:IAO_0000116 "PS 2-9-2020: For me there is still the open question on how to best model the different sponsor types (e.g. gold, silver, bronze...). As the possible sponsor types can have various schemes, it seems best to have named individuals of the aeon:Sponsor class at the moment." ;
+                  obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
+                  rdfs:label "sponsor role"@en ;
+                  aeon:SMW_datatype "Category" ;
+                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000016
-:AEON_0000016 rdf:type owl:Class ;
-              rdfs:subClassOf <http://purl.obolibrary.org/obo/IAO_0020000> ;
-              <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000423> ;
-              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"@en ;
-              rdfs:label "digital object identifier"@en ;
-              :SMW_datatype "Category" ;
-              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:AEON_0000016 rdf:type owl:Class ;
+                  rdfs:subClassOf obo:IAO_0020000 ;
+                  obo:IAO_0000114 obo:IAO_0000423 ;
+                  obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
+                  rdfs:label "digital object identifier"@en ;
+                  aeon:SMW_datatype "Category" ;
+                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000017
-:AEON_0000017 rdf:type owl:Class ;
-              rdfs:subClassOf <http://purl.obolibrary.org/obo/IAO_0000578> ;
-              <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000423> ;
-              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert" ;
-              rdfs:label "GND ID" ;
-              :SMW_datatype "Category" ;
-              :SMW_import_info """[[partOfSubobject::Template:Subobject External_Process_ID]]
+aeon:AEON_0000017 rdf:type owl:Class ;
+                  rdfs:subClassOf obo:IAO_0000578 ;
+                  obo:IAO_0000114 obo:IAO_0000423 ;
+                  obo:IAO_0000117 "PERSON: Philip Strömert" ;
+                  rdfs:label "GND ID" ;
+                  aeon:SMW_datatype "Category" ;
+                  aeon:SMW_import_info """[[partOfSubobject::Template:Subobject External_Process_ID]]
 [[partOfSubobject::Template:Subobject Person_ID]]
 [[partOfSubobject::Template:Subobject Organization_ID]]
 
@@ -3095,51 +3101,51 @@ See the [SKOS-PRIMER] for more examples of identifying and describing SKOS conce
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000018
-:AEON_0000018 rdf:type owl:Class ;
-              rdfs:subClassOf <http://purl.obolibrary.org/obo/IAO_0000578> ;
-              <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000423> ;
-              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert" ;
-              rdfs:label "ISNI" ;
-              :SMW_datatype "Category" ;
-              :SMW_import_info """[[partOfSubobject::Template:Subobject Person_ID]]
+aeon:AEON_0000018 rdf:type owl:Class ;
+                  rdfs:subClassOf obo:IAO_0000578 ;
+                  obo:IAO_0000114 obo:IAO_0000423 ;
+                  obo:IAO_0000117 "PERSON: Philip Strömert" ;
+                  rdfs:label "ISNI" ;
+                  aeon:SMW_datatype "Category" ;
+                  aeon:SMW_import_info """[[partOfSubobject::Template:Subobject Person_ID]]
 [[partOfSubobject::Template:Subobject Organization_ID]]
 
 [[Category:AEON]] [[Category:Imported vocabulary]]""" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000019
-:AEON_0000019 rdf:type owl:Class ;
-              rdfs:subClassOf <http://purl.obolibrary.org/obo/IAO_0000578> ;
-              <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000423> ;
-              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert" ;
-              rdfs:label "ORCID" ;
-              :SMW_datatype "Category" ;
-              :SMW_import_info """[[partOfSubobject::Template:Subobject Person_ID]]
+aeon:AEON_0000019 rdf:type owl:Class ;
+                  rdfs:subClassOf obo:IAO_0000578 ;
+                  obo:IAO_0000114 obo:IAO_0000423 ;
+                  obo:IAO_0000117 "PERSON: Philip Strömert" ;
+                  rdfs:label "ORCID" ;
+                  aeon:SMW_datatype "Category" ;
+                  aeon:SMW_import_info """[[partOfSubobject::Template:Subobject Person_ID]]
 
 [[Category:AEON]] [[Category:Imported vocabulary]]""" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000020
-:AEON_0000020 rdf:type owl:Class ;
-              rdfs:subClassOf <http://purl.obolibrary.org/obo/IAO_0000578> ;
-              <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000423> ;
-              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert" ;
-              rdfs:label "ROR ID" ;
-              :SMW_datatype "Category" ;
-              :SMW_import_info """[[partOfSubobject::Template:Subobject Organization_ID]]
+aeon:AEON_0000020 rdf:type owl:Class ;
+                  rdfs:subClassOf obo:IAO_0000578 ;
+                  obo:IAO_0000114 obo:IAO_0000423 ;
+                  obo:IAO_0000117 "PERSON: Philip Strömert" ;
+                  rdfs:label "ROR ID" ;
+                  aeon:SMW_datatype "Category" ;
+                  aeon:SMW_import_info """[[partOfSubobject::Template:Subobject Organization_ID]]
 
 [[Category:AEON]] [[Category:Imported vocabulary]]""" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000021
-:AEON_0000021 rdf:type owl:Class ;
-              rdfs:subClassOf <http://purl.obolibrary.org/obo/IAO_0000578> ;
-              <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000423> ;
-              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert" ;
-              <http://purl.obolibrary.org/obo/IAO_0006011> "\"https://www.wikidata.org/wiki/\"^^ xsd:anyURI"@en ;
-              rdfs:label "Wikidata QID"@en ;
-              :SMW_datatype "Category" ;
-              :SMW_import_info """[[partOfSubobject::Template:Subobject Process_External_ID]]
+aeon:AEON_0000021 rdf:type owl:Class ;
+                  rdfs:subClassOf obo:IAO_0000578 ;
+                  obo:IAO_0000114 obo:IAO_0000423 ;
+                  obo:IAO_0000117 "PERSON: Philip Strömert" ;
+                  obo:IAO_0006011 "\"https://www.wikidata.org/wiki/\"^^ xsd:anyURI"@en ;
+                  rdfs:label "Wikidata QID"@en ;
+                  aeon:SMW_datatype "Category" ;
+                  aeon:SMW_import_info """[[partOfSubobject::Template:Subobject Process_External_ID]]
 [[partOfSubobject::Template:Subobject Person_ID]]
 [[partOfSubobject::Template:Subobject Organization_ID]]
 
@@ -3147,77 +3153,77 @@ See the [SKOS-PRIMER] for more examples of identifying and describing SKOS conce
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000022
-:AEON_0000022 rdf:type owl:Class ;
-              rdfs:subClassOf <http://purl.obolibrary.org/obo/GAZ_00000448> ;
-              rdfs:label "city"@en ;
-              :SMW_datatype "Category" ;
-              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:AEON_0000022 rdf:type owl:Class ;
+                  rdfs:subClassOf obo:GAZ_00000448 ;
+                  rdfs:label "city"@en ;
+                  aeon:SMW_datatype "Category" ;
+                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000023
-:AEON_0000023 rdf:type owl:Class ;
-              rdfs:subClassOf <http://purl.obolibrary.org/obo/GAZ_00000448> ;
-              rdfs:label "country"@en ;
-              :SMW_datatype "Category" ;
-              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:AEON_0000023 rdf:type owl:Class ;
+                  rdfs:subClassOf obo:GAZ_00000448 ;
+                  rdfs:label "country"@en ;
+                  aeon:SMW_datatype "Category" ;
+                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000024
-:AEON_0000024 rdf:type owl:Class ;
-              rdfs:subClassOf <http://purl.obolibrary.org/obo/GAZ_00000448> ;
-              <http://purl.obolibrary.org/obo/IAO_0000118> "province"@en ;
-              rdfs:label "state"@en ;
-              :SMW_datatype "Category" ;
-              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:AEON_0000024 rdf:type owl:Class ;
+                  rdfs:subClassOf obo:GAZ_00000448 ;
+                  obo:IAO_0000118 "province"@en ;
+                  rdfs:label "state"@en ;
+                  aeon:SMW_datatype "Category" ;
+                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000025
-:AEON_0000025 rdf:type owl:Class ;
-              rdfs:subClassOf <http://purl.obolibrary.org/obo/GAZ_00000448> ;
-              rdfs:label "event venue"@en ;
-              :SMW_datatype "Category" ;
-              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:AEON_0000025 rdf:type owl:Class ;
+                  rdfs:subClassOf obo:GAZ_00000448 ;
+                  rdfs:label "event venue"@en ;
+                  aeon:SMW_datatype "Category" ;
+                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000027
-:AEON_0000027 rdf:type owl:Class ;
-              rdfs:subClassOf <http://www.w3.org/2004/02/skos/core#Concept> ;
-              <http://purl.obolibrary.org/obo/IAO_0000112> "DDC 410 Linguistics, OECD 6.02 Languages and literature"@en ;
-              <http://purl.obolibrary.org/obo/IAO_0000115> "'academic field' is a skos:Concept that describes the research field of an academic event or event series. As opposed to the class 'topic', the instances of this class must be terms from a controlled vocabulary or thesaurus."@en ;
-              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert" ;
-              rdfs:label "academic field"@en ;
-              :SMW_datatype "Category" ;
-              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:AEON_0000027 rdf:type owl:Class ;
+                  rdfs:subClassOf skos:Concept ;
+                  obo:IAO_0000112 "DDC 410 Linguistics, OECD 6.02 Languages and literature"@en ;
+                  obo:IAO_0000115 "'academic field' is a skos:Concept that describes the research field of an academic event or event series. As opposed to the class 'topic', the instances of this class must be terms from a controlled vocabulary or thesaurus."@en ;
+                  obo:IAO_0000117 "PERSON: Philip Strömert" ;
+                  rdfs:label "academic field"@en ;
+                  aeon:SMW_datatype "Category" ;
+                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000028
-:AEON_0000028 rdf:type owl:Class ;
-              rdfs:subClassOf <http://www.w3.org/2004/02/skos/core#Concept> ;
-              <http://purl.obolibrary.org/obo/IAO_0000112> "\"The future of knowlegde graphs in the humanities\" could be a topic of an interdisciplinary oriented computer sciences conference."@en ;
-              <http://purl.obolibrary.org/obo/IAO_0000115> "Topic is a skos:Concept that describes the central theme of an academic event or event series. In contrast to 'academic field' the instances of the class topic should not be terms of a controlled vocabulary or thesaurus."@en ;
-              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert" ;
-              rdfs:label "topic"@en .
+aeon:AEON_0000028 rdf:type owl:Class ;
+                  rdfs:subClassOf skos:Concept ;
+                  obo:IAO_0000112 "\"The future of knowlegde graphs in the humanities\" could be a topic of an interdisciplinary oriented computer sciences conference."@en ;
+                  obo:IAO_0000115 "Topic is a skos:Concept that describes the central theme of an academic event or event series. In contrast to 'academic field' the instances of the class topic should not be terms of a controlled vocabulary or thesaurus."@en ;
+                  obo:IAO_0000117 "PERSON: Philip Strömert" ;
+                  rdfs:label "topic"@en .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000029
-:AEON_0000029 rdf:type owl:Class ;
-              rdfs:subClassOf <http://purl.obolibrary.org/obo/BFO_0000029> ;
-              <http://purl.obolibrary.org/obo/IAO_0000117> "Philip Strömert"^^xsd:string ;
-              <http://purl.org/dc/elements/1.1/date> "2020-10-14T15:31:27Z"^^xsd:dateTime ;
-              rdfs:label "virtual location"@en ;
-              :SMW_datatype "Category" ;
-              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:AEON_0000029 rdf:type owl:Class ;
+                  rdfs:subClassOf obo:BFO_0000029 ;
+                  obo:IAO_0000117 "Philip Strömert"^^xsd:string ;
+                  <http://purl.org/dc/elements/1.1/date> "2020-10-14T15:31:27Z"^^xsd:dateTime ;
+                  rdfs:label "virtual location"@en ;
+                  aeon:SMW_datatype "Category" ;
+                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000030
-:AEON_0000030 rdf:type owl:Class ;
-              rdfs:subClassOf <http://purl.obolibrary.org/obo/IAO_0000030> ;
-              <http://purl.obolibrary.org/obo/IAO_0000115> "The financial cost of attendance at a scientific event."@en ;
-              <http://purl.obolibrary.org/obo/IAO_0000116> "PS: It needs to be discussed, if having fee as ICE is sufficient/correct."@en ;
-              <http://purl.obolibrary.org/obo/IAO_0000117> "Philip Strömert"^^xsd:string ;
-              rdfs:label "fee"@en ;
-              :SMW_datatype "Category" ;
-              :SMW_import_info """The individuals/instances of this class make up the allowed value list in [[MediaWiki:Smw_allows_list_Has_fee]].
+aeon:AEON_0000030 rdf:type owl:Class ;
+                  rdfs:subClassOf obo:IAO_0000030 ;
+                  obo:IAO_0000115 "The financial cost of attendance at a scientific event."@en ;
+                  obo:IAO_0000116 "PS: It needs to be discussed, if having fee as ICE is sufficient/correct."@en ;
+                  obo:IAO_0000117 "Philip Strömert"^^xsd:string ;
+                  rdfs:label "fee"@en ;
+                  aeon:SMW_datatype "Category" ;
+                  aeon:SMW_import_info """The individuals/instances of this class make up the allowed value list in [[MediaWiki:Smw_allows_list_Has_fee]].
 
 [[partOfSubobject::Template:Subobject Fee]]
 
@@ -3225,364 +3231,364 @@ See the [SKOS-PRIMER] for more examples of identifying and describing SKOS conce
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000034
-:AEON_0000034 rdf:type owl:Class ;
-              rdfs:subClassOf <http://purl.obolibrary.org/obo/IAO_0020000> ;
-              <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000423> ;
-              <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert" ;
-              <http://purl.org/dc/elements/1.1/date> "2020-11-20T17:31:33Z"^^xsd:dateTime ;
-              rdfs:label "distributed identifier"@en .
+aeon:AEON_0000034 rdf:type owl:Class ;
+                  rdfs:subClassOf obo:IAO_0020000 ;
+                  obo:IAO_0000114 obo:IAO_0000423 ;
+                  obo:IAO_0000117 "PERSON: Philip Strömert" ;
+                  <http://purl.org/dc/elements/1.1/date> "2020-11-20T17:31:33Z"^^xsd:dateTime ;
+                  rdfs:label "distributed identifier"@en .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000042
-:AEON_0000042 rdf:type owl:Class ;
-              rdfs:subClassOf <http://purl.obolibrary.org/obo/BFO_0000027> ;
-              <http://purl.obolibrary.org/obo/IAO_0000600> "An academic event committee or commission is a body of one or more persons that is responsible for the realization of a certain task or aspect in an academic event."@en ;
-              rdfs:label "event committee"@en ;
-              <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "pending"@en ;
-              :SMW_datatype "Category" ;
-              :SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+aeon:AEON_0000042 rdf:type owl:Class ;
+                  rdfs:subClassOf obo:BFO_0000027 ;
+                  obo:IAO_0000600 "An academic event committee or commission is a body of one or more persons that is responsible for the realization of a certain task or aspect in an academic event."@en ;
+                  rdfs:label "event committee"@en ;
+                  ns:term_status "pending"@en ;
+                  aeon:SMW_datatype "Category" ;
+                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
 
 
 ###  https://github.com/tibonto/aeon#attendee
-:attendee rdf:type owl:Class ;
-          owl:equivalentClass [ rdf:type owl:Restriction ;
-                                owl:onProperty <http://purl.obolibrary.org/obo/RO_0000087> ;
-                                owl:someValuesFrom [ owl:intersectionOf ( :AEON_0000010
-                                                                          [ rdf:type owl:Restriction ;
-                                                                            owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000054> ;
-                                                                            owl:someValuesFrom <http://purl.obolibrary.org/obo/OBI_0000011>
-                                                                          ]
-                                                                        ) ;
-                                                     rdf:type owl:Class
-                                                   ]
-                              ] ;
-          rdfs:subClassOf :contributor ;
-          <http://purl.obolibrary.org/obo/IAO_0000112> "Philip Strömert is an attendee of PIDapalooza 2021."@en ;
-          <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000423> ;
-          <http://purl.obolibrary.org/obo/IAO_0000115> "An attendee is a contributer that holds an attendee role which is being realized in a planned process."@en ;
-          <http://purl.obolibrary.org/obo/IAO_0000116> """The general assumption is that the attendee role is being realized the moment someone shows up to an event which she is expected to participate in as part of an audience. Someone who plans to attend some academic event but never shows up during this event, would not be considered an attendee of the event.
+aeon:attendee rdf:type owl:Class ;
+              owl:equivalentClass [ rdf:type owl:Restriction ;
+                                    owl:onProperty obo:RO_0000087 ;
+                                    owl:someValuesFrom [ owl:intersectionOf ( aeon:AEON_0000010
+                                                                              [ rdf:type owl:Restriction ;
+                                                                                owl:onProperty obo:BFO_0000054 ;
+                                                                                owl:someValuesFrom obo:OBI_0000011
+                                                                              ]
+                                                                            ) ;
+                                                         rdf:type owl:Class
+                                                       ]
+                                  ] ;
+              rdfs:subClassOf aeon:contributor ;
+              obo:IAO_0000112 "Philip Strömert is an attendee of PIDapalooza 2021."@en ;
+              obo:IAO_0000114 obo:IAO_0000423 ;
+              obo:IAO_0000115 "An attendee is a contributer that holds an attendee role which is being realized in a planned process."@en ;
+              obo:IAO_0000116 """The general assumption is that the attendee role is being realized the moment someone shows up to an event which she is expected to participate in as part of an audience. Someone who plans to attend some academic event but never shows up during this event, would not be considered an attendee of the event.
 
 Defining 'attendee' is not trivial, as the expectations of what an attendee must do, can differ from community to community and from event type to event type. For some an attendee must have been accredited by some official organizer and might only get a certificate of attendence at the end of it, when a certain amount of participation (e.g. visited sessions, completed workshops) has been achieved. For others it might suffice to simple be present."""@en ,
-                                                       "We need this concept of an attendee in order to be able to properly quantify the participation in a planned process. For this we would also need to have an action specification that is the conretizaion of the attendee role."@en ;
-          <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string ;
-          <http://purl.obolibrary.org/obo/IAO_0000600> "A person who participates actively or passively in an event."@en ;
-          rdfs:label "attendee"@en .
+                              "We need this concept of an attendee in order to be able to properly quantify the participation in a planned process. For this we would also need to have an action specification that is the conretizaion of the attendee role."@en ;
+              obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string ;
+              obo:IAO_0000600 "A person who participates actively or passively in an event."@en ;
+              rdfs:label "attendee"@en .
 
 
 ###  https://github.com/tibonto/aeon#committee_chair
-:committee_chair rdf:type owl:Class ;
-                 owl:equivalentClass [ owl:intersectionOf ( [ rdf:type owl:Restriction ;
-                                                              owl:onProperty <http://purl.obolibrary.org/obo/RO_0000087> ;
-                                                              owl:someValuesFrom [ owl:intersectionOf ( :AEON_0000008
+aeon:committee_chair rdf:type owl:Class ;
+                     owl:equivalentClass [ owl:intersectionOf ( [ rdf:type owl:Restriction ;
+                                                                  owl:onProperty obo:RO_0000087 ;
+                                                                  owl:someValuesFrom [ owl:intersectionOf ( aeon:AEON_0000008
+                                                                                                            [ rdf:type owl:Restriction ;
+                                                                                                              owl:onProperty obo:BFO_0000054 ;
+                                                                                                              owl:someValuesFrom obo:OBI_0000011
+                                                                                                            ]
+                                                                                                          ) ;
+                                                                                       rdf:type owl:Class
+                                                                                     ]
+                                                                ]
+                                                                [ rdf:type owl:Restriction ;
+                                                                  owl:onProperty obo:RO_0002350 ;
+                                                                  owl:someValuesFrom aeon:AEON_0000042
+                                                                ]
+                                                              ) ;
+                                           rdf:type owl:Class
+                                         ] ;
+                     rdfs:subClassOf aeon:committee_member ;
+                     obo:IAO_0000114 obo:IAO_0000423 ;
+                     obo:IAO_0000115 "A committee chair is a committee member that holds a committee chair role which is being realized in a planned process."@en ;
+                     obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string ;
+                     obo:IAO_0000600 "A committee chair is a committe member that is expected to speak on behalf of and to be responsible for the committee."@en ,
+                                     "The person who is in charge of a committee with primary responsibility for carrying out the committee's duties."@en ;
+                     rdfs:label "event committee chair"@en .
+
+
+###  https://github.com/tibonto/aeon#committee_member
+aeon:committee_member rdf:type owl:Class ;
+                      owl:equivalentClass [ owl:intersectionOf ( [ rdf:type owl:Restriction ;
+                                                                   owl:onProperty obo:RO_0000087 ;
+                                                                   owl:someValuesFrom [ owl:intersectionOf ( aeon:AEON_0000007
+                                                                                                             [ rdf:type owl:Restriction ;
+                                                                                                               owl:onProperty obo:BFO_0000054 ;
+                                                                                                               owl:someValuesFrom obo:OBI_0000011
+                                                                                                             ]
+                                                                                                           ) ;
+                                                                                        rdf:type owl:Class
+                                                                                      ]
+                                                                 ]
+                                                                 [ rdf:type owl:Restriction ;
+                                                                   owl:onProperty obo:RO_0002350 ;
+                                                                   owl:someValuesFrom aeon:AEON_0000042
+                                                                 ]
+                                                               ) ;
+                                            rdf:type owl:Class
+                                          ] ;
+                      rdfs:subClassOf aeon:organizer ,
+                                      [ rdf:type owl:Restriction ;
+                                        owl:onProperty obo:RO_0002350 ;
+                                        owl:someValuesFrom aeon:AEON_0000042
+                                      ] ;
+                      obo:IAO_0000114 obo:IAO_0000423 ;
+                      obo:IAO_0000115 "A committee member is an organizer that holds a committee member role which is being realized in a planned process."@en ;
+                      obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string ;
+                      rdfs:label "event committee member"@en .
+
+
+###  https://github.com/tibonto/aeon#contact_person
+aeon:contact_person rdf:type owl:Class ;
+                    owl:equivalentClass [ rdf:type owl:Restriction ;
+                                          owl:onProperty obo:RO_0000087 ;
+                                          owl:someValuesFrom [ owl:intersectionOf ( aeon:AEON_0000009
+                                                                                    [ rdf:type owl:Restriction ;
+                                                                                      owl:onProperty obo:BFO_0000054 ;
+                                                                                      owl:someValuesFrom obo:OBI_0000011
+                                                                                    ]
+                                                                                  ) ;
+                                                               rdf:type owl:Class
+                                                             ]
+                                        ] ;
+                    rdfs:subClassOf aeon:organizer ;
+                    obo:IAO_0000114 obo:IAO_0000423 ;
+                    obo:IAO_0000115 "A contact person is an organizer that holds a contact person role which is being realized in a planned process."@en ;
+                    obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string ;
+                    obo:IAO_0000600 "A contact peron is defined by its role to be the person who answers general questions about a planned process and who forwards any further inquiries to the appropriate recipiant."@en ;
+                    rdfs:label "contact person"@en .
+
+
+###  https://github.com/tibonto/aeon#contributor
+aeon:contributor rdf:type owl:Class ;
+                 owl:equivalentClass [ owl:intersectionOf ( [ rdf:type owl:Class ;
+                                                              owl:unionOf ( obo:NCBITaxon_9606
+                                                                            obo:OBI_0000245
+                                                                          )
+                                                            ]
+                                                            [ rdf:type owl:Restriction ;
+                                                              owl:onProperty obo:RO_0000087 ;
+                                                              owl:someValuesFrom [ owl:intersectionOf ( aeon:AEON_0000005
                                                                                                         [ rdf:type owl:Restriction ;
-                                                                                                          owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000054> ;
-                                                                                                          owl:someValuesFrom <http://purl.obolibrary.org/obo/OBI_0000011>
+                                                                                                          owl:onProperty obo:BFO_0000054 ;
+                                                                                                          owl:someValuesFrom obo:OBI_0000011
                                                                                                         ]
                                                                                                       ) ;
                                                                                    rdf:type owl:Class
                                                                                  ]
                                                             ]
-                                                            [ rdf:type owl:Restriction ;
-                                                              owl:onProperty <http://purl.obolibrary.org/obo/RO_0002350> ;
-                                                              owl:someValuesFrom :AEON_0000042
-                                                            ]
                                                           ) ;
                                        rdf:type owl:Class
                                      ] ;
-                 rdfs:subClassOf :committee_member ;
-                 <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000423> ;
-                 <http://purl.obolibrary.org/obo/IAO_0000115> "A committee chair is a committee member that holds a committee chair role which is being realized in a planned process."@en ;
-                 <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string ;
-                 <http://purl.obolibrary.org/obo/IAO_0000600> "A committee chair is a committe member that is expected to speak on behalf of and to be responsible for the committee."@en ,
-                                                              "The person who is in charge of a committee with primary responsibility for carrying out the committee's duties."@en ;
-                 rdfs:label "event committee chair"@en .
-
-
-###  https://github.com/tibonto/aeon#committee_member
-:committee_member rdf:type owl:Class ;
-                  owl:equivalentClass [ owl:intersectionOf ( [ rdf:type owl:Restriction ;
-                                                               owl:onProperty <http://purl.obolibrary.org/obo/RO_0000087> ;
-                                                               owl:someValuesFrom [ owl:intersectionOf ( :AEON_0000007
-                                                                                                         [ rdf:type owl:Restriction ;
-                                                                                                           owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000054> ;
-                                                                                                           owl:someValuesFrom <http://purl.obolibrary.org/obo/OBI_0000011>
-                                                                                                         ]
-                                                                                                       ) ;
-                                                                                    rdf:type owl:Class
-                                                                                  ]
-                                                             ]
-                                                             [ rdf:type owl:Restriction ;
-                                                               owl:onProperty <http://purl.obolibrary.org/obo/RO_0002350> ;
-                                                               owl:someValuesFrom :AEON_0000042
-                                                             ]
-                                                           ) ;
-                                        rdf:type owl:Class
-                                      ] ;
-                  rdfs:subClassOf :organizer ,
-                                  [ rdf:type owl:Restriction ;
-                                    owl:onProperty <http://purl.obolibrary.org/obo/RO_0002350> ;
-                                    owl:someValuesFrom :AEON_0000042
-                                  ] ;
-                  <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000423> ;
-                  <http://purl.obolibrary.org/obo/IAO_0000115> "A committee member is an organizer that holds a committee member role which is being realized in a planned process."@en ;
-                  <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string ;
-                  rdfs:label "event committee member"@en .
-
-
-###  https://github.com/tibonto/aeon#contact_person
-:contact_person rdf:type owl:Class ;
-                owl:equivalentClass [ rdf:type owl:Restriction ;
-                                      owl:onProperty <http://purl.obolibrary.org/obo/RO_0000087> ;
-                                      owl:someValuesFrom [ owl:intersectionOf ( :AEON_0000009
-                                                                                [ rdf:type owl:Restriction ;
-                                                                                  owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000054> ;
-                                                                                  owl:someValuesFrom <http://purl.obolibrary.org/obo/OBI_0000011>
-                                                                                ]
-                                                                              ) ;
-                                                           rdf:type owl:Class
-                                                         ]
-                                    ] ;
-                rdfs:subClassOf :organizer ;
-                <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000423> ;
-                <http://purl.obolibrary.org/obo/IAO_0000115> "A contact person is an organizer that holds a contact person role which is being realized in a planned process."@en ;
-                <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string ;
-                <http://purl.obolibrary.org/obo/IAO_0000600> "A contact peron is defined by its role to be the person who answers general questions about a planned process and who forwards any further inquiries to the appropriate recipiant."@en ;
-                rdfs:label "contact person"@en .
-
-
-###  https://github.com/tibonto/aeon#contributor
-:contributor rdf:type owl:Class ;
-             owl:equivalentClass [ owl:intersectionOf ( [ rdf:type owl:Class ;
-                                                          owl:unionOf ( <http://purl.obolibrary.org/obo/NCBITaxon_9606>
-                                                                        <http://purl.obolibrary.org/obo/OBI_0000245>
-                                                                      )
-                                                        ]
-                                                        [ rdf:type owl:Restriction ;
-                                                          owl:onProperty <http://purl.obolibrary.org/obo/RO_0000087> ;
-                                                          owl:someValuesFrom [ owl:intersectionOf ( :AEON_0000005
-                                                                                                    [ rdf:type owl:Restriction ;
-                                                                                                      owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000054> ;
-                                                                                                      owl:someValuesFrom <http://purl.obolibrary.org/obo/OBI_0000011>
-                                                                                                    ]
-                                                                                                  ) ;
-                                                                               rdf:type owl:Class
-                                                                             ]
-                                                        ]
-                                                      ) ;
-                                   rdf:type owl:Class
-                                 ] ;
-             rdfs:subClassOf <http://purl.obolibrary.org/obo/BFO_0000040> ;
-             <http://purl.obolibrary.org/obo/IAO_0000112> "All organizers and participants of the academic event called PIDapalooza 2020 are contributors of that particular event.."@en ;
-             <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000423> ;
-             <http://purl.obolibrary.org/obo/IAO_0000115> "A contributor is a person or organization that holds a contributor role which is being realized in a planned process."@en ;
-             <http://purl.obolibrary.org/obo/IAO_0000116> ""@en ,
-                                                          "An academic conference is being realized by the contributions of different kinds of people and organizations. The organizers plan the program and manage the needed logistics. The sponsors provide the resources and funds needed for the realization. The speakers contribute by presenting their academic work. The reviewers make sure the submitted work is worth to be presented. The moderators make sure that the mode of communication is caried out as planned by the organizer. The attendees contribute by being there as the audience, providing feedback and by making up the pool of possible future collaborators."@en ,
-                                                          """This class and its children should be defined in an ontology that covers the domain of contributorship in the sciences. 
+                 rdfs:subClassOf obo:BFO_0000040 ;
+                 obo:IAO_0000112 "All organizers and participants of the academic event called PIDapalooza 2020 are contributors of that particular event.."@en ;
+                 obo:IAO_0000114 obo:IAO_0000423 ;
+                 obo:IAO_0000115 "A contributor is a person or organization that holds a contributor role which is being realized in a planned process."@en ;
+                 obo:IAO_0000116 ""@en ,
+                                 "An academic conference is being realized by the contributions of different kinds of people and organizations. The organizers plan the program and manage the needed logistics. The sponsors provide the resources and funds needed for the realization. The speakers contribute by presenting their academic work. The reviewers make sure the submitted work is worth to be presented. The moderators make sure that the mode of communication is caried out as planned by the organizer. The attendees contribute by being there as the audience, providing feedback and by making up the pool of possible future collaborators."@en ,
+                                 """This class and its children should be defined in an ontology that covers the domain of contributorship in the sciences. 
 The contributor ontology (CRO - http://purl.obolibrary.org/obo/cro.owl) seems to be the best place. However at the moment CRO only covers \"the diverse roles performed in the work leading to a published research output in the sciences.\" An academic event or event series should ot be understood as a published research output, as they are procceses (occurents) and not ICEs."""@en ;
-             <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string ;
-             <http://purl.obolibrary.org/obo/IAO_0000600> "A person or organization can only be considered a contributor of some planned process, if and only if the act of contributing has been fulfilled. The contributor role is being realized, when the task (objective specification) attached to this role has been achieved somehow. It can thus be possible for a person or organization to hold multiple roles either in the same or in different planned processes."@en ;
-             rdfs:label "contributor"@en ;
-             <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> "TODO: There needs to be an ICE branch in AEON covering the action and objective specifications which the various contributors have to concretize when realizing their roles. The concretization of these specification calsses needs to be axiomized here and in the various contributor roles."@en .
+                 obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string ;
+                 obo:IAO_0000600 "A person or organization can only be considered a contributor of some planned process, if and only if the act of contributing has been fulfilled. The contributor role is being realized, when the task (objective specification) attached to this role has been achieved somehow. It can thus be possible for a person or organization to hold multiple roles either in the same or in different planned processes."@en ;
+                 rdfs:label "contributor"@en ;
+                 ns:term_status "TODO: There needs to be an ICE branch in AEON covering the action and objective specifications which the various contributors have to concretize when realizing their roles. The concretization of these specification calsses needs to be axiomized here and in the various contributor roles."@en .
 
 
 ###  https://github.com/tibonto/aeon#finance_committee
-:finance_committee rdf:type owl:Class ;
-                   rdfs:subClassOf :AEON_0000042 ;
-                   <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string ;
-                   <http://purl.obolibrary.org/obo/IAO_0000600> "The finance committee has the task of monitoring the budget of an academic event."@en ;
-                   rdfs:label "event finance committee"@en .
+aeon:finance_committee rdf:type owl:Class ;
+                       rdfs:subClassOf aeon:AEON_0000042 ;
+                       obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string ;
+                       obo:IAO_0000600 "The finance committee has the task of monitoring the budget of an academic event."@en ;
+                       rdfs:label "event finance committee"@en .
 
 
 ###  https://github.com/tibonto/aeon#general_committee
-:general_committee rdf:type owl:Class ;
-                   rdfs:subClassOf :AEON_0000042 ;
-                   <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string ;
-                   <http://purl.obolibrary.org/obo/IAO_0000118> "steering committee"@en ;
-                   <http://purl.obolibrary.org/obo/IAO_0000600> "The general or steering committee is responsible for the entire conceptual design of an academic event, from decisions on the content focus, budget, size, choice of venue and time, selection of other responsible persons, etc."@en ;
-                   rdfs:label "general committee"@en .
+aeon:general_committee rdf:type owl:Class ;
+                       rdfs:subClassOf aeon:AEON_0000042 ;
+                       obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string ;
+                       obo:IAO_0000118 "steering committee"@en ;
+                       obo:IAO_0000600 "The general or steering committee is responsible for the entire conceptual design of an academic event, from decisions on the content focus, budget, size, choice of venue and time, selection of other responsible persons, etc."@en ;
+                       rdfs:label "general committee"@en .
 
 
 ###  https://github.com/tibonto/aeon#keynote_speaker
-:keynote_speaker rdf:type owl:Class ;
-                 owl:equivalentClass [ rdf:type owl:Restriction ;
-                                       owl:onProperty <http://purl.obolibrary.org/obo/RO_0000087> ;
-                                       owl:someValuesFrom [ owl:intersectionOf ( :AEON_0000014
-                                                                                 [ rdf:type owl:Restriction ;
-                                                                                   owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000054> ;
-                                                                                   owl:someValuesFrom <http://purl.obolibrary.org/obo/OBI_0000011>
-                                                                                 ]
-                                                                               ) ;
-                                                            rdf:type owl:Class
-                                                          ]
-                                     ] ;
-                 rdfs:subClassOf :speaker ;
-                 <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000423> ;
-                 <http://purl.obolibrary.org/obo/IAO_0000115> "A 'keynote speaker' is a presenter that holds a keynote speaker role which is being realized in a planned process."@en ;
-                 <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string ;
-                 <http://purl.obolibrary.org/obo/IAO_0000600> "An invited person - often a multiplier in his or her (research) field - responsible for delivering a keynote speech."@en ;
-                 rdfs:label "keynote speaker"@en .
+aeon:keynote_speaker rdf:type owl:Class ;
+                     owl:equivalentClass [ rdf:type owl:Restriction ;
+                                           owl:onProperty obo:RO_0000087 ;
+                                           owl:someValuesFrom [ owl:intersectionOf ( aeon:AEON_0000014
+                                                                                     [ rdf:type owl:Restriction ;
+                                                                                       owl:onProperty obo:BFO_0000054 ;
+                                                                                       owl:someValuesFrom obo:OBI_0000011
+                                                                                     ]
+                                                                                   ) ;
+                                                                rdf:type owl:Class
+                                                              ]
+                                         ] ;
+                     rdfs:subClassOf aeon:speaker ;
+                     obo:IAO_0000114 obo:IAO_0000423 ;
+                     obo:IAO_0000115 "A 'keynote speaker' is a presenter that holds a keynote speaker role which is being realized in a planned process."@en ;
+                     obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string ;
+                     obo:IAO_0000600 "An invited person - often a multiplier in his or her (research) field - responsible for delivering a keynote speech."@en ;
+                     rdfs:label "keynote speaker"@en .
 
 
 ###  https://github.com/tibonto/aeon#local_committee
-:local_committee rdf:type owl:Class ;
-                 rdfs:subClassOf :AEON_0000042 ;
-                 <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string ;
-                 <http://purl.obolibrary.org/obo/IAO_0000600> "The local committee takes care of planning, organizing and carrying out an academic event on site (venue, registration, supply, accommodations etc.)"@en ;
-                 rdfs:label "local committee"@en .
+aeon:local_committee rdf:type owl:Class ;
+                     rdfs:subClassOf aeon:AEON_0000042 ;
+                     obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string ;
+                     obo:IAO_0000600 "The local committee takes care of planning, organizing and carrying out an academic event on site (venue, registration, supply, accommodations etc.)"@en ;
+                     rdfs:label "local committee"@en .
 
 
 ###  https://github.com/tibonto/aeon#moderator
-:moderator rdf:type owl:Class ;
-           owl:equivalentClass [ rdf:type owl:Restriction ;
-                                 owl:onProperty <http://purl.obolibrary.org/obo/RO_0000087> ;
-                                 owl:someValuesFrom [ owl:intersectionOf ( :AEON_0000011
-                                                                           [ rdf:type owl:Restriction ;
-                                                                             owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000054> ;
-                                                                             owl:someValuesFrom <http://purl.obolibrary.org/obo/OBI_0000011>
-                                                                           ]
-                                                                         ) ;
-                                                      rdf:type owl:Class
-                                                    ]
-                               ] ;
-           rdfs:subClassOf :contributor ;
-           <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000423> ;
-           <http://purl.obolibrary.org/obo/IAO_0000115> "A moderator is a contributer that holds a moderating role which is being realized in a planned process."@en ;
-           <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string ;
-           <http://purl.obolibrary.org/obo/IAO_0000600> "A person responsible for facilitating a session at an academic event."@en ;
-           rdfs:label "moderator"@en .
+aeon:moderator rdf:type owl:Class ;
+               owl:equivalentClass [ rdf:type owl:Restriction ;
+                                     owl:onProperty obo:RO_0000087 ;
+                                     owl:someValuesFrom [ owl:intersectionOf ( aeon:AEON_0000011
+                                                                               [ rdf:type owl:Restriction ;
+                                                                                 owl:onProperty obo:BFO_0000054 ;
+                                                                                 owl:someValuesFrom obo:OBI_0000011
+                                                                               ]
+                                                                             ) ;
+                                                          rdf:type owl:Class
+                                                        ]
+                                   ] ;
+               rdfs:subClassOf aeon:contributor ;
+               obo:IAO_0000114 obo:IAO_0000423 ;
+               obo:IAO_0000115 "A moderator is a contributer that holds a moderating role which is being realized in a planned process."@en ;
+               obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string ;
+               obo:IAO_0000600 "A person responsible for facilitating a session at an academic event."@en ;
+               rdfs:label "moderator"@en .
 
 
 ###  https://github.com/tibonto/aeon#organizer
-:organizer rdf:type owl:Class ;
-           owl:equivalentClass [ rdf:type owl:Restriction ;
-                                 owl:onProperty <http://purl.obolibrary.org/obo/RO_0000087> ;
-                                 owl:someValuesFrom [ owl:intersectionOf ( :AEON_0000006
-                                                                           [ rdf:type owl:Restriction ;
-                                                                             owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000054> ;
-                                                                             owl:someValuesFrom <http://purl.obolibrary.org/obo/OBI_0000011>
-                                                                           ]
-                                                                         ) ;
-                                                      rdf:type owl:Class
-                                                    ]
-                               ] ;
-           rdfs:subClassOf :contributor ;
-           <http://purl.obolibrary.org/obo/IAO_0000112> "DataCite is an organizer of PIDapalooza 2020."@en ,
-                                                        "Organizers of academic events or event series are often organizations that form special taks forces, or event committees, in order to plan and manage all aspects related to the realization of the event or event series." ;
-           <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000423> ;
-           <http://purl.obolibrary.org/obo/IAO_0000115> "An organizer is a contributer that holds an organizing role which is being realized in a planned process."@en ;
-           <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string ;
-           <http://purl.obolibrary.org/obo/IAO_0000600> "A person or organization that is responsible for the planning and realization of a planned process." .
+aeon:organizer rdf:type owl:Class ;
+               owl:equivalentClass [ rdf:type owl:Restriction ;
+                                     owl:onProperty obo:RO_0000087 ;
+                                     owl:someValuesFrom [ owl:intersectionOf ( aeon:AEON_0000006
+                                                                               [ rdf:type owl:Restriction ;
+                                                                                 owl:onProperty obo:BFO_0000054 ;
+                                                                                 owl:someValuesFrom obo:OBI_0000011
+                                                                               ]
+                                                                             ) ;
+                                                          rdf:type owl:Class
+                                                        ]
+                                   ] ;
+               rdfs:subClassOf aeon:contributor ;
+               obo:IAO_0000112 "DataCite is an organizer of PIDapalooza 2020."@en ,
+                               "Organizers of academic events or event series are often organizations that form special taks forces, or event committees, in order to plan and manage all aspects related to the realization of the event or event series." ;
+               obo:IAO_0000114 obo:IAO_0000423 ;
+               obo:IAO_0000115 "An organizer is a contributer that holds an organizing role which is being realized in a planned process."@en ;
+               obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string ;
+               obo:IAO_0000600 "A person or organization that is responsible for the planning and realization of a planned process." .
 
 
 ###  https://github.com/tibonto/aeon#program_committee
-:program_committee rdf:type owl:Class ;
-                   rdfs:subClassOf :AEON_0000042 ;
-                   <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string ;
-                   <http://purl.obolibrary.org/obo/IAO_0000600> "The programme committee is responsible for the selection of submissions (peer review process) and content of an academic event."@en ;
-                   rdfs:label "program committee"@en .
+aeon:program_committee rdf:type owl:Class ;
+                       rdfs:subClassOf aeon:AEON_0000042 ;
+                       obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string ;
+                       obo:IAO_0000600 "The programme committee is responsible for the selection of submissions (peer review process) and content of an academic event."@en ;
+                       rdfs:label "program committee"@en .
 
 
 ###  https://github.com/tibonto/aeon#publication_committee
-:publication_committee rdf:type owl:Class ;
-                       rdfs:subClassOf :AEON_0000042 ;
-                       <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string ;
-                       <http://purl.obolibrary.org/obo/IAO_0000600> "The publication committee deals with the publication of the proceedings of an academic event(editorial and peer review process)."@en ;
-                       rdfs:label "publication committee"@en .
+aeon:publication_committee rdf:type owl:Class ;
+                           rdfs:subClassOf aeon:AEON_0000042 ;
+                           obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string ;
+                           obo:IAO_0000600 "The publication committee deals with the publication of the proceedings of an academic event(editorial and peer review process)."@en ;
+                           rdfs:label "publication committee"@en .
 
 
 ###  https://github.com/tibonto/aeon#publicity_committee
-:publicity_committee rdf:type owl:Class ;
-                     rdfs:subClassOf :AEON_0000042 ;
-                     <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string ;
-                     <http://purl.obolibrary.org/obo/IAO_0000600> "The publicity committee is responsible for the external communication of an academic event: promotion, (social) media relations, web presence, further releases, etc."@en ;
-                     rdfs:label "publicity committee"@en .
+aeon:publicity_committee rdf:type owl:Class ;
+                         rdfs:subClassOf aeon:AEON_0000042 ;
+                         obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string ;
+                         obo:IAO_0000600 "The publicity committee is responsible for the external communication of an academic event: promotion, (social) media relations, web presence, further releases, etc."@en ;
+                         rdfs:label "publicity committee"@en .
 
 
 ###  https://github.com/tibonto/aeon#reviewer
-:reviewer rdf:type owl:Class ;
-          owl:equivalentClass [ rdf:type owl:Restriction ;
-                                owl:onProperty <http://purl.obolibrary.org/obo/RO_0000087> ;
-                                owl:someValuesFrom [ owl:intersectionOf ( :AEON_0000012
-                                                                          [ rdf:type owl:Restriction ;
-                                                                            owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000054> ;
-                                                                            owl:someValuesFrom <http://purl.obolibrary.org/obo/OBI_0000011>
-                                                                          ]
-                                                                        ) ;
-                                                     rdf:type owl:Class
-                                                   ]
-                              ] ;
-          rdfs:subClassOf :contributor ;
-          <http://purl.obolibrary.org/obo/IAO_0000112> "The reviewer of a conference who reviews the submitted papers."@en ;
-          <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000423> ;
-          <http://purl.obolibrary.org/obo/IAO_0000115> "A reviewer is a contributer that holds a reviewer role which is being realized in a planned process."@en ;
-          <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string ;
-          rdfs:label "reviewer"@en .
+aeon:reviewer rdf:type owl:Class ;
+              owl:equivalentClass [ rdf:type owl:Restriction ;
+                                    owl:onProperty obo:RO_0000087 ;
+                                    owl:someValuesFrom [ owl:intersectionOf ( aeon:AEON_0000012
+                                                                              [ rdf:type owl:Restriction ;
+                                                                                owl:onProperty obo:BFO_0000054 ;
+                                                                                owl:someValuesFrom obo:OBI_0000011
+                                                                              ]
+                                                                            ) ;
+                                                         rdf:type owl:Class
+                                                       ]
+                                  ] ;
+              rdfs:subClassOf aeon:contributor ;
+              obo:IAO_0000112 "The reviewer of a conference who reviews the submitted papers."@en ;
+              obo:IAO_0000114 obo:IAO_0000423 ;
+              obo:IAO_0000115 "A reviewer is a contributer that holds a reviewer role which is being realized in a planned process."@en ;
+              obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string ;
+              rdfs:label "reviewer"@en .
 
 
 ###  https://github.com/tibonto/aeon#speaker
-:speaker rdf:type owl:Class ;
-         owl:equivalentClass [ rdf:type owl:Restriction ;
-                               owl:onProperty <http://purl.obolibrary.org/obo/RO_0000087> ;
-                               owl:someValuesFrom [ owl:intersectionOf ( :AEON_0000013
-                                                                         [ rdf:type owl:Restriction ;
-                                                                           owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000054> ;
-                                                                           owl:someValuesFrom <http://purl.obolibrary.org/obo/OBI_0000011>
-                                                                         ]
-                                                                       ) ;
-                                                    rdf:type owl:Class
-                                                  ]
-                             ] ;
-         rdfs:subClassOf :contributor ;
-         <http://purl.obolibrary.org/obo/IAO_0000112> "A presenter is a person who's role it is to present some body of work to an audience."@en ,
-                                                      "Philip Strömert is a presenter at PIDapalooza 2021."@en ;
-         <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000423> ;
-         <http://purl.obolibrary.org/obo/IAO_0000115> "A presenter is a contributer that holds a presenter role which is being realized in a planned process."@en ;
-         <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string ;
-         <http://purl.obolibrary.org/obo/IAO_0000118> "speaker"@en ;
-         rdfs:label "presenter"@en .
+aeon:speaker rdf:type owl:Class ;
+             owl:equivalentClass [ rdf:type owl:Restriction ;
+                                   owl:onProperty obo:RO_0000087 ;
+                                   owl:someValuesFrom [ owl:intersectionOf ( aeon:AEON_0000013
+                                                                             [ rdf:type owl:Restriction ;
+                                                                               owl:onProperty obo:BFO_0000054 ;
+                                                                               owl:someValuesFrom obo:OBI_0000011
+                                                                             ]
+                                                                           ) ;
+                                                        rdf:type owl:Class
+                                                      ]
+                                 ] ;
+             rdfs:subClassOf aeon:contributor ;
+             obo:IAO_0000112 "A presenter is a person who's role it is to present some body of work to an audience."@en ,
+                             "Philip Strömert is a presenter at PIDapalooza 2021."@en ;
+             obo:IAO_0000114 obo:IAO_0000423 ;
+             obo:IAO_0000115 "A presenter is a contributer that holds a presenter role which is being realized in a planned process."@en ;
+             obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string ;
+             obo:IAO_0000118 "speaker"@en ;
+             rdfs:label "presenter"@en .
 
 
 ###  https://github.com/tibonto/aeon#sponsor
-:sponsor rdf:type owl:Class ;
-         owl:equivalentClass [ rdf:type owl:Restriction ;
-                               owl:onProperty <http://purl.obolibrary.org/obo/RO_0000087> ;
-                               owl:someValuesFrom [ owl:intersectionOf ( :AEON_0000015
-                                                                         [ rdf:type owl:Restriction ;
-                                                                           owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000054> ;
-                                                                           owl:someValuesFrom <http://purl.obolibrary.org/obo/OBI_0000011>
-                                                                         ]
-                                                                       ) ;
-                                                    rdf:type owl:Class
-                                                  ]
-                             ] ;
-         rdfs:subClassOf :contributor ;
-         <http://purl.obolibrary.org/obo/IAO_0000112> "An organization or person that promises to fund an academic event is a sponsor of that event the moment the promised funds have been recieved by the organizers of the event."@en ;
-         <http://purl.obolibrary.org/obo/IAO_0000114> <http://purl.obolibrary.org/obo/IAO_0000423> ;
-         <http://purl.obolibrary.org/obo/IAO_0000115> "A sponsor is a contributer that holds a sponsor role which is being realized in a planned process."@en ;
-         <http://purl.obolibrary.org/obo/IAO_0000116> "Philip Strömert 2-9-2020: For me there is still the open question on how to best model the different sponsor types (e.g. gold, silver, bronze...), as there are various schemes. At the moment any sponsor type other than gold, silver or bronze can be further specified by using the data property \"sponsor_type\". We could also reuse the \"event type a SKOS:concept\" pattern here. But it seems best to have a clear definition of each sponsor type, in order to be able to subclass them here and add the corresponding roles and properties."@en ;
-         <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string .
+aeon:sponsor rdf:type owl:Class ;
+             owl:equivalentClass [ rdf:type owl:Restriction ;
+                                   owl:onProperty obo:RO_0000087 ;
+                                   owl:someValuesFrom [ owl:intersectionOf ( aeon:AEON_0000015
+                                                                             [ rdf:type owl:Restriction ;
+                                                                               owl:onProperty obo:BFO_0000054 ;
+                                                                               owl:someValuesFrom obo:OBI_0000011
+                                                                             ]
+                                                                           ) ;
+                                                        rdf:type owl:Class
+                                                      ]
+                                 ] ;
+             rdfs:subClassOf aeon:contributor ;
+             obo:IAO_0000112 "An organization or person that promises to fund an academic event is a sponsor of that event the moment the promised funds have been recieved by the organizers of the event."@en ;
+             obo:IAO_0000114 obo:IAO_0000423 ;
+             obo:IAO_0000115 "A sponsor is a contributer that holds a sponsor role which is being realized in a planned process."@en ;
+             obo:IAO_0000116 "Philip Strömert 2-9-2020: For me there is still the open question on how to best model the different sponsor types (e.g. gold, silver, bronze...), as there are various schemes. At the moment any sponsor type other than gold, silver or bronze can be further specified by using the data property \"sponsor_type\". We could also reuse the \"event type a SKOS:concept\" pattern here. But it seems best to have a clear definition of each sponsor type, in order to be able to subclass them here and add the corresponding roles and properties."@en ;
+             obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string .
 
 
 ###  https://github.com/tibonto/aeon#sponsorship_committee
-:sponsorship_committee rdf:type owl:Class ;
-                       rdfs:subClassOf :AEON_0000042 ;
-                       <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string ;
-                       rdfs:label "sponsorship committee"@en .
+aeon:sponsorship_committee rdf:type owl:Class ;
+                           rdfs:subClassOf aeon:AEON_0000042 ;
+                           obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string ;
+                           rdfs:label "sponsorship committee"@en .
 
 
 ###  https://github.com/tibonto/aeon#technical_committee
-:technical_committee rdf:type owl:Class ;
-                     rdfs:subClassOf :AEON_0000042 ;
-                     <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string ;
-                     rdfs:label "technical committee"@en .
+aeon:technical_committee rdf:type owl:Class ;
+                         rdfs:subClassOf aeon:AEON_0000042 ;
+                         obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string ;
+                         rdfs:label "technical committee"@en .
 
 
 ###  https://github.com/tibonto/aeon#wikiCFP_ID
-:wikiCFP_ID rdf:type owl:Class ;
-            rdfs:subClassOf <http://purl.obolibrary.org/obo/IAO_0000578> ;
-            <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert" ;
-            rdfs:label "wikiCFP ID" ;
-            <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> <http://purl.obolibrary.org/obo/IAO_0000423> .
+aeon:wikiCFP_ID rdf:type owl:Class ;
+                rdfs:subClassOf obo:IAO_0000578 ;
+                obo:IAO_0000117 "PERSON: Philip Strömert" ;
+                rdfs:label "wikiCFP ID" ;
+                ns:term_status obo:IAO_0000423 .
 
 
 #################################################################
@@ -3590,238 +3596,238 @@ The contributor ontology (CRO - http://purl.obolibrary.org/obo/cro.owl) seems to
 #################################################################
 
 ###  http://purl.obolibrary.org/obo/IAO_0000002
-<http://purl.obolibrary.org/obo/IAO_0000002> rdf:type owl:NamedIndividual ,
-                                                      <http://purl.obolibrary.org/obo/IAO_0000078> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000111> "example to be eventually removed"@en ;
-                                             rdfs:label "example to be eventually removed"@en .
+obo:IAO_0000002 rdf:type owl:NamedIndividual ,
+                         obo:IAO_0000078 ;
+                obo:IAO_0000111 "example to be eventually removed"@en ;
+                rdfs:label "example to be eventually removed"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000120
-<http://purl.obolibrary.org/obo/IAO_0000120> rdf:type owl:NamedIndividual ,
-                                                      <http://purl.obolibrary.org/obo/IAO_0000078> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000111> "metadata complete"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000115> "Class has all its metadata, but is either not guaranteed to be in its final location in the asserted IS_A hierarchy or refers to another class that is not complete."@en ;
-                                             rdfs:label "metadata complete"@en .
+obo:IAO_0000120 rdf:type owl:NamedIndividual ,
+                         obo:IAO_0000078 ;
+                obo:IAO_0000111 "metadata complete"@en ;
+                obo:IAO_0000115 "Class has all its metadata, but is either not guaranteed to be in its final location in the asserted IS_A hierarchy or refers to another class that is not complete."@en ;
+                rdfs:label "metadata complete"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000122
-<http://purl.obolibrary.org/obo/IAO_0000122> rdf:type owl:NamedIndividual ,
-                                                      <http://purl.obolibrary.org/obo/IAO_0000078> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000111> "ready for release"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000115> "Class has undergone final review, is ready for use, and will be included in the next release. Any class lacking \"ready_for_release\" should be considered likely to change place in hierarchy, have its definition refined, or be obsoleted in the next release.  Those classes deemed \"ready_for_release\" will also derived from a chain of ancestor classes that are also \"ready_for_release.\""@en ;
-                                             rdfs:label "ready for release"@en .
+obo:IAO_0000122 rdf:type owl:NamedIndividual ,
+                         obo:IAO_0000078 ;
+                obo:IAO_0000111 "ready for release"@en ;
+                obo:IAO_0000115 "Class has undergone final review, is ready for use, and will be included in the next release. Any class lacking \"ready_for_release\" should be considered likely to change place in hierarchy, have its definition refined, or be obsoleted in the next release.  Those classes deemed \"ready_for_release\" will also derived from a chain of ancestor classes that are also \"ready_for_release.\""@en ;
+                rdfs:label "ready for release"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000123
-<http://purl.obolibrary.org/obo/IAO_0000123> rdf:type owl:NamedIndividual ,
-                                                      <http://purl.obolibrary.org/obo/IAO_0000078> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000111> "metadata incomplete"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000115> "Class is being worked on; however, the metadata (including definition) are not complete or sufficiently clear to the branch editors."@en ;
-                                             rdfs:label "metadata incomplete"@en .
+obo:IAO_0000123 rdf:type owl:NamedIndividual ,
+                         obo:IAO_0000078 ;
+                obo:IAO_0000111 "metadata incomplete"@en ;
+                obo:IAO_0000115 "Class is being worked on; however, the metadata (including definition) are not complete or sufficiently clear to the branch editors."@en ;
+                rdfs:label "metadata incomplete"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000125
-<http://purl.obolibrary.org/obo/IAO_0000125> rdf:type owl:NamedIndividual ,
-                                                      <http://purl.obolibrary.org/obo/IAO_0000078> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000111> "pending final vetting"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000115> "All definitions, placement in the asserted IS_A hierarchy and required minimal metadata are complete. The class is awaiting a final review by someone other than the term editor."@en ;
-                                             rdfs:label "pending final vetting"@en .
+obo:IAO_0000125 rdf:type owl:NamedIndividual ,
+                         obo:IAO_0000078 ;
+                obo:IAO_0000111 "pending final vetting"@en ;
+                obo:IAO_0000115 "All definitions, placement in the asserted IS_A hierarchy and required minimal metadata are complete. The class is awaiting a final review by someone other than the term editor."@en ;
+                rdfs:label "pending final vetting"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000226
-<http://purl.obolibrary.org/obo/IAO_0000226> rdf:type owl:NamedIndividual ,
-                                                      <http://purl.obolibrary.org/obo/IAO_0000225> ,
-                                                      owl:Thing ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000111> "placeholder removed"@en ;
-                                             rdfs:label "placeholder removed"@en .
+obo:IAO_0000226 rdf:type owl:NamedIndividual ,
+                         obo:IAO_0000225 ,
+                         owl:Thing ;
+                obo:IAO_0000111 "placeholder removed"@en ;
+                rdfs:label "placeholder removed"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000227
-<http://purl.obolibrary.org/obo/IAO_0000227> rdf:type owl:NamedIndividual ,
-                                                      <http://purl.obolibrary.org/obo/IAO_0000225> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000111> "terms merged"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000116> "An editor note should explain what were the merged terms and the reason for the merge."@en ;
-                                             rdfs:label "terms merged"@en .
+obo:IAO_0000227 rdf:type owl:NamedIndividual ,
+                         obo:IAO_0000225 ;
+                obo:IAO_0000111 "terms merged"@en ;
+                obo:IAO_0000116 "An editor note should explain what were the merged terms and the reason for the merge."@en ;
+                rdfs:label "terms merged"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000228
-<http://purl.obolibrary.org/obo/IAO_0000228> rdf:type owl:NamedIndividual ,
-                                                      <http://purl.obolibrary.org/obo/IAO_0000225> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000111> "term imported"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000116> "This is to be used when the original term has been replaced by a term imported from an other ontology. An editor note should indicate what is the URI of the new term to use."@en ;
-                                             rdfs:label "term imported"@en .
+obo:IAO_0000228 rdf:type owl:NamedIndividual ,
+                         obo:IAO_0000225 ;
+                obo:IAO_0000111 "term imported"@en ;
+                obo:IAO_0000116 "This is to be used when the original term has been replaced by a term imported from an other ontology. An editor note should indicate what is the URI of the new term to use."@en ;
+                rdfs:label "term imported"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000229
-<http://purl.obolibrary.org/obo/IAO_0000229> rdf:type owl:NamedIndividual ,
-                                                      <http://purl.obolibrary.org/obo/IAO_0000225> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000111> "term split"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000116> "This is to be used when a term has been split in two or more new terms. An editor note should indicate the reason for the split and indicate the URIs of the new terms created."@en ;
-                                             rdfs:label "term split"@en .
+obo:IAO_0000229 rdf:type owl:NamedIndividual ,
+                         obo:IAO_0000225 ;
+                obo:IAO_0000111 "term split"@en ;
+                obo:IAO_0000116 "This is to be used when a term has been split in two or more new terms. An editor note should indicate the reason for the split and indicate the URIs of the new terms created."@en ;
+                rdfs:label "term split"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000423
-<http://purl.obolibrary.org/obo/IAO_0000423> rdf:type owl:NamedIndividual ,
-                                                      <http://purl.obolibrary.org/obo/IAO_0000078> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000111> "to be replaced with external ontology term"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000115> "Terms with this status should eventually replaced with a term from another ontology."@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000117> "Alan Ruttenberg"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000119> "group:OBI"@en ;
-                                             rdfs:label "to be replaced with external ontology term"@en .
+obo:IAO_0000423 rdf:type owl:NamedIndividual ,
+                         obo:IAO_0000078 ;
+                obo:IAO_0000111 "to be replaced with external ontology term"@en ;
+                obo:IAO_0000115 "Terms with this status should eventually replaced with a term from another ontology."@en ;
+                obo:IAO_0000117 "Alan Ruttenberg"@en ;
+                obo:IAO_0000119 "group:OBI"@en ;
+                rdfs:label "to be replaced with external ontology term"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000428
-<http://purl.obolibrary.org/obo/IAO_0000428> rdf:type owl:NamedIndividual ,
-                                                      <http://purl.obolibrary.org/obo/IAO_0000078> ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000111> "requires discussion"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000115> "A term that is metadata complete, has been reviewed, and problems have been identified that require discussion before release. Such a term requires editor note(s) to identify the outstanding issues."@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000117> "Alan Ruttenberg"@en ;
-                                             <http://purl.obolibrary.org/obo/IAO_0000119> "group:OBI"@en ;
-                                             rdfs:label "requires discussion"@en .
+obo:IAO_0000428 rdf:type owl:NamedIndividual ,
+                         obo:IAO_0000078 ;
+                obo:IAO_0000111 "requires discussion"@en ;
+                obo:IAO_0000115 "A term that is metadata complete, has been reviewed, and problems have been identified that require discussion before release. Such a term requires editor note(s) to identify the outstanding issues."@en ;
+                obo:IAO_0000117 "Alan Ruttenberg"@en ;
+                obo:IAO_0000119 "group:OBI"@en ;
+                rdfs:label "requires discussion"@en .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0010000
-:AEON_0010000 rdf:type owl:NamedIndividual ,
-                       :AEON_0000004 ;
-              rdfs:label "Colloquium" .
+aeon:AEON_0010000 rdf:type owl:NamedIndividual ,
+                           aeon:AEON_0000004 ;
+                  rdfs:label "Colloquium" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0010001
-:AEON_0010001 rdf:type owl:NamedIndividual ,
-                       :AEON_0000004 ;
-              rdfs:label "Conference" .
+aeon:AEON_0010001 rdf:type owl:NamedIndividual ,
+                           aeon:AEON_0000004 ;
+                  rdfs:label "Conference" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0010002
-:AEON_0010002 rdf:type owl:NamedIndividual ,
-                       :AEON_0000004 ;
-              rdfs:label "Forum" .
+aeon:AEON_0010002 rdf:type owl:NamedIndividual ,
+                           aeon:AEON_0000004 ;
+                  rdfs:label "Forum" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0010003
-:AEON_0010003 rdf:type owl:NamedIndividual ,
-                       :AEON_0000004 ;
-              rdfs:label "Hackathon" .
+aeon:AEON_0010003 rdf:type owl:NamedIndividual ,
+                           aeon:AEON_0000004 ;
+                  rdfs:label "Hackathon" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0010004
-:AEON_0010004 rdf:type owl:NamedIndividual ,
-                       :AEON_0000004 ;
-              rdfs:label "Seminar" .
+aeon:AEON_0010004 rdf:type owl:NamedIndividual ,
+                           aeon:AEON_0000004 ;
+                  rdfs:label "Seminar" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0010005
-:AEON_0010005 rdf:type owl:NamedIndividual ,
-                       :AEON_0000004 ;
-              rdfs:label "Session" .
+aeon:AEON_0010005 rdf:type owl:NamedIndividual ,
+                           aeon:AEON_0000004 ;
+                  rdfs:label "Session" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0010006
-:AEON_0010006 rdf:type owl:NamedIndividual ,
-                       :AEON_0000004 ;
-              rdfs:label "Symposium" .
+aeon:AEON_0010006 rdf:type owl:NamedIndividual ,
+                           aeon:AEON_0000004 ;
+                  rdfs:label "Symposium" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0010007
-:AEON_0010007 rdf:type owl:NamedIndividual ,
-                       :AEON_0000004 ;
-              rdfs:label "Talk" .
+aeon:AEON_0010007 rdf:type owl:NamedIndividual ,
+                           aeon:AEON_0000004 ;
+                  rdfs:label "Talk" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0010008
-:AEON_0010008 rdf:type owl:NamedIndividual ,
-                       :AEON_0000004 ;
-              rdfs:label "Track" .
+aeon:AEON_0010008 rdf:type owl:NamedIndividual ,
+                           aeon:AEON_0000004 ;
+                  rdfs:label "Track" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0010009
-:AEON_0010009 rdf:type owl:NamedIndividual ,
-                       :AEON_0000004 ;
-              rdfs:label "Tutorial" .
+aeon:AEON_0010009 rdf:type owl:NamedIndividual ,
+                           aeon:AEON_0000004 ;
+                  rdfs:label "Tutorial" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0010010
-:AEON_0010010 rdf:type owl:NamedIndividual ,
-                       :AEON_0000004 ;
-              rdfs:label "Workshop" .
+aeon:AEON_0010010 rdf:type owl:NamedIndividual ,
+                           aeon:AEON_0000004 ;
+                  rdfs:label "Workshop" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0010011
-:AEON_0010011 rdf:type owl:NamedIndividual ,
-                       :AEON_0000004 ;
-              rdfs:label "Other event type"@en .
+aeon:AEON_0010011 rdf:type owl:NamedIndividual ,
+                           aeon:AEON_0000004 ;
+                  rdfs:label "Other event type"@en .
 
 
 ###  https://github.com/tibonto/aeon#Lisbon
-:Lisbon rdf:type owl:NamedIndividual .
+aeon:Lisbon rdf:type owl:NamedIndividual .
 
 
 ###  https://github.com/tibonto/aeon#Portugal
-:Portugal rdf:type owl:NamedIndividual .
+aeon:Portugal rdf:type owl:NamedIndividual .
 
 
 ###  https://github.com/tibonto/aeon#_PIDapalooza
-:_PIDapalooza rdf:type owl:NamedIndividual ;
-              rdfs:comment <http://purl.obolibrary.org/obo/IAO_0000002> ;
-              rdfs:label "_PIDapalooza"@en .
+aeon:_PIDapalooza rdf:type owl:NamedIndividual ;
+                  rdfs:comment obo:IAO_0000002 ;
+                  rdfs:label "_PIDapalooza"@en .
 
 
 ###  https://github.com/tibonto/aeon#_PIDapalooza2020
-:_PIDapalooza2020 rdf:type owl:NamedIndividual ;
-                  <http://purl.obolibrary.org/obo/BFO_0000055> :__PIDapalooza_Role_1 ,
-                                                               :__PIDapalooza_Role_2 ;
-                  :AEON_0000050 :_Person_1 ;
-                  :AEON_0000055 :_Person_2 ;
-                  :end_date "2020-01-30T17:00:00"^^xsd:dateTime ;
-                  :number_of_attendees 117 ;
-                  :number_of_tracks 13 ;
-                  :start_date "2020-01-29T09:00:00"^^xsd:dateTime ;
-                  rdfs:comment <http://purl.obolibrary.org/obo/IAO_0000002> ;
-                  rdfs:label "_PIDapalooza2020"@en .
+aeon:_PIDapalooza2020 rdf:type owl:NamedIndividual ;
+                      obo:BFO_0000055 aeon:__PIDapalooza_Role_1 ,
+                                      aeon:__PIDapalooza_Role_2 ;
+                      aeon:AEON_0000050 aeon:_Person_1 ;
+                      aeon:AEON_0000055 aeon:_Person_2 ;
+                      aeon:end_date "2020-01-30T17:00:00"^^xsd:dateTime ;
+                      aeon:number_of_attendees 117 ;
+                      aeon:number_of_tracks 13 ;
+                      aeon:start_date "2020-01-29T09:00:00"^^xsd:dateTime ;
+                      rdfs:comment obo:IAO_0000002 ;
+                      rdfs:label "_PIDapalooza2020"@en .
 
 
 ###  https://github.com/tibonto/aeon#_PIDapalooza_general_committee
-:_PIDapalooza_general_committee rdf:type owl:NamedIndividual ,
-                                         :general_committee ;
-                                <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string .
+aeon:_PIDapalooza_general_committee rdf:type owl:NamedIndividual ,
+                                             aeon:general_committee ;
+                                    obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string .
 
 
 ###  https://github.com/tibonto/aeon#_Person_1
-:_Person_1 rdf:type owl:NamedIndividual ;
-           <http://purl.obolibrary.org/obo/IAO_0000235> <https://orcid.org/0000-0002-1595-3213> ;
-           <http://purl.obolibrary.org/obo/RO_0000087> :__PIDapalooza_Role_1 ;
-           :first_name "Philip"^^xsd:string ;
-           :last_name "Strömert"^^xsd:string ;
-           <http://www.w3.org/2003/06/sw-vocab-status/ns#term_status> <http://purl.obolibrary.org/obo/IAO_0000002> .
+aeon:_Person_1 rdf:type owl:NamedIndividual ;
+               obo:IAO_0000235 <https://orcid.org/0000-0002-1595-3213> ;
+               obo:RO_0000087 aeon:__PIDapalooza_Role_1 ;
+               aeon:first_name "Philip"^^xsd:string ;
+               aeon:last_name "Strömert"^^xsd:string ;
+               ns:term_status obo:IAO_0000002 .
 
 
 ###  https://github.com/tibonto/aeon#_Person_2
-:_Person_2 rdf:type owl:NamedIndividual ;
-           <http://purl.obolibrary.org/obo/RO_0000087> :__PIDapalooza_Role_2 ;
-           <http://purl.obolibrary.org/obo/RO_0002350> :_PIDapalooza_general_committee ;
-           :personal_name "Sam general committee Chair" ;
-           <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string .
+aeon:_Person_2 rdf:type owl:NamedIndividual ;
+               obo:RO_0000087 aeon:__PIDapalooza_Role_2 ;
+               obo:RO_0002350 aeon:_PIDapalooza_general_committee ;
+               aeon:personal_name "Sam general committee Chair" ;
+               obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string .
 
 
 ###  https://github.com/tibonto/aeon#__PIDapalooza_Role_1
-:__PIDapalooza_Role_1 rdf:type owl:NamedIndividual ;
-                      <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string .
+aeon:__PIDapalooza_Role_1 rdf:type owl:NamedIndividual ;
+                          obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string .
 
 
 ###  https://github.com/tibonto/aeon#__PIDapalooza_Role_2
-:__PIDapalooza_Role_2 rdf:type owl:NamedIndividual ;
-                      <http://purl.obolibrary.org/obo/IAO_0000117> "PERSON: Philip Strömert"^^xsd:string .
+aeon:__PIDapalooza_Role_2 rdf:type owl:NamedIndividual ;
+                          obo:IAO_0000117 "PERSON: Philip Strömert"^^xsd:string .
 
 
 ###  https://orcid.org/0000-0002-1595-3213
 <https://orcid.org/0000-0002-1595-3213> rdf:type owl:NamedIndividual ;
-                                        :ID_base_URL "https://orcid.org/"^^xsd:anyURI .
+                                        aeon:ID_base_URL "https://orcid.org/"^^xsd:anyURI .
 
 
 ###  https://www.wikidata.org/wiki/Q65929359
 <https://www.wikidata.org/wiki/Q65929359> rdf:type owl:NamedIndividual ;
-                                          :ID_base_URL "https://www.wikidata.org/wiki/"^^xsd:anyURI ;
-                                          rdfs:comment <http://purl.obolibrary.org/obo/IAO_0000002> .
+                                          aeon:ID_base_URL "https://www.wikidata.org/wiki/"^^xsd:anyURI ;
+                                          rdfs:comment obo:IAO_0000002 .
 
 
 #################################################################
@@ -3829,56 +3835,56 @@ The contributor ontology (CRO - http://purl.obolibrary.org/obo/cro.owl) seems to
 #################################################################
 
 [ rdf:type owl:AllDisjointClasses ;
-  owl:members ( <http://purl.obolibrary.org/obo/BFO_0000004>
-                <http://purl.obolibrary.org/obo/BFO_0000020>
-                <http://purl.obolibrary.org/obo/BFO_0000031>
+  owl:members ( obo:BFO_0000004
+                obo:BFO_0000020
+                obo:BFO_0000031
               )
 ] .
 
 
 [ rdf:type owl:AllDisjointClasses ;
-  owl:members ( <http://purl.obolibrary.org/obo/BFO_0000008>
-                <http://purl.obolibrary.org/obo/BFO_0000011>
-                <http://purl.obolibrary.org/obo/BFO_0000015>
-                <http://purl.obolibrary.org/obo/BFO_0000035>
+  owl:members ( obo:BFO_0000008
+                obo:BFO_0000011
+                obo:BFO_0000015
+                obo:BFO_0000035
               )
 ] .
 
 
 [ rdf:type owl:AllDisjointClasses ;
-  owl:members ( :AEON_0000006
-                :AEON_0000010
-                :AEON_0000011
-                :AEON_0000012
-                :AEON_0000013
+  owl:members ( aeon:AEON_0000006
+                aeon:AEON_0000010
+                aeon:AEON_0000011
+                aeon:AEON_0000012
+                aeon:AEON_0000013
               )
 ] .
 
 
 [ rdf:type owl:AllDifferent ;
-  owl:distinctMembers ( <http://purl.obolibrary.org/obo/IAO_0000226>
-                        <http://purl.obolibrary.org/obo/IAO_0000227>
-                        <http://purl.obolibrary.org/obo/IAO_0000228>
-                        <http://purl.obolibrary.org/obo/IAO_0000229>
+  owl:distinctMembers ( obo:IAO_0000226
+                        obo:IAO_0000227
+                        obo:IAO_0000228
+                        obo:IAO_0000229
                       )
 ] .
 
 
 [ rdf:type owl:AllDifferent ;
-  owl:distinctMembers ( :AEON_0010000
-                        :AEON_0010001
-                        :AEON_0010002
-                        :AEON_0010003
-                        :AEON_0010004
-                        :AEON_0010005
-                        :AEON_0010006
-                        :AEON_0010007
-                        :AEON_0010008
-                        :AEON_0010009
-                        :AEON_0010010
-                        :AEON_0010011
+  owl:distinctMembers ( aeon:AEON_0010000
+                        aeon:AEON_0010001
+                        aeon:AEON_0010002
+                        aeon:AEON_0010003
+                        aeon:AEON_0010004
+                        aeon:AEON_0010005
+                        aeon:AEON_0010006
+                        aeon:AEON_0010007
+                        aeon:AEON_0010008
+                        aeon:AEON_0010009
+                        aeon:AEON_0010010
+                        aeon:AEON_0010011
                       )
 ] .
 
 
-###  Generated by the OWL API (version 4.5.6) https://github.com/owlcs/owlapi
+###  Generated by the OWL API (version 4.5.9.2019-02-01T07:24:44Z) https://github.com/owlcs/owlapi

--- a/aeon.ttl
+++ b/aeon.ttl
@@ -298,24 +298,6 @@ aeon:AEON_0000026 rdf:type owl:AnnotationProperty ;
                   rdfs:label "maps to"@de .
 
 
-###  https://github.com/tibonto/aeon#SMW_datatype
-aeon:SMW_datatype rdf:type owl:AnnotationProperty .
-
-
-###  https://github.com/tibonto/aeon#SMW_import_info
-aeon:SMW_import_info rdf:type owl:AnnotationProperty .
-
-
-###  https://github.com/tibonto/aeon#WikidataLabel
-aeon:WikidataLabel rdf:type owl:AnnotationProperty ;
-                   obo:IAO_0000115 "WikidataLabel is used to map a class or property to a certain label in the Wikidata namespace." .
-
-
-###  https://github.com/tibonto/aeon#WikidataURI
-aeon:WikidataURI rdf:type owl:AnnotationProperty ;
-                 obo:IAO_0000115 "WikidataURI is used to map a class or property to the URI in the Wikidata namespace." .
-
-
 #################################################################
 #    Object Properties
 #################################################################
@@ -442,9 +424,7 @@ Some currently missing phenomena that should be considered \"about\" are predica
                 obo:IAO_0000119 "Smith, Ceusters, Ruttenberg, 2000 years of philosophy"@en ;
                 obo:IAO_0000412 "http://purl.obolibrary.org/obo/iao/2020-12-09/iao.owl"^^xsd:string ;
                 rdfs:label "is about"@en ;
-                aeon:AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P921\", \"label\": \"main_subjectLabel\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Property:Field\", \"label\": \"Field\"}, \"gnd\": {\"uri\": \"https://d-nb.info/standards/elementset/gnd#topic\", \"label\": \"Topic that is related to a corporate body, conference, person, family, subject heading or work.\"}}"^^xsd:string ;
-                aeon:SMW_datatype "Text" ;
-                aeon:SMW_import_info "Controlled vocabulary in [[MediaWiki:Smw_allows_list_Subject]] [[Category:IAO]] [[Category:Imported vocabulary]]" .
+                aeon:AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P921\", \"label\": \"main_subjectLabel\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Property:Field\", \"label\": \"Field\"}, \"gnd\": {\"uri\": \"https://d-nb.info/standards/elementset/gnd#topic\", \"label\": \"Topic that is related to a corporate body, conference, person, family, subject heading or work.\"}}"^^xsd:string .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000219
@@ -653,11 +633,7 @@ aeon:AEON_0000032 rdf:type owl:ObjectProperty ;
                   obo:IAO_0000115 "A relation obtaining between a planned process and a skos:Concept that is used to descibe the social format of an 'academic event'."@en ;
                   obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
                   rdfs:label "has event type"@en ;
-                  aeon:AEON_0000026 "{\"wikidata\": {\"uri\": null, \"label\": \"event_type\"}, \"openresearch\": {\"uri\": null, \"label\": \"Type\"}}"^^xsd:string ;
-                  aeon:SMW_datatype "Text" ;
-                  aeon:SMW_import_info """The allowed value list for this property is defined in [[MediaWiki:Smw_allows_list_has_event_type]].
-[[Category:AEON]] [[Category:Imported vocabulary]]""" ;
-                  aeon:WikidataLabel "event_type" .
+                  aeon:AEON_0000026 "{\"wikidata\": {\"uri\": null, \"label\": \"event_type\"}, \"openresearch\": {\"uri\": null, \"label\": \"Type\"}}"^^xsd:string .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000033
@@ -699,13 +675,7 @@ aeon:AEON_0000043 rdf:type owl:ObjectProperty ;
                   rdfs:range aeon:AEON_0000030 ;
                   obo:IAO_0000115 "A relation obtaining between a planned process and an 'information content entity' that is about the amount of money one has to pay in order to be an allowed participant of the planned process."@en ;
                   obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
-                  rdfs:label "has fee"@en ;
-                  aeon:SMW_datatype "Text" ;
-                  aeon:SMW_import_info """The allowed value list for this property is defined in [[MediaWiki:Smw_allows_list_Has_fee]].
-
-[[partOfSubobject::Template:Subobject Fee]]
-
-[[Category:AEON]] [[Category:Imported vocabulary]]""" .
+                  rdfs:label "has fee"@en .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000045
@@ -717,9 +687,7 @@ aeon:AEON_0000045 rdf:type owl:ObjectProperty ;
                   obo:IAO_0000115 "'has contributor' is a relation obtaining between a planned process and a person or organization that holds a contributor role which is being realized by the planned process. A contribution to a planned process takes place when someone works on the planning or realization of a planned process."@en ,
                                   "A relation obtaining between an entity and its corresponding Wikidata entity identifier."@en ;
                   obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
-                  rdfs:label "has contributor"@en ;
-                  aeon:SMW_datatype "Page" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+                  rdfs:label "has contributor"@en .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000046
@@ -731,11 +699,7 @@ aeon:AEON_0000046 rdf:type owl:ObjectProperty ;
                   obo:IAO_0000115 "A relation obtaining between a planned process and a person that holds an attendee role which is being realized by the planned process."@en ;
                   obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
                   rdfs:label "has attendee"@en ;
-                  aeon:AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P710\", \"label\": \"participantLabel\"}}"^^xsd:string ;
-                  aeon:SMW_datatype "Page" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" ;
-                  aeon:WikidataLabel "participantLabel" ;
-                  aeon:WikidataURI "https://www.wikidata.org/wiki/Property:P710" .
+                  aeon:AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P710\", \"label\": \"participantLabel\"}}"^^xsd:string .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000047
@@ -746,9 +710,7 @@ aeon:AEON_0000047 rdf:type owl:ObjectProperty ;
                   rdfs:range aeon:moderator ;
                   obo:IAO_0000115 "A relation obtaining between a planned process and a person that holds a moderator role which is being realized by the planned process."@en ;
                   obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
-                  rdfs:label "has moderator"@en ;
-                  aeon:SMW_datatype "Page" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+                  rdfs:label "has moderator"@en .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000048
@@ -760,11 +722,7 @@ aeon:AEON_0000048 rdf:type owl:ObjectProperty ;
                   obo:IAO_0000115 "A relation obtaining between a planned process and a person or organization that holds an organizer role which is being realized by the planned process."@en ;
                   obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
                   rdfs:label "has organizer"@en ;
-                  aeon:AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P664\", \"label\": \"organizerLabel\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Property:Has_organizer\", \"label\": \"Has_organizer\"},\"crossref\": {\"api_proceedings_endpoint_uri\": \"https://api.crossref.org/types/proceedings/works?select=event\", \"json_api_key\": {\"event\": \"sponsor\"}}}"^^xsd:string ;
-                  aeon:SMW_datatype "Page" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" ;
-                  aeon:WikidataLabel "organizerLabel" ;
-                  aeon:WikidataURI "https://www.wikidata.org/wiki/Property:P664" .
+                  aeon:AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P664\", \"label\": \"organizerLabel\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Property:Has_organizer\", \"label\": \"Has_organizer\"},\"crossref\": {\"api_proceedings_endpoint_uri\": \"https://api.crossref.org/types/proceedings/works?select=event\", \"json_api_key\": {\"event\": \"sponsor\"}}}"^^xsd:string .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000049
@@ -775,11 +733,7 @@ aeon:AEON_0000049 rdf:type owl:ObjectProperty ;
                   rdfs:range aeon:reviewer ;
                   obo:IAO_0000115 "A relation obtaining between a planned process and a person that holds a reviewer role which is being realized by the planned process."@en ;
                   obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
-                  rdfs:label "has reviewer"@en ;
-                  aeon:SMW_datatype "Page" ;
-                  aeon:SMW_import_info """[[partOfSubobject::Template:Subobject Contributor]]
-
-[[Category:AEON]] [[Category:Imported vocabulary]]""" .
+                  rdfs:label "has reviewer"@en .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000050
@@ -791,13 +745,7 @@ aeon:AEON_0000050 rdf:type owl:ObjectProperty ;
                   obo:IAO_0000115 "A relation obtaining between a planned process and a person that holds a presenter role which is being realized by the planned process."@en ;
                   obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
                   rdfs:label "has presenter"@en ;
-                  aeon:AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P823\", \"label\": \"speaker\"}}"^^xsd:string ;
-                  aeon:SMW_datatype "Page" ;
-                  aeon:SMW_import_info """[[partOfSubobject::Template:Subobject Contributor]]
-
-[[Category:AEON]] [[Category:Imported vocabulary]]""" ;
-                  aeon:WikidataLabel "speaker" ;
-                  aeon:WikidataURI "https://www.wikidata.org/wiki/Property:P823" .
+                  aeon:AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P823\", \"label\": \"speaker\"}}"^^xsd:string .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000051
@@ -808,11 +756,7 @@ aeon:AEON_0000051 rdf:type owl:ObjectProperty ;
                   rdfs:range aeon:sponsor ;
                   obo:IAO_0000115 "A relation obtaining between a planned process and a person or organization that holds a sponsor role which is being realized by the planned process."@en ;
                   obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
-                  rdfs:label "has sponsor"@en ;
-                  aeon:SMW_datatype "Page" ;
-                  aeon:SMW_import_info """[[partOfSubobject::Template:Subobject Sponsor]]
-
-[[Category:AEON]] [[Category:Imported vocabulary]]""" .
+                  rdfs:label "has sponsor"@en .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000052
@@ -823,9 +767,7 @@ aeon:AEON_0000052 rdf:type owl:ObjectProperty ;
                   rdfs:range aeon:committee_member ;
                   obo:IAO_0000115 "A relation obtaining between a planned process and a person that holds a committee member role which is being realized by the planned process."@en ;
                   obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
-                  rdfs:label "has committee member"@en ;
-                  aeon:SMW_datatype "Page" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+                  rdfs:label "has committee member"@en .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000053
@@ -836,9 +778,7 @@ aeon:AEON_0000053 rdf:type owl:ObjectProperty ;
                   rdfs:range aeon:contact_person ;
                   obo:IAO_0000115 "A relation obtaining between a planned process and a person that holds a contact person role which is being realized by the planned process."@en ;
                   obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
-                  rdfs:label "has contact person"@en ;
-                  aeon:SMW_datatype "Page" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+                  rdfs:label "has contact person"@en .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000054
@@ -849,11 +789,7 @@ aeon:AEON_0000054 rdf:type owl:ObjectProperty ;
                   rdfs:range aeon:keynote_speaker ;
                   obo:IAO_0000115 "A relation between a planned process and a person that holds a keynote speaker role which is being realized by the planned process."@en ;
                   obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
-                  rdfs:label "has keynote speaker"@en ;
-                  aeon:SMW_datatype "Page" ;
-                  aeon:SMW_import_info """[[partOfSubobject::Template:Subobject Contributor]]
-                         
-[[Category:AEON]] [[Category:Imported vocabulary]]""" .
+                  rdfs:label "has keynote speaker"@en .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000055
@@ -864,11 +800,7 @@ aeon:AEON_0000055 rdf:type owl:ObjectProperty ;
                   rdfs:range aeon:committee_chair ;
                   obo:IAO_0000115 "A relation obtaining between a planned process and a person that holds a committee chair role which is being realized by the planned process."@en ;
                   obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
-                  rdfs:label "has committee chair"@en ;
-                  aeon:SMW_datatype "Page" ;
-                  aeon:SMW_import_info """[[partOfSubobject::Template:Subobject Contributor]]
-
-[[Category:AEON]] [[Category:Imported vocabulary]]""" .
+                  rdfs:label "has committee chair"@en .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000075
@@ -879,11 +811,7 @@ aeon:AEON_0000075 rdf:type owl:ObjectProperty ;
                   obo:IAO_0000115 "A relation obtaining between a data item and its corresponding digital object identifier."@en ;
                   obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
                   rdfs:label "has DOI"@en ;
-                  ns:term_status obo:IAO_0000423 ;
-                  aeon:SMW_datatype "External identifier" ;
-                  aeon:SMW_import_info """External formatter uri [[External formatter uri::https://doi.org/$1]]
-
-[[Category:AEON]] [[Category:Imported vocabulary]]""" .
+                  ns:term_status obo:IAO_0000423 .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000076
@@ -895,17 +823,7 @@ aeon:AEON_0000076 rdf:type owl:ObjectProperty ;
                   obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
                   rdfs:label "has GND"@en ;
                   ns:term_status obo:IAO_0000423 ;
-                  aeon:AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P227\", \"label\": \"GND_ID\"}, \"gnd\": {\"uri\": \"https://d-nb.info/standards/elementset/gnd#gndIdentifier\", \"label\": \"GND-Identifier\"}}"^^xsd:string ;
-                  aeon:SMW_datatype "External identifier" ;
-                  aeon:SMW_import_info """External formatter uri [[External formatter uri::http://d-nb.info/gnd/$1]]
-
-[[partOfSubobject::Template:Subobject External_Process_ID]]
-[[partOfSubobject::Template:Subobject Person_ID]]
-[[partOfSubobject::Template:Subobject Organization_ID]]
-
-[[Category:AEON]] [[Category:Imported vocabulary]]""" ;
-                  aeon:WikidataLabel "GND_ID" ;
-                  aeon:WikidataURI "https://www.wikidata.org/wiki/Property:P227" .
+                  aeon:AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P227\", \"label\": \"GND_ID\"}, \"gnd\": {\"uri\": \"https://d-nb.info/standards/elementset/gnd#gndIdentifier\", \"label\": \"GND-Identifier\"}}"^^xsd:string .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000077
@@ -920,14 +838,7 @@ aeon:AEON_0000077 rdf:type owl:ObjectProperty ;
                   obo:IAO_0000115 "A relation obtaining between a person or organization and the 'international standard name identifier' used to denote the entity."@en ;
                   obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
                   rdfs:label "has ISNI"@en ;
-                  ns:term_status obo:IAO_0000423 ;
-                  aeon:SMW_datatype "External identifier" ;
-                  aeon:SMW_import_info """External formatter uri [[External formatter uri::https://isni.org/isni/$1]]
-
-[[partOfSubobject::Template:Subobject Person_ID]]
-[[partOfSubobject::Template:Subobject Organization_ID]]
-
-[[Category:AEON]] [[Category:Imported vocabulary]]""" .
+                  ns:term_status obo:IAO_0000423 .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000078
@@ -938,13 +849,7 @@ aeon:AEON_0000078 rdf:type owl:ObjectProperty ;
                   obo:IAO_0000115 "A relation obtaining between a person and the 'open researcher and contributor identifier' used to denote the entity."@en ;
                   obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
                   rdfs:label "has ORCID"@en ;
-                  ns:term_status obo:IAO_0000423 ;
-                  aeon:SMW_datatype "External identifier" ;
-                  aeon:SMW_import_info """External formatter uri [[External formatter uri::https://orcid.org/$1]]
-
-[[partOfSubobject::Template:Subobject Person_ID]]
-
-[[Category:AEON]] [[Category:Imported vocabulary]]""" .
+                  ns:term_status obo:IAO_0000423 .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000079
@@ -955,13 +860,7 @@ aeon:AEON_0000079 rdf:type owl:ObjectProperty ;
                   obo:IAO_0000115 "A relation obtaining between a person and the 'research organization registry identifier' used to denote the entity."@en ;
                   obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
                   rdfs:label "has ROR"@en ;
-                  ns:term_status obo:IAO_0000423 ;
-                  aeon:SMW_datatype "External identifier" ;
-                  aeon:SMW_import_info """External formatter uri [[External formatter uri::https://ror.org/$1]]
-
-[[partOfSubobject::Template:Subobject Organization_ID]]
-
-[[Category:AEON]] [[Category:Imported vocabulary]]""" .
+                  ns:term_status obo:IAO_0000423 .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000080
@@ -973,16 +872,7 @@ aeon:AEON_0000080 rdf:type owl:ObjectProperty ;
                   obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
                   rdfs:label "has Wikidata QID"@en ;
                   ns:term_status obo:IAO_0000423 ;
-                  aeon:AEON_0000026 "{\"wikidata\": {\"uri\": null, \"label\": \"itemID\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Property:Wikidataid\", \"label\": \"Wikidataid\"}}"^^xsd:string ;
-                  aeon:SMW_datatype "External identifier" ;
-                  aeon:SMW_import_info """External formatter uri [[External formatter uri::https://www.wikidata.org/wiki/$1]]
-
-[[partOfSubobject::Template:Subobject Process_External_ID]]
-[[partOfSubobject::Template:Subobject Person_ID]]
-[[partOfSubobject::Template:Subobject Organization_ID]]
-
-[[Category:AEON]] [[Category:Imported vocabulary]]""" ;
-                  aeon:WikidataLabel "itemID" .
+                  aeon:AEON_0000026 "{\"wikidata\": {\"uri\": null, \"label\": \"itemID\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Property:Wikidataid\", \"label\": \"Wikidataid\"}}"^^xsd:string .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000081
@@ -992,9 +882,7 @@ aeon:AEON_0000081 rdf:type owl:ObjectProperty ;
                   rdfs:domain aeon:AEON_0000002 ;
                   rdfs:range aeon:AEON_0000001 ;
                   obo:IAO_0000115 "A relation obtaining between an academic event series and an academic event. It is used to express that the academic event is part of a specific event series."@en ;
-                  rdfs:label "has academic event"@en ;
-                  aeon:SMW_datatype "Page" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+                  rdfs:label "has academic event"@en .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000082
@@ -1005,9 +893,7 @@ aeon:AEON_0000082 rdf:type owl:ObjectProperty ;
                   rdfs:range aeon:AEON_0000001 ;
                   obo:IAO_0000115 "see inverse property"@en ;
                   obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
-                  rdfs:label "collocated event of"@en ;
-                  aeon:SMW_datatype "Page" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+                  rdfs:label "collocated event of"@en .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000083
@@ -1018,9 +904,7 @@ aeon:AEON_0000083 rdf:type owl:ObjectProperty ;
                   rdfs:range aeon:AEON_0000001 ;
                   obo:IAO_0000115 "see inverse property"@en ;
                   obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
-                  rdfs:label "joint event of"@en ;
-                  aeon:SMW_datatype "Page" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+                  rdfs:label "joint event of"@en .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000084
@@ -1031,9 +915,7 @@ aeon:AEON_0000084 rdf:type owl:ObjectProperty ;
                   obo:IAO_0000115 "see inverse property"@en ;
                   obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
                   rdfs:label "part of series"@en ;
-                  aeon:AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P179\", \"label\": \"part_of_the_seriesLabel\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Property:Event_in_series\", \"label\": \"Event_in_series\"}}"^^xsd:string ;
-                  aeon:SMW_datatype "Page" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+                  aeon:AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P179\", \"label\": \"part_of_the_seriesLabel\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Property:Event_in_series\", \"label\": \"Event_in_series\"}}"^^xsd:string .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000085
@@ -1044,9 +926,7 @@ aeon:AEON_0000085 rdf:type owl:ObjectProperty ;
                   rdfs:range aeon:AEON_0000001 ;
                   obo:IAO_0000115 "see inverse property"@en ;
                   obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
-                  rdfs:label "umbrella event of"@en ;
-                  aeon:SMW_datatype "Page" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+                  rdfs:label "umbrella event of"@en .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000086
@@ -1055,11 +935,7 @@ aeon:AEON_0000086 rdf:type owl:ObjectProperty ;
                   rdfs:domain aeon:AEON_0000001 ;
                   rdfs:range aeon:AEON_0000023 ;
                   rdfs:label "occurs in country"@en ;
-                  aeon:AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P17\", \"label\": \"countryLabel\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Property:Has_location_country\", \"label\": \"Has_location_country\"}}"^^xsd:string ;
-                  aeon:SMW_datatype "Text" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" ;
-                  aeon:WikidataLabel "countryLabel" ;
-                  aeon:WikidataURI "https://www.wikidata.org/wiki/Property:P17" .
+                  aeon:AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P17\", \"label\": \"countryLabel\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Property:Has_location_country\", \"label\": \"Has_location_country\"}}"^^xsd:string .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000087
@@ -1068,9 +944,7 @@ aeon:AEON_0000087 rdf:type owl:ObjectProperty ;
                   rdfs:domain aeon:AEON_0000001 ;
                   rdfs:range aeon:AEON_0000022 ;
                   rdfs:label "occurs in city"@en ;
-                  aeon:AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P276\", \"label\": \"locationLabel\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Property:Has_location_city\", \"label\": \"Has_location_city\"}, \"gnd\": {\"uri\": \"https://d-nb.info/standards/elementset/gnd#placeOfConferenceOrEvent\", \"label\": \"Place of conference or event\"}}"^^xsd:string ;
-                  aeon:SMW_datatype "Text" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+                  aeon:AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P276\", \"label\": \"locationLabel\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Property:Has_location_city\", \"label\": \"Has_location_city\"}, \"gnd\": {\"uri\": \"https://d-nb.info/standards/elementset/gnd#placeOfConferenceOrEvent\", \"label\": \"Place of conference or event\"}}"^^xsd:string .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000088
@@ -1079,9 +953,7 @@ aeon:AEON_0000088 rdf:type owl:ObjectProperty ;
                   rdfs:domain aeon:AEON_0000001 ;
                   rdfs:range aeon:AEON_0000024 ;
                   rdfs:label "occurs in state"@en ;
-                  aeon:AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P131\", \"label\": \"located_in_the_administrative_territorial_entityLabel\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Property:Has_location_state\", \"label\": \"Has_location_state\"}}"^^xsd:string ;
-                  aeon:SMW_datatype "Text" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+                  aeon:AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P131\", \"label\": \"located_in_the_administrative_territorial_entityLabel\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Property:Has_location_state\", \"label\": \"Has_location_state\"}}"^^xsd:string .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000089
@@ -1089,9 +961,7 @@ aeon:AEON_0000089 rdf:type owl:ObjectProperty ;
                   rdfs:subPropertyOf obo:BFO_0000066 ;
                   rdfs:domain aeon:AEON_0000001 ;
                   rdfs:range aeon:AEON_0000025 ;
-                  rdfs:label "occurs in venue"@en ;
-                  aeon:SMW_datatype "Text" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+                  rdfs:label "occurs in venue"@en .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000090
@@ -1099,9 +969,7 @@ aeon:AEON_0000090 rdf:type owl:ObjectProperty ;
                   rdfs:subPropertyOf obo:BFO_0000066 ;
                   rdfs:domain aeon:AEON_0000001 ;
                   rdfs:range aeon:AEON_0000029 ;
-                  rdfs:label "occurs in virtual place"@en ;
-                  aeon:SMW_datatype "URL" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+                  rdfs:label "occurs in virtual place"@en .
 
 
 ###  https://github.com/tibonto/aeon#academic_field_of
@@ -1302,9 +1170,7 @@ owl:topDataProperty rdfs:range rdfs:Literal .
 aeon:CORE_ranking rdf:type owl:DatatypeProperty ;
                   rdfs:subPropertyOf aeon:metric ;
                   rdfs:domain aeon:AEON_0000001 ;
-                  rdfs:label "CORE ranking"@en ;
-                  aeon:SMW_datatype "Text" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+                  rdfs:label "CORE ranking"@en .
 
 
 ###  https://github.com/tibonto/aeon#ID
@@ -1312,13 +1178,7 @@ aeon:ID rdf:type owl:DatatypeProperty ;
         rdfs:subPropertyOf owl:topDataProperty ;
         rdfs:domain obo:IAO_0020000 ;
         obo:IAO_0000115 "The literal value of an identifier."@en ;
-        rdfs:label "identifier"@en ;
-        aeon:SMW_datatype "Text" ;
-        aeon:SMW_import_info """[[partOfSubobject::Template:Subobject External_Process_ID]]
-[[partOfSubobject::Template:Subobject Person_ID]]
-[[partOfSubobject::Template:Subobject Organization_ID]]
-
-[[Category:AEON]] [[Category:Imported vocabulary]]""" .
+        rdfs:label "identifier"@en .
 
 
 ###  https://github.com/tibonto/aeon#ID_URL
@@ -1327,13 +1187,7 @@ aeon:ID_URL rdf:type owl:DatatypeProperty ;
             rdfs:domain obo:IAO_0020000 ;
             rdfs:range xsd:anyURI ;
             rdfs:comment "The literal value of the full URL used by the identifier scheme, based on the concatination of base URL and ID (ID_URL:value = ID_base_URL:value + ID:value)."@en ;
-            rdfs:label "identifier URI"@en ;
-            aeon:SMW_datatype "URL" ;
-            aeon:SMW_import_info """[[partOfSubobject::Template:Subobject External_Process_ID]]
-[[partOfSubobject::Template:Subobject Person_ID]]
-[[partOfSubobject::Template:Subobject Organization_ID]]
-
-[[Category:AEON]] [[Category:Imported vocabulary]]""" .
+            rdfs:label "identifier URI"@en .
 
 
 ###  https://github.com/tibonto/aeon#ID_base_URL
@@ -1342,13 +1196,7 @@ aeon:ID_base_URL rdf:type owl:DatatypeProperty ;
                  rdfs:domain obo:IAO_0020000 ;
                  rdfs:range xsd:anyURI ;
                  rdfs:comment "The literal value of the base URL used by the identifier scheme."@en ;
-                 rdfs:label "identifier base URI"@en ;
-                 aeon:SMW_datatype "URL" ;
-                 aeon:SMW_import_info """[[partOfSubobject::Template:Subobject External_Process_ID]]
-[[partOfSubobject::Template:Subobject Person_ID]]
-[[partOfSubobject::Template:Subobject Organization_ID]]
-
-[[Category:AEON]] [[Category:Imported vocabulary]]""" .
+                 rdfs:label "identifier base URI"@en .
 
 
 ###  https://github.com/tibonto/aeon#abstract_deadline
@@ -1356,36 +1204,28 @@ aeon:abstract_deadline rdf:type owl:DatatypeProperty ;
                        rdfs:subPropertyOf aeon:deadline ;
                        rdfs:domain aeon:AEON_0000001 ;
                        rdfs:range xsd:dateTimeStamp ;
-                       rdfs:label "abstract deadline"@en ;
-                       aeon:SMW_datatype "Date" ;
-                       aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+                       rdfs:label "abstract deadline"@en .
 
 
 ###  https://github.com/tibonto/aeon#acceptance_rate
 aeon:acceptance_rate rdf:type owl:DatatypeProperty ;
                      rdfs:subPropertyOf aeon:metric ;
                      rdfs:domain aeon:AEON_0000001 ;
-                     rdfs:label "acceptance rate"@en ;
-                     aeon:SMW_datatype "Number" ;
-                     aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+                     rdfs:label "acceptance rate"@en .
 
 
 ###  https://github.com/tibonto/aeon#accepted_papers
 aeon:accepted_papers rdf:type owl:DatatypeProperty ;
                      rdfs:subPropertyOf aeon:metric ;
                      rdfs:domain aeon:AEON_0000001 ;
-                     rdfs:label "accepted papers"@en ;
-                     aeon:SMW_datatype "Number" ;
-                     aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+                     rdfs:label "accepted papers"@en .
 
 
 ###  https://github.com/tibonto/aeon#accepted_short_papers
 aeon:accepted_short_papers rdf:type owl:DatatypeProperty ;
                            rdfs:subPropertyOf aeon:metric ;
                            rdfs:domain aeon:AEON_0000001 ;
-                           rdfs:label "accepted short papers"@en ;
-                           aeon:SMW_datatype "Number" ;
-                           aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+                           rdfs:label "accepted short papers"@en .
 
 
 ###  https://github.com/tibonto/aeon#camera-ready_deadline
@@ -1393,72 +1233,56 @@ aeon:camera-ready_deadline rdf:type owl:DatatypeProperty ;
                            rdfs:subPropertyOf aeon:deadline ;
                            rdfs:domain aeon:AEON_0000001 ;
                            rdfs:range xsd:dateTimeStamp ;
-                           rdfs:label "camera-ready deadline"@en ;
-                           aeon:SMW_datatype "Date" ;
-                           aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+                           rdfs:label "camera-ready deadline"@en .
 
 
 ###  https://github.com/tibonto/aeon#city
 aeon:city rdf:type owl:DatatypeProperty ;
           rdfs:subPropertyOf aeon:location ;
           rdfs:domain aeon:AEON_0000022 ;
-          rdfs:label "city"@en ;
-          aeon:SMW_datatype "Text" ;
-          aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+          rdfs:label "city"@en .
 
 
 ###  https://github.com/tibonto/aeon#contact
 aeon:contact rdf:type owl:DatatypeProperty ;
              rdfs:subPropertyOf owl:topDataProperty ;
              rdfs:domain aeon:AEON_0000009 ;
-             rdfs:label "contact"@en ;
-             aeon:SMW_datatype "Text" ;
-             aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+             rdfs:label "contact"@en .
 
 
 ###  https://github.com/tibonto/aeon#contact_email
 aeon:contact_email rdf:type owl:DatatypeProperty ;
                    rdfs:subPropertyOf aeon:contact ;
                    rdfs:domain aeon:AEON_0000009 ;
-                   rdfs:label "contact email"@en ;
-                   aeon:SMW_datatype "Email" ;
-                   aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+                   rdfs:label "contact email"@en .
 
 
 ###  https://github.com/tibonto/aeon#contact_person_name
 aeon:contact_person_name rdf:type owl:DatatypeProperty ;
                          rdfs:subPropertyOf aeon:contact ;
                          rdfs:domain aeon:AEON_0000009 ;
-                         rdfs:label "contact person"@en ;
-                         aeon:SMW_datatype "Text" ;
-                         aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+                         rdfs:label "contact person"@en .
 
 
 ###  https://github.com/tibonto/aeon#contact_phone
 aeon:contact_phone rdf:type owl:DatatypeProperty ;
                    rdfs:subPropertyOf aeon:contact ;
                    rdfs:domain aeon:AEON_0000009 ;
-                   rdfs:label "contact phone"@en ;
-                   aeon:SMW_datatype "Telephone number" ;
-                   aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+                   rdfs:label "contact phone"@en .
 
 
 ###  https://github.com/tibonto/aeon#coordinates
 aeon:coordinates rdf:type owl:DatatypeProperty ;
                  rdfs:subPropertyOf aeon:location ;
                  rdfs:domain obo:GAZ_00000448 ;
-                 rdfs:label "coordinates"@en ;
-                 aeon:SMW_datatype "Geographic coordinates" ;
-                 aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+                 rdfs:label "coordinates"@en .
 
 
 ###  https://github.com/tibonto/aeon#country
 aeon:country rdf:type owl:DatatypeProperty ;
              rdfs:subPropertyOf aeon:location ;
              rdfs:domain aeon:AEON_0000023 ;
-             rdfs:label "country"@en ;
-             aeon:SMW_datatype "Text" ;
-             aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+             rdfs:label "country"@en .
 
 
 ###  https://github.com/tibonto/aeon#deadline
@@ -1466,9 +1290,7 @@ aeon:deadline rdf:type owl:DatatypeProperty ;
               rdfs:subPropertyOf owl:topDataProperty ;
               rdfs:domain aeon:AEON_0000001 ;
               rdfs:range xsd:dateTime ;
-              rdfs:label "deadline"@en ;
-              aeon:SMW_datatype "Date" ;
-              aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+              rdfs:label "deadline"@en .
 
 
 ###  https://github.com/tibonto/aeon#demo_deadline
@@ -1476,9 +1298,7 @@ aeon:demo_deadline rdf:type owl:DatatypeProperty ;
                    rdfs:subPropertyOf aeon:deadline ;
                    rdfs:domain aeon:AEON_0000001 ;
                    rdfs:range xsd:dateTimeStamp ;
-                   rdfs:label "demo deadline"@en ;
-                   aeon:SMW_datatype "Date" ;
-                   aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+                   rdfs:label "demo deadline"@en .
 
 
 ###  https://github.com/tibonto/aeon#duration
@@ -1486,11 +1306,7 @@ aeon:duration rdf:type owl:DatatypeProperty ;
               rdfs:subPropertyOf owl:topDataProperty ;
               rdfs:domain aeon:AEON_0000001 ;
               rdfs:label "duration"@en ;
-              aeon:AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P2047\", \"label\": \"duration\"}, \"gnd\": {\"uri\": \"https://d-nb.info/standards/elementset/gnd#dateOfConferenceOrEvent\", \"label\": \"Date of conference or event\"}}"^^xsd:string ;
-              aeon:SMW_datatype "Quantity" ;
-              aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" ;
-              aeon:WikidataLabel "duration" ;
-              aeon:WikidataURI "https://www.wikidata.org/wiki/Property:P2047" .
+              aeon:AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P2047\", \"label\": \"duration\"}, \"gnd\": {\"uri\": \"https://d-nb.info/standards/elementset/gnd#dateOfConferenceOrEvent\", \"label\": \"Date of conference or event\"}}"^^xsd:string .
 
 
 ###  https://github.com/tibonto/aeon#end_date
@@ -1499,11 +1315,7 @@ aeon:end_date rdf:type owl:DatatypeProperty ;
               rdfs:domain aeon:AEON_0000001 ;
               rdfs:range xsd:dateTimeStamp ;
               rdfs:label "end date"@en ;
-              aeon:AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P582\", \"label\": \"end_time\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Property:End_date\", \"label\": \"End_date\"},\"crossref\": {\"api_proceedings_endpoint_uri\": \"https://api.crossref.org/types/proceedings/works?select=event\", \"json_api_key\": {\"event\": \"end\"}}}"^^xsd:string ;
-              aeon:SMW_datatype "Date" ;
-              aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" ;
-              aeon:WikidataLabel "end_time" ;
-              aeon:WikidataURI "https://www.wikidata.org/wiki/Property:P582" .
+              aeon:AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P582\", \"label\": \"end_time\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Property:End_date\", \"label\": \"End_date\"},\"crossref\": {\"api_proceedings_endpoint_uri\": \"https://api.crossref.org/types/proceedings/works?select=event\", \"json_api_key\": {\"event\": \"end\"}}}"^^xsd:string .
 
 
 ###  https://github.com/tibonto/aeon#event_frequency
@@ -1512,13 +1324,7 @@ aeon:event_frequency rdf:type owl:DatatypeProperty ;
                      rdfs:domain aeon:AEON_0000002 ;
                      obo:IAO_0000115 "The event frequency is the literal value of the number of month until the next event in a certain takes place." ;
                      rdfs:label "event frequency"@en ;
-                     aeon:AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P2257\", \"label\": \"event_interval_inmonths\"}}"^^xsd:string ;
-                     aeon:SMW_datatype "Quantity" ;
-                     aeon:SMW_import_info """[[Corresponds to::1 month]] [[Corresponds to::1 months]] [[display units::months]]
-
-[[Category:AEON]] [[Category:Imported vocabulary]]""" ;
-                     aeon:WikidataLabel "event_interval_inmonths" ;
-                     aeon:WikidataURI "https://www.wikidata.org/wiki/Property:P2257" .
+                     aeon:AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P2257\", \"label\": \"event_interval_inmonths\"}}"^^xsd:string .
 
 
 ###  https://github.com/tibonto/aeon#event_number
@@ -1527,9 +1333,7 @@ aeon:event_number rdf:type owl:DatatypeProperty ;
                   rdfs:range xsd:string ;
                   obo:IAO_0000115 "The ordinal number of an academic event, if it is a part of an event series." ;
                   rdfs:label "event number"@en ;
-                  aeon:AEON_0000026 "{\"crossref\": {\"api_proceedings_endpoint_uri\": \"https://api.crossref.org/types/proceedings/works?select=event\", \"json_api_key\": {\"event\": \"number\"}}}"^^xsd:string ;
-                  aeon:SMW_datatype "Text" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+                  aeon:AEON_0000026 "{\"crossref\": {\"api_proceedings_endpoint_uri\": \"https://api.crossref.org/types/proceedings/works?select=event\", \"json_api_key\": {\"event\": \"number\"}}}"^^xsd:string .
 
 
 ###  https://github.com/tibonto/aeon#event_status
@@ -1562,9 +1366,7 @@ ConfIDent → DataCite
 scheduled → valid
 postponed → updated
 cancled → withdrawn"""@en ;
-                  rdfs:label "event status"@en ;
-                  aeon:SMW_datatype "Text" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+                  rdfs:label "event status"@en .
 
 
 ###  https://github.com/tibonto/aeon#event_type_other
@@ -1572,9 +1374,7 @@ aeon:event_type_other rdf:type owl:DatatypeProperty ;
                       rdfs:subPropertyOf owl:topDataProperty ;
                       rdfs:domain aeon:AEON_0000004 ;
                       rdfs:range xsd:string ;
-                      rdfs:label "event type other"@en ;
-                      aeon:SMW_datatype "Text" ;
-                      aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+                      rdfs:label "event type other"@en .
 
 
 ###  https://github.com/tibonto/aeon#event_year
@@ -1582,9 +1382,7 @@ aeon:event_year rdf:type owl:DatatypeProperty ;
                 rdfs:domain aeon:AEON_0000001 ;
                 rdfs:range xsd:integer ;
                 obo:IAO_0000115 "The year in which an event takes place."@en ;
-                rdfs:label "event year"@en ;
-                aeon:SMW_datatype "Date" ;
-                aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+                rdfs:label "event year"@en .
 
 
 ###  https://github.com/tibonto/aeon#fee
@@ -1593,11 +1391,7 @@ aeon:fee rdf:type owl:DatatypeProperty ;
          rdfs:domain aeon:AEON_0000030 ;
          obo:IAO_0000115 "The literal value of the type of fee an aeon:event can have."@en ;
          obo:IAO_0000600 "There are various type of fees for an event, such as the regular fee, a reduced fee, a member fee and so forth." ;
-         rdfs:label "fee"@en ;
-         aeon:SMW_datatype "Text" ;
-         aeon:SMW_import_info """[[partOfSubobject::Template:Subobject Fee]]
-
-[[Category:AEON]] [[Category:Imported vocabulary]]""" .
+         rdfs:label "fee"@en .
 
 
 ###  https://github.com/tibonto/aeon#fee_currency
@@ -1605,24 +1399,14 @@ aeon:fee_currency rdf:type owl:DatatypeProperty ;
                   rdfs:subPropertyOf aeon:fee ;
                   rdfs:domain aeon:AEON_0000030 ;
                   rdfs:comment "This property should have a value from the controlled list defined by the ISO_4217 standard (https://en.wikipedia.org/wiki/ISO_4217)." ;
-                  rdfs:label "fee currency"@en ;
-                  aeon:SMW_datatype "Text" ;
-                  aeon:SMW_import_info """Controlled vocabulary in [[MediaWiki:Smw_allows_list_Fee_currency]]
-
-[[partOfSubobject::Template:Subobject Fee]]
-
-[[Category:AEON]] [[Category:Imported vocabulary]]""" .
+                  rdfs:label "fee currency"@en .
 
 
 ###  https://github.com/tibonto/aeon#fee_value
 aeon:fee_value rdf:type owl:DatatypeProperty ;
                rdfs:subPropertyOf aeon:fee ;
                rdfs:domain aeon:AEON_0000030 ;
-               rdfs:label "fee value"@en ;
-               aeon:SMW_datatype "Number" ;
-               aeon:SMW_import_info """[[partOfSubobject::Template:Subobject Fee]]
-
-[[Category:AEON]] [[Category:Imported vocabulary]]""" .
+               rdfs:label "fee value"@en .
 
 
 ###  https://github.com/tibonto/aeon#first_name
@@ -1631,9 +1415,7 @@ aeon:first_name rdf:type owl:DatatypeProperty ;
                 rdfs:domain obo:NCBITaxon_9606 ;
                 rdfs:range xsd:string ;
                 obo:IAO_0000115 "The literal value of the first name of a person."@en ;
-                rdfs:label "first name"@en ;
-                aeon:SMW_datatype "Text" ;
-                aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+                rdfs:label "first name"@en .
 
 
 ###  https://github.com/tibonto/aeon#landing_page
@@ -1642,24 +1424,14 @@ aeon:landing_page rdf:type owl:DatatypeProperty ;
                   rdfs:domain obo:IAO_0020000 ;
                   rdfs:range xsd:anyURI ;
                   rdfs:comment "The literal value of the landing page (URL) an ID resolves to when following the ID_URL."@en ;
-                  rdfs:label "identifier landing page"@en ;
-                  aeon:SMW_datatype "URL" ;
-                  aeon:SMW_import_info """[[partOfSubobject::Template:Subobject External_Process_ID]]
-[[partOfSubobject::Template:Subobject Person_ID]]
-[[partOfSubobject::Template:Subobject Organization_ID]]
-
-[[Category:AEON]] [[Category:Imported vocabulary]]""" .
+                  rdfs:label "identifier landing page"@en .
 
 
 ###  https://github.com/tibonto/aeon#language
 aeon:language rdf:type owl:DatatypeProperty ;
               rdfs:subPropertyOf owl:topDataProperty ;
               rdfs:label "language"@en ;
-              aeon:AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P2936\", \"label\": \"language_usedLabel\"}}"^^xsd:string ;
-              aeon:SMW_datatype "Text" ;
-              aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" ;
-              aeon:WikidataLabel "language_usedLabel" ;
-              aeon:WikidataURI "https://www.wikidata.org/wiki/Property:P2936" .
+              aeon:AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P2936\", \"label\": \"language_usedLabel\"}}"^^xsd:string .
 
 
 ###  https://github.com/tibonto/aeon#last_name
@@ -1668,26 +1440,20 @@ aeon:last_name rdf:type owl:DatatypeProperty ;
                rdfs:domain obo:NCBITaxon_9606 ;
                rdfs:range xsd:string ;
                obo:IAO_0000115 "The literal value of the last name, or family name, of a person."@en ;
-               rdfs:label "last name"@en ;
-               aeon:SMW_datatype "Text" ;
-               aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+               rdfs:label "last name"@en .
 
 
 ###  https://github.com/tibonto/aeon#location
 aeon:location rdf:type owl:DatatypeProperty ;
               rdfs:subPropertyOf owl:topDataProperty ;
               rdfs:domain obo:BFO_0000029 ;
-              rdfs:label "location"@en ;
-              aeon:SMW_datatype "Text" ;
-              aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+              rdfs:label "location"@en .
 
 
 ###  https://github.com/tibonto/aeon#logo
 aeon:logo rdf:type owl:DatatypeProperty ;
           rdfs:subPropertyOf owl:topDataProperty ;
-          rdfs:label "logo"@en ;
-          aeon:SMW_datatype "Page" ;
-          aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+          rdfs:label "logo"@en .
 
 
 ###  https://github.com/tibonto/aeon#meeting_URL
@@ -1695,29 +1461,21 @@ aeon:meeting_URL rdf:type owl:DatatypeProperty ;
                  rdfs:subPropertyOf aeon:location ;
                  rdfs:domain aeon:AEON_0000029 ;
                  rdfs:range xsd:anyURI ;
-                 rdfs:label "meeting URL"@en ;
-                 aeon:SMW_datatype "URL" ;
-                 aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+                 rdfs:label "meeting URL"@en .
 
 
 ###  https://github.com/tibonto/aeon#metric
 aeon:metric rdf:type owl:DatatypeProperty ;
             rdfs:subPropertyOf owl:topDataProperty ;
             rdfs:domain obo:OBI_0000011 ;
-            rdfs:label "metric"@en ;
-            aeon:SMW_datatype "Text" ;
-            aeon:SMW_import_info """[[partOfSubobject::Template:Subobject Metric]]
-
-[[Category:AEON]] [[Category:Imported vocabulary]]""" .
+            rdfs:label "metric"@en .
 
 
 ###  https://github.com/tibonto/aeon#name
 aeon:name rdf:type owl:DatatypeProperty ;
           rdfs:subPropertyOf owl:topDataProperty ;
           obo:IAO_0000115 "The literal value of the name of a thing."@en ;
-          rdfs:label "name"@en ;
-          aeon:SMW_datatype "Text" ;
-          aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+          rdfs:label "name"@en .
 
 
 ###  https://github.com/tibonto/aeon#notification_deadline
@@ -1725,9 +1483,7 @@ aeon:notification_deadline rdf:type owl:DatatypeProperty ;
                            rdfs:subPropertyOf aeon:deadline ;
                            rdfs:domain aeon:AEON_0000001 ;
                            rdfs:range xsd:dateTimeStamp ;
-                           rdfs:label "notification deadline"@en ;
-                           aeon:SMW_datatype "Date" ;
-                           aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+                           rdfs:label "notification deadline"@en .
 
 
 ###  https://github.com/tibonto/aeon#number_of_attendees
@@ -1735,18 +1491,14 @@ aeon:number_of_attendees rdf:type owl:DatatypeProperty ;
                          rdfs:subPropertyOf aeon:metric ;
                          rdfs:domain aeon:AEON_0000001 ;
                          rdfs:label "number of attendess"@en ;
-                         aeon:AEON_0000026 "{\"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Property:Attendees\", \"label\": \"Attendees\"}}"^^xsd:string ;
-                         aeon:SMW_datatype "Number" ;
-                         aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+                         aeon:AEON_0000026 "{\"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Property:Attendees\", \"label\": \"Attendees\"}}"^^xsd:string .
 
 
 ###  https://github.com/tibonto/aeon#number_of_tracks
 aeon:number_of_tracks rdf:type owl:DatatypeProperty ;
                       rdfs:subPropertyOf aeon:metric ;
                       rdfs:domain aeon:AEON_0000001 ;
-                      rdfs:label "number of tracks"@en ;
-                      aeon:SMW_datatype "Number" ;
-                      aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+                      rdfs:label "number of tracks"@en .
 
 
 ###  https://github.com/tibonto/aeon#organizational_name
@@ -1755,9 +1507,7 @@ aeon:organizational_name rdf:type owl:DatatypeProperty ;
                          rdfs:domain obo:OBI_0000245 ;
                          rdfs:range xsd:string ;
                          obo:IAO_0000115 "The literal value of the name to denote an organization."@en ;
-                         rdfs:label "organizational name"@en ;
-                         aeon:SMW_datatype "Text" ;
-                         aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+                         rdfs:label "organizational name"@en .
 
 
 ###  https://github.com/tibonto/aeon#paper_deadline
@@ -1765,9 +1515,7 @@ aeon:paper_deadline rdf:type owl:DatatypeProperty ;
                     rdfs:subPropertyOf aeon:deadline ;
                     rdfs:domain aeon:AEON_0000001 ;
                     rdfs:range xsd:dateTimeStamp ;
-                    rdfs:label "paper deadline"@en ;
-                    aeon:SMW_datatype "Date" ;
-                    aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+                    rdfs:label "paper deadline"@en .
 
 
 ###  https://github.com/tibonto/aeon#personal_name
@@ -1776,9 +1524,7 @@ aeon:personal_name rdf:type owl:DatatypeProperty ;
                    rdfs:domain obo:NCBITaxon_9606 ;
                    rdfs:range xsd:string ;
                    obo:IAO_0000115 "The literal value of the name to denote a person."@en ;
-                   rdfs:label "personal name"@en ;
-                   aeon:SMW_datatype "Text" ;
-                   aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+                   rdfs:label "personal name"@en .
 
 
 ###  https://github.com/tibonto/aeon#poster_deadline
@@ -1786,9 +1532,7 @@ aeon:poster_deadline rdf:type owl:DatatypeProperty ;
                      rdfs:subPropertyOf aeon:deadline ;
                      rdfs:domain aeon:AEON_0000001 ;
                      rdfs:range xsd:dateTimeStamp ;
-                     rdfs:label "poster deadline"@en ;
-                     aeon:SMW_datatype "Date" ;
-                     aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+                     rdfs:label "poster deadline"@en .
 
 
 ###  https://github.com/tibonto/aeon#previous_end_date
@@ -1796,9 +1540,7 @@ aeon:previous_end_date rdf:type owl:DatatypeProperty ;
                        rdfs:subPropertyOf aeon:end_date ;
                        rdfs:domain aeon:AEON_0000001 ;
                        rdfs:range xsd:dateTime ;
-                       rdfs:label "previous end date"@en ;
-                       aeon:SMW_datatype "Date" ;
-                       aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+                       rdfs:label "previous end date"@en .
 
 
 ###  https://github.com/tibonto/aeon#previous_start_date
@@ -1806,18 +1548,14 @@ aeon:previous_start_date rdf:type owl:DatatypeProperty ;
                          rdfs:subPropertyOf aeon:start_date ;
                          rdfs:domain aeon:AEON_0000001 ;
                          rdfs:range xsd:dateTimeStamp ;
-                         rdfs:label "previous start date"@en ;
-                         aeon:SMW_datatype "Date" ;
-                         aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+                         rdfs:label "previous start date"@en .
 
 
 ###  https://github.com/tibonto/aeon#proceedings_site_count
 aeon:proceedings_site_count rdf:type owl:DatatypeProperty ;
                             rdfs:subPropertyOf aeon:metric ;
                             rdfs:domain aeon:AEON_0000001 ;
-                            rdfs:label "proceeding cite count"@en ;
-                            aeon:SMW_datatype "Number" ;
-                            aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+                            rdfs:label "proceeding cite count"@en .
 
 
 ###  https://github.com/tibonto/aeon#process_acronym
@@ -1827,11 +1565,7 @@ aeon:process_acronym rdf:type owl:DatatypeProperty ;
                      obo:IAO_0000112 "\"DILS 2019\" is the official acronym of the academic event \"13th International Conference on Data Integration in Life Science\""@en ;
                      obo:IAO_0000115 "The literal value of the official acronym of an aeon:process, that is either an academic event or event series."@en ;
                      rdfs:label "acronym"@en ;
-                     aeon:AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P1813\", \"label\": \"short_nameLabel\"}, \"gnd\": {\"uri\": \"https://d-nb.info/standards/elementset/gnd#abbreviatedNameForTheConferenceOrEvent\", \"label\": \"Abbreviated name for the conference or event\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Property:Acronym\", \"label\": \"Acronym\"}, \"crossref\": {\"api_proceedings_endpoint_uri\": \"https://api.crossref.org/types/proceedings/works?select=event\", \"json_api_key\": {\"event\": \"acronym\"}}}"^^xsd:string ;
-                     aeon:SMW_datatype "Text" ;
-                     aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" ;
-                     aeon:WikidataLabel "short_nameLabel" ;
-                     aeon:WikidataURI "https://www.wikidata.org/wiki/Property:P1813" .
+                     aeon:AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P1813\", \"label\": \"short_nameLabel\"}, \"gnd\": {\"uri\": \"https://d-nb.info/standards/elementset/gnd#abbreviatedNameForTheConferenceOrEvent\", \"label\": \"Abbreviated name for the conference or event\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Property:Acronym\", \"label\": \"Acronym\"}, \"crossref\": {\"api_proceedings_endpoint_uri\": \"https://api.crossref.org/types/proceedings/works?select=event\", \"json_api_key\": {\"event\": \"acronym\"}}}"^^xsd:string .
 
 
 ###  https://github.com/tibonto/aeon#process_alternative_name
@@ -1840,9 +1574,7 @@ aeon:process_alternative_name rdf:type owl:DatatypeProperty ;
                               rdfs:range xsd:string ;
                               rdfs:comment "The Literal value of an alternative name of an aeon:process, that is either an academic event or event series."@en ;
                               rdfs:label "alternative name"@en ;
-                              aeon:AEON_0000026 "{\"gnd\": {\"uri\": \"https://d-nb.info/standards/elementset/gnd#variantNameForTheConferenceOrEvent\", \"label\": \"Variant name for the conference or event\"}, \"crossref\": {\"api_proceedings_endpoint_uri\": \"https://api.crossref.org/types/proceedings/works?select=title\", \"json_api_key\": \"title\"}}"^^xsd:string ;
-                              aeon:SMW_datatype "Text" ;
-                              aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+                              aeon:AEON_0000026 "{\"gnd\": {\"uri\": \"https://d-nb.info/standards/elementset/gnd#variantNameForTheConferenceOrEvent\", \"label\": \"Variant name for the conference or event\"}, \"crossref\": {\"api_proceedings_endpoint_uri\": \"https://api.crossref.org/types/proceedings/works?select=title\", \"json_api_key\": \"title\"}}"^^xsd:string .
 
 
 ###  https://github.com/tibonto/aeon#process_former_name
@@ -1850,9 +1582,7 @@ aeon:process_former_name rdf:type owl:DatatypeProperty ;
                          rdfs:subPropertyOf aeon:name ;
                          rdfs:range xsd:string ;
                          rdfs:comment "The Literal value of the former official name of an aeon:process, that is either an academic event or event series."@en ;
-                         rdfs:label "former name"@en ;
-                         aeon:SMW_datatype "Text" ;
-                         aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+                         rdfs:label "former name"@en .
 
 
 ###  https://github.com/tibonto/aeon#process_translated_name
@@ -1860,9 +1590,7 @@ aeon:process_translated_name rdf:type owl:DatatypeProperty ;
                              rdfs:subPropertyOf aeon:name ;
                              rdfs:range xsd:string ;
                              obo:IAO_0000115 "The literal value of the translation of the official name (title) of an aeon:process, that is either an academic event or event series."@en ;
-                             rdfs:label "translated name"@en ;
-                             aeon:SMW_datatype "Text" ;
-                             aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+                             rdfs:label "translated name"@en .
 
 
 ###  https://github.com/tibonto/aeon#process_website
@@ -1871,20 +1599,14 @@ aeon:process_website rdf:type owl:DatatypeProperty ;
                      rdfs:domain obo:OBI_0000011 ;
                      rdfs:range xsd:anyURI ;
                      rdfs:label "process website"@en ;
-                     aeon:AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P856\", \"label\": \"official_website\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Property:Homepage\", \"label\": \"Homepage\"}}"^^xsd:string ;
-                     aeon:SMW_datatype "URL" ;
-                     aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" ;
-                     aeon:WikidataLabel "official_website" ;
-                     aeon:WikidataURI "https://www.wikidata.org/wiki/Property:P856" .
+                     aeon:AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P856\", \"label\": \"official_website\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Property:Homepage\", \"label\": \"Homepage\"}}"^^xsd:string .
 
 
 ###  https://github.com/tibonto/aeon#series_cite_count
 aeon:series_cite_count rdf:type owl:DatatypeProperty ;
                        rdfs:subPropertyOf aeon:metric ;
                        rdfs:domain aeon:AEON_0000002 ;
-                       rdfs:label "series cite count"@en ;
-                       aeon:SMW_datatype "Number" ;
-                       aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+                       rdfs:label "series cite count"@en .
 
 
 ###  https://github.com/tibonto/aeon#sponsor_type
@@ -1892,11 +1614,7 @@ aeon:sponsor_type rdf:type owl:DatatypeProperty ;
                   rdfs:subPropertyOf owl:topDataProperty ;
                   rdfs:domain aeon:AEON_0000015 ;
                   rdfs:range xsd:string ;
-                  rdfs:label "sponsor type"@en ;
-                  aeon:SMW_datatype "Text" ;
-                  aeon:SMW_import_info """Controlled vocabulary in [[MediaWiki:Smw _allows_list_Sponsor_type]] 
-
-[[Category:AEON]] [[Category:Imported vocabulary]]""" .
+                  rdfs:label "sponsor type"@en .
 
 
 ###  https://github.com/tibonto/aeon#start_date
@@ -1905,20 +1623,14 @@ aeon:start_date rdf:type owl:DatatypeProperty ;
                 rdfs:domain aeon:AEON_0000001 ;
                 rdfs:range xsd:dateTime ;
                 rdfs:label "start date"@en ;
-                aeon:AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P580\", \"label\": \"start_time\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Property:Start_date\", \"label\": \"Start_date\"},\"crossref\": {\"api_proceedings_endpoint_uri\": \"https://api.crossref.org/types/proceedings/works?select=event\", \"json_api_key\": {\"event\": \"start\"}}}"^^xsd:string ;
-                aeon:SMW_datatype "Date" ;
-                aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" ;
-                aeon:WikidataLabel "start_time" ;
-                aeon:WikidataURI "https://www.wikidata.org/wiki/Property:P580" .
+                aeon:AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Property:P580\", \"label\": \"start_time\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Property:Start_date\", \"label\": \"Start_date\"},\"crossref\": {\"api_proceedings_endpoint_uri\": \"https://api.crossref.org/types/proceedings/works?select=event\", \"json_api_key\": {\"event\": \"start\"}}}"^^xsd:string .
 
 
 ###  https://github.com/tibonto/aeon#state
 aeon:state rdf:type owl:DatatypeProperty ;
            rdfs:subPropertyOf aeon:location ;
            rdfs:domain aeon:AEON_0000024 ;
-           rdfs:label "state"@en ;
-           aeon:SMW_datatype "Text" ;
-           aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+           rdfs:label "state"@en .
 
 
 ###  https://github.com/tibonto/aeon#submission_deadline
@@ -1926,34 +1638,26 @@ aeon:submission_deadline rdf:type owl:DatatypeProperty ;
                          rdfs:subPropertyOf aeon:deadline ;
                          rdfs:domain aeon:AEON_0000001 ;
                          rdfs:range xsd:dateTimeStamp ;
-                         rdfs:label "submission deadline"@en ;
-                         aeon:SMW_datatype "Date" ;
-                         aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+                         rdfs:label "submission deadline"@en .
 
 
 ###  https://github.com/tibonto/aeon#submitted_papers
 aeon:submitted_papers rdf:type owl:DatatypeProperty ;
                       rdfs:subPropertyOf aeon:metric ;
                       rdfs:domain aeon:AEON_0000001 ;
-                      rdfs:label "submitted papers"@en ;
-                      aeon:SMW_datatype "Number" ;
-                      aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+                      rdfs:label "submitted papers"@en .
 
 
 ###  https://github.com/tibonto/aeon#summary
 aeon:summary rdf:type owl:DatatypeProperty ;
              rdfs:subPropertyOf owl:topDataProperty ;
-             rdfs:label "summary"@en ;
-             aeon:SMW_datatype "Text" ;
-             aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+             rdfs:label "summary"@en .
 
 
 ###  https://github.com/tibonto/aeon#summary_licence
 aeon:summary_licence rdf:type owl:DatatypeProperty ;
                      rdfs:subPropertyOf aeon:summary ;
-                     rdfs:label "summary licence"@en ;
-                     aeon:SMW_datatype "Text" ;
-                     aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+                     rdfs:label "summary licence"@en .
 
 
 ###  https://github.com/tibonto/aeon#tutorial_deadline
@@ -1961,18 +1665,14 @@ aeon:tutorial_deadline rdf:type owl:DatatypeProperty ;
                        rdfs:subPropertyOf aeon:deadline ;
                        rdfs:domain aeon:AEON_0000001 ;
                        rdfs:range xsd:dateTimeStamp ;
-                       rdfs:label "tutorial deadline"@en ;
-                       aeon:SMW_datatype "Date" ;
-                       aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+                       rdfs:label "tutorial deadline"@en .
 
 
 ###  https://github.com/tibonto/aeon#venue
 aeon:venue rdf:type owl:DatatypeProperty ;
            rdfs:subPropertyOf aeon:location ;
            rdfs:domain aeon:AEON_0000025 ;
-           rdfs:label "venue"@en ;
-           aeon:SMW_datatype "Text" ;
-           aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+           rdfs:label "venue"@en .
 
 
 ###  https://github.com/tibonto/aeon#venue_URL
@@ -1980,9 +1680,7 @@ aeon:venue_URL rdf:type owl:DatatypeProperty ;
                rdfs:subPropertyOf aeon:venue ;
                rdfs:domain aeon:AEON_0000025 ;
                rdfs:range xsd:anyURI ;
-               rdfs:label "venue website"@en ;
-               aeon:SMW_datatype "URL" ;
-               aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+               rdfs:label "venue website"@en .
 
 
 ###  https://github.com/tibonto/aeon#workshop_deadline
@@ -1990,9 +1688,7 @@ aeon:workshop_deadline rdf:type owl:DatatypeProperty ;
                        rdfs:subPropertyOf aeon:deadline ;
                        rdfs:domain aeon:AEON_0000001 ;
                        rdfs:range xsd:dateTimeStamp ;
-                       rdfs:label "workshop deadline"@en ;
-                       aeon:SMW_datatype "Date" ;
-                       aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+                       rdfs:label "workshop deadline"@en .
 
 
 #################################################################
@@ -2362,9 +2058,7 @@ obo:BFO_0000148 rdf:type owl:Class ;
 ###  http://purl.obolibrary.org/obo/GAZ_00000448
 obo:GAZ_00000448 rdf:type owl:Class ;
                  rdfs:subClassOf obo:BFO_0000029 ;
-                 rdfs:label "geographic location"@en ;
-                 aeon:SMW_datatype "Category" ;
-                 aeon:SMW_import_info "[[Category:GAZ]] [[Category:Imported vocabulary]]" .
+                 rdfs:label "geographic location"@en .
 
 
 ###  http://purl.obolibrary.org/obo/IAO_0000027
@@ -2685,9 +2379,7 @@ obo:ICO_0000048 rdf:type owl:Class ;
                 obo:IAO_0000115 "An organization that is operated without the principal goal of making a financial profit."@en ;
                 obo:IAO_0000117 "Yongqun He"@en ;
                 obo:IAO_0000412 "http://purl.obolibrary.org/obo/2020-08-27/ico.owl"^^xsd:string ;
-                rdfs:label "nonprofit organization"@en ;
-                aeon:SMW_datatype "Category" ;
-                aeon:SMW_import_info "[[Category:ICO]] [[Category:Imported vocabulary]]" .
+                rdfs:label "nonprofit organization"@en .
 
 
 ###  http://purl.obolibrary.org/obo/ICO_0000049
@@ -2696,9 +2388,7 @@ obo:ICO_0000049 rdf:type owl:Class ;
                 obo:IAO_0000115 "An organization which has the principle goal of earning financial profit."@en ;
                 obo:IAO_0000117 "Yongqun He"@en ;
                 obo:IAO_0000412 "http://purl.obolibrary.org/obo/2020-08-27/ico.owl"^^xsd:string ;
-                rdfs:label "profit organization"@en ;
-                aeon:SMW_datatype "Category" ;
-                aeon:SMW_import_info "[[Category:ICO]] [[Category:Imported vocabulary]]" .
+                rdfs:label "profit organization"@en .
 
 
 ###  http://purl.obolibrary.org/obo/NCBITaxon_9606
@@ -2717,9 +2407,7 @@ obo:NCBITaxon_9606 rdf:type owl:Class ;
                                    "human being"^^xsd:string ,
                                    "man"^^xsd:string ;
                    obo:IAO_0000412 "http://purl.obolibrary.org/obo/obi/2020-12-16/obi.owl"^^xsd:string ;
-                   rdfs:label "Homo sapiens"^^xsd:string ;
-                   aeon:SMW_datatype "Category" ;
-                   aeon:SMW_import_info "[[Category:NCBITaxon]] [[Category:Imported vocabulary]]" .
+                   rdfs:label "Homo sapiens"^^xsd:string .
 
 
 ###  http://purl.obolibrary.org/obo/OBI_0000011
@@ -2768,9 +2456,7 @@ for now."""@en ;
                                 "PERSON: Susanna Sansone"^^xsd:string ;
                 obo:IAO_0000119 "GROUP: OBI"^^xsd:string ;
                 obo:IAO_0000412 "http://purl.obolibrary.org/obo/obi/2020-12-16/obi.owl"^^xsd:string ;
-                rdfs:label "organization"@en ;
-                aeon:SMW_datatype "Category" ;
-                aeon:SMW_import_info "[[Category:OBI]] [[Category:Imported vocabulary]]" .
+                rdfs:label "organization"@en .
 
 
 ###  http://purl.obolibrary.org/obo/OBI_0100026
@@ -2795,9 +2481,7 @@ Note that, because SKOS is designed to be a vehicle for representing semi-formal
 
 See the [SKOS-PRIMER] for more examples of identifying and describing SKOS concepts."""@en ;
              obo:IAO_0000412 "https://www.w3.org/2009/08/skos-reference/skos.html#Concept" ;
-             rdfs:label "Concept" ;
-             aeon:SMW_datatype "Category" ;
-             aeon:SMW_import_info "[[Category:SKOS]] [[Category:Imported vocabulary]]" .
+             rdfs:label "Concept" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000001
@@ -2818,10 +2502,7 @@ aeon:AEON_0000001 rdf:type owl:Class ;
 * It needs to be discussed, if we need the \"process boundary\" class to describe the start and end of an academic event or event series.
 * It needs to be discussed, if we need the \"temporal region\" and \"spatiotemporal region\"  classes to describe the duration and manifestation in spacetime of an academic event or event series."""@en ;
                   rdfs:label "academic event"@en ;
-                  aeon:AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Q1656682\", \"label\": \"eventLabel\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Category:Event\", \"label\": \"Event\"}, \"gnd\": {\"uri\": \"https://d-nb.info/standards/elementset/gnd#ConferenceOrEvent\", \"label\": \"Conference or Event\"}}"^^xsd:string ;
-                  aeon:SMW_datatype "Category" ;
-                  aeon:SMW_import_info """
-           [[Category:AEON]] [[Category:Imported vocabulary]]""" .
+                  aeon:AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Q1656682\", \"label\": \"eventLabel\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Category:Event\", \"label\": \"Event\"}, \"gnd\": {\"uri\": \"https://d-nb.info/standards/elementset/gnd#ConferenceOrEvent\", \"label\": \"Conference or Event\"}}"^^xsd:string .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000002
@@ -2833,9 +2514,7 @@ aeon:AEON_0000002 rdf:type owl:Class ;
                                   ] ;
                   obo:IAO_0000112 "International Semantic Web Conference (ISWC) series" ;
                   rdfs:label "academic event series" ;
-                  aeon:AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Q15900647\", \"label\": \"conference_seriesLabel\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Category:Event_series\", \"label\": \"Event_series\"}, \"gnd\": {\"uri\": \"https://d-nb.info/standards/elementset/gnd#SeriesOfConferenceOrEvent\", \"label\": \"Series of conference or event\"}}"^^xsd:string ;
-                  aeon:SMW_datatype "Category" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+                  aeon:AEON_0000026 "{\"wikidata\": {\"uri\": \"https://www.wikidata.org/wiki/Q15900647\", \"label\": \"conference_seriesLabel\"}, \"openresearch\": {\"uri\": \"https://www.openresearch.org/wiki/Category:Event_series\", \"label\": \"Event_series\"}, \"gnd\": {\"uri\": \"https://d-nb.info/standards/elementset/gnd#SeriesOfConferenceOrEvent\", \"label\": \"Series of conference or event\"}}"^^xsd:string .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000003
@@ -2845,9 +2524,7 @@ aeon:AEON_0000003 rdf:type owl:Class ;
                   obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
                   obo:IAO_0000118 "ConfIDent ID"@en ;
                   rdfs:label "internal identifier"@en ;
-                  ns:term_status obo:IAO_0000423 ;
-                  aeon:SMW_datatype "Category" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+                  ns:term_status obo:IAO_0000423 .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000004
@@ -2856,9 +2533,7 @@ aeon:AEON_0000004 rdf:type owl:Class ;
                   obo:IAO_0000115 "An event type is a skos:Concept that is being used to distinguish between the different academic event formats."@en ;
                   obo:IAO_0000116 "As the used definitions of the various academic event types can vary strongly between different communities and societies, we chose to model the type of an event as a SKOS concept instead of adding subclasses to the \"academic event\" class. The most commonly used event types are provided in AEON as named instances of this class."@en ;
                   obo:IAO_0000117 "PERSON: Philip Strömert" ;
-                  rdfs:label "event type"@en ;
-                  aeon:SMW_datatype "Category" ;
-                  aeon:SMW_import_info "The individuals/instances of this class make up the allowed value list in [[MediaWiki:Smw_allows_list_has_event_type]]. [[Category:AEON]] [[Category:Imported vocabulary]]" .
+                  rdfs:label "event type"@en .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000005
@@ -2890,9 +2565,7 @@ aeon:AEON_0000005 rdf:type owl:Class ;
                   obo:IAO_0000115 "The contributor role inheres in a person or organization that participates in a planned process by somehow contributing to it."@en ;
                   obo:IAO_0000117 "PERSON: Philip Strömert" ;
                   <http://purl.org/dc/elements/1.1/date> "2020-09-28T12:51:02Z"^^xsd:dateTime ;
-                  rdfs:label "contributor role"@en ;
-                  aeon:SMW_datatype "Category" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+                  rdfs:label "contributor role"@en .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000006
@@ -2907,11 +2580,7 @@ aeon:AEON_0000006 rdf:type owl:Class ;
                   rdfs:subClassOf aeon:AEON_0000005 ;
                   obo:IAO_0000115 "The organizer role inheres in a person or organization that contributes to a planned process by planning and managing its realization."@en ;
                   obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
-                  rdfs:label "organizer role"@en ;
-                  aeon:SMW_datatype "Category" ;
-                  aeon:SMW_import_info """[[partOfSubobject::Template:Subobject Organizer]]
-
-[[Category:AEON]] [[Category:Imported vocabulary]]""" .
+                  rdfs:label "organizer role"@en .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000007
@@ -2927,11 +2596,7 @@ aeon:AEON_0000007 rdf:type owl:Class ;
                   owl:disjointWith aeon:AEON_0000009 ;
                   obo:IAO_0000115 "The 'committee member role' inheres in a person who contributes to a planned process by somehow realizing the function of the committe he is a member of."@en ;
                   obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
-                  rdfs:label "event committee member role"@en ;
-                  aeon:SMW_datatype "Category" ;
-                  aeon:SMW_import_info """[[partOfSubobject::Template:Subobject Committee]]
-
-[[Category:AEON]] [[Category:Imported vocabulary]]""" .
+                  rdfs:label "event committee member role"@en .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000008
@@ -2946,9 +2611,7 @@ aeon:AEON_0000008 rdf:type owl:Class ;
                   rdfs:subClassOf aeon:AEON_0000007 ;
                   obo:IAO_0000115 "The 'committee chair role' inheres in a person who contributes to a planned process by somehow realizing the function of the committee he is a chair of."@en ;
                   obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
-                  rdfs:label "event committee chair role"@en ;
-                  aeon:SMW_datatype "Category" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+                  rdfs:label "event committee chair role"@en .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000009
@@ -2963,9 +2626,7 @@ aeon:AEON_0000009 rdf:type owl:Class ;
                   rdfs:subClassOf aeon:AEON_0000006 ;
                   obo:IAO_0000115 "The contact person role inheres in a person that contributes to a planned process by functioning as the addressee of the planned process who answers general inquiries and redirects more complex inqueries to a more appropriate addressee."@en ;
                   obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
-                  rdfs:label "contact person role"@en ;
-                  aeon:SMW_datatype "Category" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+                  rdfs:label "contact person role"@en .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000010
@@ -2980,9 +2641,7 @@ aeon:AEON_0000010 rdf:type owl:Class ;
                   rdfs:subClassOf aeon:AEON_0000005 ;
                   obo:IAO_0000115 "The attendee role inheres in a person that contributes to a planned process by attending it."@en ;
                   obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
-                  rdfs:label "attendee role"@en ;
-                  aeon:SMW_datatype "Category" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+                  rdfs:label "attendee role"@en .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000011
@@ -2997,9 +2656,7 @@ aeon:AEON_0000011 rdf:type owl:Class ;
                   rdfs:subClassOf aeon:AEON_0000005 ;
                   obo:IAO_0000115 "The moderating role inheres in a person that contributes to a planned process by facilitating the communication."@en ;
                   obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
-                  rdfs:label "moderator role"@en ;
-                  aeon:SMW_datatype "Category" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+                  rdfs:label "moderator role"@en .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000012
@@ -3017,9 +2674,7 @@ aeon:AEON_0000012 rdf:type owl:Class ;
                   obo:IAO_0000116 "ToDo: use CRO IRI http://purl.obolibrary.org/obo/CRO_0000101"@en ;
                   obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
                   obo:IAO_0000118 "manuscript review role"@en ;
-                  rdfs:label "reviewer role"@en ;
-                  aeon:SMW_datatype "Category" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+                  rdfs:label "reviewer role"@en .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000013
@@ -3036,9 +2691,7 @@ aeon:AEON_0000013 rdf:type owl:Class ;
                   obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
                   obo:IAO_0000118 "invited speaker role"@en ;
                   obo:IAO_0006011 "http://purl.obolibrary.org/obo/CRO_0000100"^^xsd:anyURI ;
-                  rdfs:label "presenter role"@en ;
-                  aeon:SMW_datatype "Category" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+                  rdfs:label "presenter role"@en .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000014
@@ -3053,9 +2706,7 @@ aeon:AEON_0000014 rdf:type owl:Class ;
                   rdfs:subClassOf aeon:AEON_0000013 ;
                   obo:IAO_0000115 "The keynote speaker role inheres in a person that contributes to a planned process by holding a keynote speech at a planned process."@en ;
                   obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
-                  rdfs:label "keynote speaker role"@en ;
-                  aeon:SMW_datatype "Category" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+                  rdfs:label "keynote speaker role"@en .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000015
@@ -3071,9 +2722,7 @@ aeon:AEON_0000015 rdf:type owl:Class ;
                   obo:IAO_0000115 "The sponsor role inheres in a person or organization that contributes to a planned process by providing the financial or material ressources needed to realize a planned process."@en ;
                   obo:IAO_0000116 "PS 2-9-2020: For me there is still the open question on how to best model the different sponsor types (e.g. gold, silver, bronze...). As the possible sponsor types can have various schemes, it seems best to have named individuals of the aeon:Sponsor class at the moment." ;
                   obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
-                  rdfs:label "sponsor role"@en ;
-                  aeon:SMW_datatype "Category" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+                  rdfs:label "sponsor role"@en .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000016
@@ -3081,9 +2730,7 @@ aeon:AEON_0000016 rdf:type owl:Class ;
                   rdfs:subClassOf obo:IAO_0020000 ;
                   obo:IAO_0000114 obo:IAO_0000423 ;
                   obo:IAO_0000117 "PERSON: Philip Strömert"@en ;
-                  rdfs:label "digital object identifier"@en ;
-                  aeon:SMW_datatype "Category" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+                  rdfs:label "digital object identifier"@en .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000017
@@ -3091,13 +2738,7 @@ aeon:AEON_0000017 rdf:type owl:Class ;
                   rdfs:subClassOf obo:IAO_0000578 ;
                   obo:IAO_0000114 obo:IAO_0000423 ;
                   obo:IAO_0000117 "PERSON: Philip Strömert" ;
-                  rdfs:label "GND ID" ;
-                  aeon:SMW_datatype "Category" ;
-                  aeon:SMW_import_info """[[partOfSubobject::Template:Subobject External_Process_ID]]
-[[partOfSubobject::Template:Subobject Person_ID]]
-[[partOfSubobject::Template:Subobject Organization_ID]]
-
-[[Category:AEON]] [[Category:Imported vocabulary]]""" .
+                  rdfs:label "GND ID" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000018
@@ -3105,12 +2746,7 @@ aeon:AEON_0000018 rdf:type owl:Class ;
                   rdfs:subClassOf obo:IAO_0000578 ;
                   obo:IAO_0000114 obo:IAO_0000423 ;
                   obo:IAO_0000117 "PERSON: Philip Strömert" ;
-                  rdfs:label "ISNI" ;
-                  aeon:SMW_datatype "Category" ;
-                  aeon:SMW_import_info """[[partOfSubobject::Template:Subobject Person_ID]]
-[[partOfSubobject::Template:Subobject Organization_ID]]
-
-[[Category:AEON]] [[Category:Imported vocabulary]]""" .
+                  rdfs:label "ISNI" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000019
@@ -3118,11 +2754,7 @@ aeon:AEON_0000019 rdf:type owl:Class ;
                   rdfs:subClassOf obo:IAO_0000578 ;
                   obo:IAO_0000114 obo:IAO_0000423 ;
                   obo:IAO_0000117 "PERSON: Philip Strömert" ;
-                  rdfs:label "ORCID" ;
-                  aeon:SMW_datatype "Category" ;
-                  aeon:SMW_import_info """[[partOfSubobject::Template:Subobject Person_ID]]
-
-[[Category:AEON]] [[Category:Imported vocabulary]]""" .
+                  rdfs:label "ORCID" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000020
@@ -3130,11 +2762,7 @@ aeon:AEON_0000020 rdf:type owl:Class ;
                   rdfs:subClassOf obo:IAO_0000578 ;
                   obo:IAO_0000114 obo:IAO_0000423 ;
                   obo:IAO_0000117 "PERSON: Philip Strömert" ;
-                  rdfs:label "ROR ID" ;
-                  aeon:SMW_datatype "Category" ;
-                  aeon:SMW_import_info """[[partOfSubobject::Template:Subobject Organization_ID]]
-
-[[Category:AEON]] [[Category:Imported vocabulary]]""" .
+                  rdfs:label "ROR ID" .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000021
@@ -3143,46 +2771,32 @@ aeon:AEON_0000021 rdf:type owl:Class ;
                   obo:IAO_0000114 obo:IAO_0000423 ;
                   obo:IAO_0000117 "PERSON: Philip Strömert" ;
                   obo:IAO_0006011 "\"https://www.wikidata.org/wiki/\"^^ xsd:anyURI"@en ;
-                  rdfs:label "Wikidata QID"@en ;
-                  aeon:SMW_datatype "Category" ;
-                  aeon:SMW_import_info """[[partOfSubobject::Template:Subobject Process_External_ID]]
-[[partOfSubobject::Template:Subobject Person_ID]]
-[[partOfSubobject::Template:Subobject Organization_ID]]
-
-[[Category:AEON]] [[Category:Imported vocabulary]]""" .
+                  rdfs:label "Wikidata QID"@en .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000022
 aeon:AEON_0000022 rdf:type owl:Class ;
                   rdfs:subClassOf obo:GAZ_00000448 ;
-                  rdfs:label "city"@en ;
-                  aeon:SMW_datatype "Category" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+                  rdfs:label "city"@en .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000023
 aeon:AEON_0000023 rdf:type owl:Class ;
                   rdfs:subClassOf obo:GAZ_00000448 ;
-                  rdfs:label "country"@en ;
-                  aeon:SMW_datatype "Category" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+                  rdfs:label "country"@en .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000024
 aeon:AEON_0000024 rdf:type owl:Class ;
                   rdfs:subClassOf obo:GAZ_00000448 ;
                   obo:IAO_0000118 "province"@en ;
-                  rdfs:label "state"@en ;
-                  aeon:SMW_datatype "Category" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+                  rdfs:label "state"@en .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000025
 aeon:AEON_0000025 rdf:type owl:Class ;
                   rdfs:subClassOf obo:GAZ_00000448 ;
-                  rdfs:label "event venue"@en ;
-                  aeon:SMW_datatype "Category" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+                  rdfs:label "event venue"@en .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000027
@@ -3191,9 +2805,7 @@ aeon:AEON_0000027 rdf:type owl:Class ;
                   obo:IAO_0000112 "DDC 410 Linguistics, OECD 6.02 Languages and literature"@en ;
                   obo:IAO_0000115 "'academic field' is a skos:Concept that describes the research field of an academic event or event series. As opposed to the class 'topic', the instances of this class must be terms from a controlled vocabulary or thesaurus."@en ;
                   obo:IAO_0000117 "PERSON: Philip Strömert" ;
-                  rdfs:label "academic field"@en ;
-                  aeon:SMW_datatype "Category" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+                  rdfs:label "academic field"@en .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000028
@@ -3210,9 +2822,7 @@ aeon:AEON_0000029 rdf:type owl:Class ;
                   rdfs:subClassOf obo:BFO_0000029 ;
                   obo:IAO_0000117 "Philip Strömert"^^xsd:string ;
                   <http://purl.org/dc/elements/1.1/date> "2020-10-14T15:31:27Z"^^xsd:dateTime ;
-                  rdfs:label "virtual location"@en ;
-                  aeon:SMW_datatype "Category" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+                  rdfs:label "virtual location"@en .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000030
@@ -3221,13 +2831,7 @@ aeon:AEON_0000030 rdf:type owl:Class ;
                   obo:IAO_0000115 "The financial cost of attendance at a scientific event."@en ;
                   obo:IAO_0000116 "PS: It needs to be discussed, if having fee as ICE is sufficient/correct."@en ;
                   obo:IAO_0000117 "Philip Strömert"^^xsd:string ;
-                  rdfs:label "fee"@en ;
-                  aeon:SMW_datatype "Category" ;
-                  aeon:SMW_import_info """The individuals/instances of this class make up the allowed value list in [[MediaWiki:Smw_allows_list_Has_fee]].
-
-[[partOfSubobject::Template:Subobject Fee]]
-
-[[Category:AEON]] [[Category:Imported vocabulary]]""" .
+                  rdfs:label "fee"@en .
 
 
 ###  https://github.com/tibonto/aeon#AEON_0000034
@@ -3244,9 +2848,7 @@ aeon:AEON_0000042 rdf:type owl:Class ;
                   rdfs:subClassOf obo:BFO_0000027 ;
                   obo:IAO_0000600 "An academic event committee or commission is a body of one or more persons that is responsible for the realization of a certain task or aspect in an academic event."@en ;
                   rdfs:label "event committee"@en ;
-                  ns:term_status "pending"@en ;
-                  aeon:SMW_datatype "Category" ;
-                  aeon:SMW_import_info "[[Category:AEON]] [[Category:Imported vocabulary]]" .
+                  ns:term_status "pending"@en .
 
 
 ###  https://github.com/tibonto/aeon#attendee
@@ -3887,4 +3489,4 @@ aeon:__PIDapalooza_Role_2 rdf:type owl:NamedIndividual ;
 ] .
 
 
-###  Generated by the OWL API (version 4.5.9.2019-02-01T07:24:44Z) https://github.com/owlcs/owlapi
+###  Generated by the OWL API (version 4.5.6) https://github.com/owlcs/owlapi

--- a/prefixes.json
+++ b/prefixes.json
@@ -1,0 +1,18 @@
+{
+    "@context": {
+      "dc": "http://dublincore.org/specifications/dublin-core/dcmi-terms/2012-06-14/",
+      "ns": "http://www.w3.org/2003/06/sw-vocab-status/ns#",
+      "obo": "http://purl.obolibrary.org/obo/",
+      "owl": "http://www.w3.org/2002/07/owl#",
+      "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+      "xml": "http://www.w3.org/XML/1998/namespace",
+      "xsd": "http://www.w3.org/2001/XMLSchema#",
+      "aeon": "https://github.com/tibonto/aeon#",
+      "obda": "https://w3id.org/obda/vocabulary#",
+      "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+      "skos": "http://www.w3.org/2004/02/skos/core#" 
+
+    }
+  }
+
+

--- a/scripts/robot_remove_terms.sh
+++ b/scripts/robot_remove_terms.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# *** Removes terms from input ontology ***
+# run from parent dir:
+# ./scripts/robot_remove_terms.sh 
+
+robot remove --add-prefixes prefixes.json \
+--input aeon.ttl \
+--term aeon:SMW_datatype \
+--term aeon:SMW_import_info \
+--term aeon:WikidataLabel \
+--term aeon:WikidataURI  \
+--output aeon_no_SMW_datatype.ttl


### PR DESCRIPTION
closes #98 

keep it open @StroemPhi  I need to use the PR changes view to see what robot is doing.

e23c37af39c660bb4a5300184cc72b8dd2d5ceb0 removed `aeon:SMW_datatype` but robot also removed a few prefixes :-1:  will revert and try to get it under the right beahviour

