### PR TITLE
make location data properties be constrained to event venue domain

### DIFF
--- a/src/ontology/aeon-edit.owl
+++ b/src/ontology/aeon-edit.owl
@@ -743,9 +743,10 @@ SubDataPropertyOf(obo:AEON_0000147 obo:AEON_0000158)
 # Data Property: obo:AEON_0000148 (coordinates)
 
 AnnotationAssertion(obo:IAO_0000114 obo:AEON_0000148 obo:IAO_0000428)
-AnnotationAssertion(obo:IAO_0000116 obo:AEON_0000148 "A data property to provide a literal value for the coordinates of an academic event."@en)
+AnnotationAssertion(obo:IAO_0000116 obo:AEON_0000148 "A data property to provide a literal value for the coordinates of an organanized sociocultural event venue."@en)
 AnnotationAssertion(rdfs:label obo:AEON_0000148 "coordinates"@en)
 SubDataPropertyOf(obo:AEON_0000148 obo:AEON_0000155)
+DataPropertyDomain(obo:AEON_0000148 obo:AEON_0000025)
 
 # Data Property: obo:AEON_0000149 (event frequency)
 
@@ -816,10 +817,11 @@ DataPropertyRange(obo:AEON_0000154 xsd:string)
 # Data Property: obo:AEON_0000155 (location)
 
 AnnotationAssertion(obo:IAO_0000114 obo:AEON_0000155 obo:IAO_0000428)
-AnnotationAssertion(obo:IAO_0000115 obo:AEON_0000155 "A data property to provide a literal value for the location (site) of an academic event."@en)
+AnnotationAssertion(obo:IAO_0000115 obo:AEON_0000155 "A data property to provide a literal value for the location (e.g. address) of an organized sociocultural event."@en)
 AnnotationAssertion(obo:IAO_0000116 obo:AEON_0000155 "This is an artefact from a very early version of AEON that is most likely to be obsoleted, as there should be better ways to model the locations of an academic event."@en)
 AnnotationAssertion(rdfs:label obo:AEON_0000155 "location"@en)
-DataPropertyDomain(obo:AEON_0000155 obo:BFO_0000029)
+SubDataPropertyOf(obo:AEON_0000155 obo:AEON_0000171)
+DataPropertyDomain(obo:AEON_0000155 obo:AEON_0000025)
 
 # Data Property: obo:AEON_0000157 (obsolete_meeting URL)
 


### PR DESCRIPTION
This PR moves the location data properties to be data properties of event venue not bfo:site to be more specific and avoid axiom injection on BFO.